### PR TITLE
Simplify parameter validation with compile-time type constraints

### DIFF
--- a/ext/CTSolversIpopt.jl
+++ b/ext/CTSolversIpopt.jl
@@ -16,7 +16,7 @@ import NLPModels
 import SolverCore
 
 # Import parameter types
-using CTSolvers.Strategies: CPU, GPU, AbstractStrategyParameter, validate_supported_parameter
+using CTSolvers.Strategies: CPU, GPU, AbstractStrategyParameter
 
 # ============================================================================
 # Metadata definition
@@ -27,9 +27,7 @@ $(TYPEDSIGNATURES)
 
 Return metadata defining Ipopt options and their specifications.
 """
-function Strategies.metadata(::Type{Solvers.Ipopt{P}}) where {P<:AbstractStrategyParameter}
-    # Validate parameter support
-    validate_supported_parameter(Solvers.Ipopt, P)
+function Strategies.metadata(::Type{Solvers.Ipopt{P}}) where {P<:CPU}
     return Strategies.StrategyMetadata(
         # ====================================================================
         # Termination options

--- a/ext/CTSolversKnitro.jl
+++ b/ext/CTSolversKnitro.jl
@@ -16,7 +16,7 @@ import NLPModels
 import SolverCore
 
 # Import parameter types
-using CTSolvers.Strategies: CPU, GPU, AbstractStrategyParameter, validate_supported_parameter
+using CTSolvers.Strategies: CPU, GPU, AbstractStrategyParameter
 
 # ============================================================================
 # Metadata Definition
@@ -27,9 +27,7 @@ $(TYPEDSIGNATURES)
 
 Return metadata defining Knitro options and their specifications.
 """
-function Strategies.metadata(::Type{Solvers.Knitro{P}}) where {P<:AbstractStrategyParameter}
-    # Validate parameter support
-    validate_supported_parameter(Solvers.Knitro, P)
+function Strategies.metadata(::Type{Solvers.Knitro{P}}) where {P<:CPU}
     return Strategies.StrategyMetadata(
         # ====================================================================
         # TERMINATION OPTIONS

--- a/src/Modelers/adnlp.jl
+++ b/src/Modelers/adnlp.jl
@@ -159,7 +159,7 @@ modeler = Modelers.ADNLP(
 - ADNLPModels.jl: [https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl](https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl)
 - Automatic Differentiation in Julia: [https://github.com/JuliaDiff/](https://github.com/JuliaDiff/)
 """
-struct ADNLP{P<:AbstractStrategyParameter} <: AbstractNLPModeler
+struct ADNLP{P<:CPU} <: AbstractNLPModeler
     "Solver configuration options containing validated option values"
     options::Strategies.StrategyOptions
 end
@@ -179,31 +179,12 @@ Returns `CPU` as the default execution parameter.
 This method is part of the `AbstractStrategy` parameter contract and must be
 implemented by all parameterized strategies.
 
-See also: [`ADNLP`](@ref), [`CPU`](@ref), [`_supported_parameters`](@ref)
+See also: [`ADNLP`](@ref), [`CPU`](@ref)
 """
 Strategies._default_parameter(::Type{<:Modelers.ADNLP}) = CPU
 
-"""
-$(TYPEDSIGNATURES)
-
-Supported parameter types for ADNLP.
-
-Returns a tuple of parameter types that this strategy accepts. ADNLP
-only supports CPU execution.
-
-# Implementation Notes
-
-This method is part of the `AbstractStrategy` parameter contract and must be
-implemented by all parameterized strategies.
-
-See also: [`ADNLP`](@ref), [`CPU`](@ref), [`GPU`](@ref), [`_default_parameter`](@ref)
-"""
-Strategies._supported_parameters(::Type{<:Modelers.ADNLP}) = (CPU,)
-
 # Strategy metadata with option definitions (parameterized)
-function Strategies.metadata(::Type{<:Modelers.ADNLP{P}}) where {P<:AbstractStrategyParameter}
-    # Validate parameter support
-    validate_supported_parameter(Modelers.ADNLP, P)
+function Strategies.metadata(::Type{<:Modelers.ADNLP{P}}) where {P<:CPU}
     return Strategies.StrategyMetadata(
         # === Existing Options (unchanged) ===
         Strategies.OptionDefinition(;
@@ -391,10 +372,7 @@ function Modelers.ADNLP(; mode::Symbol=:strict, kwargs...)
 end
 
 # Parameterized constructor
-function Modelers.ADNLP{P}(; mode::Symbol=:strict, kwargs...) where {P<:AbstractStrategyParameter}
-    # Validate parameter support
-    validate_supported_parameter(Modelers.ADNLP, P)
-    
+function Modelers.ADNLP{P}(; mode::Symbol=:strict, kwargs...) where {P<:CPU}
     # Check for deprecated aliases
     if haskey(kwargs, :adnlp_backend)
         @warn "adnlp_backend is deprecated, use backend instead" maxlog=1

--- a/src/Modelers/exa.jl
+++ b/src/Modelers/exa.jl
@@ -197,7 +197,7 @@ modeler = Modelers.Exa{GPU}(
 - ExaModels.jl: [https://github.com/JuliaSmoothOptimizers/ExaModels.jl](https://github.com/JuliaSmoothOptimizers/ExaModels.jl)
 - KernelAbstractions.jl: [https://github.com/JuliaGPU/KernelAbstractions.jl](https://github.com/JuliaGPU/KernelAbstractions.jl)
 """
-struct Exa{P<:AbstractStrategyParameter} <: AbstractNLPModeler
+struct Exa{P<:Union{CPU, GPU}} <: AbstractNLPModeler
     options::Strategies.StrategyOptions
 end
 
@@ -216,29 +216,12 @@ Returns `CPU` as the default execution parameter.
 This method is part of the `AbstractStrategy` parameter contract and must be
 implemented by all parameterized strategies.
 
-See also: [`Exa`](@ref), [`CPU`](@ref), [`_supported_parameters`](@ref)
+See also: [`Exa`](@ref), [`CPU`](@ref)
 """
 Strategies._default_parameter(::Type{<:Modelers.Exa}) = CPU
 
-"""
-$(TYPEDSIGNATURES)
-
-Supported parameter types for Exa.
-
-Returns a tuple of parameter types that this strategy accepts. Exa
-supports both CPU and GPU execution.
-
-# Implementation Notes
-
-This method is part of the `AbstractStrategy` parameter contract and must be
-implemented by all parameterized strategies.
-
-See also: [`Exa`](@ref), [`CPU`](@ref), [`GPU`](@ref), [`_default_parameter`](@ref)
-"""
-Strategies._supported_parameters(::Type{<:Modelers.Exa}) = (CPU, GPU)
-
 # Strategy metadata with option definitions (parameterized)
-function Strategies.metadata(::Type{<:Modelers.Exa{P}}) where {P<:AbstractStrategyParameter}
+function Strategies.metadata(::Type{<:Modelers.Exa{P}}) where {P<:Union{CPU, GPU}}
     return Strategies.StrategyMetadata(
         # === Existing Options (enhanced) ===
         Strategies.OptionDefinition(;

--- a/src/Solvers/ipopt.jl
+++ b/src/Solvers/ipopt.jl
@@ -106,7 +106,7 @@ using NLPModelsIpopt
 
 See also: [`CPU`](@ref), [`AbstractNLPSolver`](@ref), [`MadNLP`](@ref), [`Knitro`](@ref)
 """
-struct Ipopt{P<:AbstractStrategyParameter} <: AbstractNLPSolver
+struct Ipopt{P<:CPU} <: AbstractNLPSolver
     "Solver configuration options containing validated option values"
     options::Strategies.StrategyOptions
 end
@@ -134,26 +134,9 @@ Returns `CPU` as the default execution parameter.
 This method is part of the `AbstractStrategy` parameter contract and must be
 implemented by all parameterized strategies.
 
-See also: [`Ipopt`](@ref), [`CPU`](@ref), [`_supported_parameters`](@ref)
+See also: [`Ipopt`](@ref), [`CPU`](@ref)
 """
 Strategies._default_parameter(::Type{<:Solvers.Ipopt}) = CPU
-
-"""
-$(TYPEDSIGNATURES)
-
-Supported parameter types for Ipopt.
-
-Returns a tuple of parameter types that this strategy accepts. Ipopt
-only supports CPU execution.
-
-# Implementation Notes
-
-This method is part of the `AbstractStrategy` parameter contract and must be
-implemented by all parameterized strategies.
-
-See also: [`Ipopt`](@ref), [`CPU`](@ref), [`GPU`](@ref), [`_default_parameter`](@ref)
-"""
-Strategies._supported_parameters(::Type{<:Solvers.Ipopt}) = (CPU,)
 
 # ============================================================================
 # Constructor with Tag Dispatch
@@ -217,9 +200,7 @@ solver_cpu = Solvers.Ipopt{CPU}(max_iter=1000, tol=1e-6)
 
 See also: [`Ipopt`](@ref), [`CPU`](@ref)
 """
-function Solvers.Ipopt{P}(; mode::Symbol=:strict, kwargs...) where {P<:AbstractStrategyParameter}
-    # Validate parameter support
-    validate_supported_parameter(Solvers.Ipopt, P)
+function Solvers.Ipopt{P}(; mode::Symbol=:strict, kwargs...) where {P<:CPU}
     return build_ipopt_solver(IpoptTag, P; mode=mode, kwargs...)
 end
 
@@ -256,11 +237,8 @@ This stub is for parameterized types `Ipopt{P}` where `P <: AbstractStrategyPara
 
 See also: [`Ipopt`](@ref), [`Strategies.StrategyMetadata`](@ref)
 """
-function Strategies.metadata(::Type{<:Solvers.Ipopt{P}}) where {P<:AbstractStrategyParameter}
-    # Validate parameter BEFORE checking extension
-    Strategies.validate_supported_parameter(Solvers.Ipopt, P)
-    
-    # If validation passes, extension is missing
+function Strategies.metadata(::Type{<:Solvers.Ipopt{P}}) where {P<:CPU}
+    # Extension is missing
     throw(Exceptions.ExtensionError(
         :NLPModelsIpopt;
         message="to access Ipopt{$P} options metadata",

--- a/src/Solvers/knitro.jl
+++ b/src/Solvers/knitro.jl
@@ -109,7 +109,7 @@ using NLPModelsKnitro
 
 See also: [`CPU`](@ref), [`AbstractNLPSolver`](@ref), [`Ipopt`](@ref), [`MadNLP`](@ref)
 """
-struct Knitro{P<:AbstractStrategyParameter} <: AbstractNLPSolver
+struct Knitro{P<:CPU} <: AbstractNLPSolver
     "Solver configuration options containing validated option values"
     options::Strategies.StrategyOptions
 end
@@ -137,26 +137,9 @@ Returns `CPU` as the default execution parameter.
 This method is part of the `AbstractStrategy` parameter contract and must be
 implemented by all parameterized strategies.
 
-See also: [`Knitro`](@ref), [`CPU`](@ref), [`_supported_parameters`](@ref)
+See also: [`Knitro`](@ref), [`CPU`](@ref)
 """
 Strategies._default_parameter(::Type{<:Solvers.Knitro}) = CPU
-
-"""
-$(TYPEDSIGNATURES)
-
-Supported parameter types for Knitro.
-
-Returns a tuple of parameter types that this strategy accepts. Knitro
-only supports CPU execution.
-
-# Implementation Notes
-
-This method is part of the `AbstractStrategy` parameter contract and must be
-implemented by all parameterized strategies.
-
-See also: [`Knitro`](@ref), [`CPU`](@ref), [`GPU`](@ref), [`_default_parameter`](@ref)
-"""
-Strategies._supported_parameters(::Type{<:Solvers.Knitro}) = (CPU,)
 
 # ============================================================================
 # Constructor with Tag Dispatch
@@ -220,9 +203,7 @@ solver_cpu = Solvers.Knitro{CPU}(maxit=1000, outlev=2)
 
 See also: [`Knitro`](@ref), [`CPU`](@ref)
 """
-function Solvers.Knitro{P}(; mode::Symbol=:strict, kwargs...) where {P<:AbstractStrategyParameter}
-    # Validate parameter support
-    validate_supported_parameter(Solvers.Knitro, P)
+function Solvers.Knitro{P}(; mode::Symbol=:strict, kwargs...) where {P<:CPU}
     return build_knitro_solver(KnitroTag, P; mode=mode, kwargs...)
 end
 
@@ -259,11 +240,8 @@ This stub is for parameterized types `Knitro{P}` where `P <: AbstractStrategyPar
 
 See also: [`Knitro`](@ref), [`Strategies.StrategyMetadata`](@ref)
 """
-function Strategies.metadata(::Type{<:Solvers.Knitro{P}}) where {P<:AbstractStrategyParameter}
-    # Validate parameter BEFORE checking extension
-    Strategies.validate_supported_parameter(Solvers.Knitro, P)
-    
-    # If validation passes, extension is missing
+function Strategies.metadata(::Type{<:Solvers.Knitro{P}}) where {P<:CPU}
+    # Extension is missing
     throw(Exceptions.ExtensionError(
         :NLPModelsKnitro;
         message="to access Knitro{$P} options metadata",

--- a/src/Solvers/madncl.jl
+++ b/src/Solvers/madncl.jl
@@ -68,7 +68,7 @@ using MadNCL, MadNLP
 
 See also: [`AbstractNLPSolver`](@ref), [`MadNLP`](@ref), [`Ipopt`](@ref), [`CPU`](@ref), [`GPU`](@ref)
 """
-struct MadNCL{P<:AbstractStrategyParameter} <: AbstractNLPSolver
+struct MadNCL{P<:Union{CPU, GPU}} <: AbstractNLPSolver
     "Solver configuration options containing validated option values"
     options::Strategies.StrategyOptions
 end
@@ -94,23 +94,6 @@ Returns `CPU` as the default execution parameter.
 See also: [`MadNCL`](@ref), [`CPU`](@ref)
 """
 Strategies._default_parameter(::Type{<:Solvers.MadNCL}) = CPU
-
-"""
-$(TYPEDSIGNATURES)
-
-Supported parameter types for MadNCL.
-
-Returns a tuple of parameter types that this strategy accepts. MadNCL
-supports both CPU and GPU execution.
-
-# Implementation Notes
-
-This method is part of the `AbstractStrategy` parameter contract and must be
-implemented by all parameterized strategies.
-
-See also: [`MadNCL`](@ref), [`CPU`](@ref), [`GPU`](@ref), [`_default_parameter`](@ref)
-"""
-Strategies._supported_parameters(::Type{<:Solvers.MadNCL}) = (CPU, GPU)
 
 # ============================================================================
 # Constructor with tag dispatch

--- a/src/Solvers/madnlp.jl
+++ b/src/Solvers/madnlp.jl
@@ -74,7 +74,7 @@ using MadNLP
 
 See also: [`AbstractNLPSolver`](@ref), [`Ipopt`](@ref), [`Solvers.MadNCL`](@ref), [`CPU`](@ref), [`GPU`](@ref)
 """
-struct MadNLP{P<:AbstractStrategyParameter} <: AbstractNLPSolver
+struct MadNLP{P<:Union{CPU, GPU}} <: AbstractNLPSolver
     "Solver configuration options containing validated option values"
     options::Strategies.StrategyOptions
 end
@@ -100,23 +100,6 @@ Returns `CPU` as the default execution parameter.
 See also: [`MadNLP`](@ref), [`CPU`](@ref)
 """
 Strategies._default_parameter(::Type{<:Solvers.MadNLP}) = CPU
-
-"""
-$(TYPEDSIGNATURES)
-
-Supported parameter types for MadNLP.
-
-Returns a tuple of parameter types that this strategy accepts. MadNLP
-supports both CPU and GPU execution.
-
-# Implementation Notes
-
-This method is part of the `AbstractStrategy` parameter contract and must be
-implemented by all parameterized strategies.
-
-See also: [`MadNLP`](@ref), [`CPU`](@ref), [`GPU`](@ref), [`_default_parameter`](@ref)
-"""
-Strategies._supported_parameters(::Type{<:Solvers.MadNLP}) = (CPU, GPU)
 
 # ============================================================================
 # Constructor with tag dispatch

--- a/src/Strategies/Strategies.jl
+++ b/src/Strategies/Strategies.jl
@@ -46,9 +46,6 @@ export AbstractStrategy, StrategyRegistry, StrategyMetadata, StrategyOptions, Op
 export RoutedOption, BypassValue
 export AbstractStrategyParameter, CPU, GPU
 
-# Parameter validation functions
-export validate_supported_parameter
-
 # Type-level contract methods
 export id, metadata
 

--- a/src/Strategies/contract/parameters.jl
+++ b/src/Strategies/contract/parameters.jl
@@ -200,44 +200,6 @@ id(::Type{GPU}) = :gpu
 """
 $(TYPEDSIGNATURES)
 
-Get the tuple of supported parameter types for a strategy.
-
-This function returns the parameter types that a strategy accepts. Strategies
-should override this method to restrict which parameters they support.
-
-# Arguments
-- `strategy_type::Type{<:AbstractStrategy}`: The strategy type
-
-# Returns
-- `Tuple{Vararg{Type{<:AbstractStrategyParameter}}}`: Tuple of supported parameter types
-
-# Default Behavior
-By default, returns `(CPU, GPU)` for backward compatibility. Strategies that
-only support a subset of parameters should override this method.
-
-# Example
-```julia
-# Strategy that only supports CPU
-_supported_parameters(::Type{<:MyStrategy}) = (CPU,)
-
-# Strategy that supports both CPU and GPU (default)
-_supported_parameters(::Type{<:MyOtherStrategy}) = (CPU, GPU)
-```
-
-See also: [`validate_supported_parameter`](@ref), [`CPU`](@ref), [`GPU`](@ref)
-"""
-function _supported_parameters(::Type{<:AbstractStrategy})
-    throw(Exceptions.NotImplemented(
-        "Strategy must implement _supported_parameters",
-        required_method="Strategies._supported_parameters(::Type{<:YourStrategy})",
-        suggestion="Define Strategies._supported_parameters(::Type{<:YourStrategy}) = (CPU,) or (CPU, GPU)",
-        context="Parameter contract - all parameterized strategies must declare supported parameters"
-    ))
-end
-
-"""
-$(TYPEDSIGNATURES)
-
 Get the default parameter type for a strategy.
 
 This function returns the default parameter type that a strategy accepts.
@@ -262,7 +224,7 @@ _default_parameter(::Type{<:MyStrategy}) = CPU
 _default_parameter(::Type{<:MyOtherStrategy}) = GPU
 ```
 
-See also: [`validate_supported_parameter`](@ref), [`CPU`](@ref), [`GPU`](@ref)
+See also: [`CPU`](@ref), [`GPU`](@ref)
 """
 function _default_parameter(::Type{<:AbstractStrategy})
     throw(Exceptions.NotImplemented(
@@ -271,75 +233,4 @@ function _default_parameter(::Type{<:AbstractStrategy})
         suggestion="Define Strategies._default_parameter(::Type{<:YourStrategy}) = CPU or GPU",
         context="Parameter contract - all parameterized strategies must declare default parameter"
     ))
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Validate that a parameter is supported by a strategy type.
-
-This function checks whether the given parameter type is in the list of
-supported parameters for the strategy. If not, it throws a detailed error
-message indicating which parameters are supported.
-
-# Arguments
-- `strategy_type::Type{<:AbstractStrategy}`: The strategy type
-- `parameter::Type{<:AbstractStrategyParameter}`: The parameter to validate
-
-# Returns
-- `Nothing`: Returns `nothing` if validation succeeds
-
-# Throws
-- `Exceptions.IncorrectArgument`: If the parameter is not supported by the strategy
-
-# Example
-```julia
-# Define a strategy that only supports CPU
-struct MyStrategy{P<:AbstractStrategyParameter} <: AbstractStrategy
-    options::StrategyOptions
-end
-
-_supported_parameters(::Type{<:MyStrategy}) = (CPU,)
-
-# This will succeed
-validate_supported_parameter(MyStrategy, CPU)
-
-# This will throw IncorrectArgument
-validate_supported_parameter(MyStrategy, GPU)
-```
-
-# Notes
-- Strategies must implement `_supported_parameters(::Type{<:StrategyType})` to
-  restrict which parameters they accept
-- The error message includes the strategy name, the invalid parameter, and the
-  list of supported parameters
-
-See also: [`_supported_parameters`](@ref), [`AbstractStrategyParameter`](@ref)
-"""
-function validate_supported_parameter(
-    strategy_type::Type{<:AbstractStrategy},
-    parameter::Type{<:AbstractStrategyParameter}
-)
-    supported = _supported_parameters(strategy_type)
-    
-    if parameter ∉ supported
-        # Extract readable names - handle both concrete and UnionAll types
-        if isa(strategy_type, UnionAll)
-            strategy_name = string(nameof(strategy_type))
-        else
-            strategy_name = string(nameof(strategy_type.name.wrapper))
-        end
-        param_name = string(nameof(parameter))
-        supported_names = join([string(nameof(p)) for p in supported], ", ")
-        
-        throw(Exceptions.IncorrectArgument(
-            "Unsupported parameter for strategy",
-            got="$strategy_name{$param_name}",
-            expected="$strategy_name with one of: $supported_names",
-            suggestion="Use $strategy_name{$(nameof(first(supported)))}() or check available parameters",
-            context="validate_supported_parameter - parameter validation"
-        ))
-    end
-    
-    return nothing
 end

--- a/test/suite/modelers/test_adnlp_parameter_validation.jl
+++ b/test/suite/modelers/test_adnlp_parameter_validation.jl
@@ -61,13 +61,13 @@ function test_adnlp_parameter_validation()
         # ====================================================================
         
         Test.@testset "Invalid GPU parameter" begin
-            # GPU parameter should throw IncorrectArgument
-            Test.@test_throws Exceptions.IncorrectArgument Modelers.ADNLP{Strategies.GPU}()
+            # GPU parameter should throw TypeError (compile-time validation)
+            Test.@test_throws TypeError Modelers.ADNLP{Strategies.GPU}()
         end
         
         Test.@testset "Invalid custom parameter" begin
-            # Custom parameter should throw IncorrectArgument
-            Test.@test_throws Exceptions.IncorrectArgument Modelers.ADNLP{FakeParam}()
+            # Custom parameter should throw TypeError (compile-time validation)
+            Test.@test_throws TypeError Modelers.ADNLP{FakeParam}()
         end
         
         # ====================================================================
@@ -87,8 +87,8 @@ function test_adnlp_parameter_validation()
         end
         
         Test.@testset "metadata() with invalid parameters" begin
-            # GPU parameter should throw IncorrectArgument
-            Test.@test_throws Exceptions.IncorrectArgument Strategies.metadata(Modelers.ADNLP{Strategies.GPU})
+            # GPU parameter should throw TypeError (compile-time validation)
+            Test.@test_throws TypeError Strategies.metadata(Modelers.ADNLP{Strategies.GPU})
         end
         
         # ====================================================================
@@ -101,29 +101,6 @@ function test_adnlp_parameter_validation()
             Test.@test Strategies.id(Modelers.ADNLP{Strategies.CPU}) == :adnlp
             
             # Note: id() doesn't validate parameters, only metadata() and constructors do
-        end
-        
-        # ====================================================================
-        # UNIT TESTS - Supported Parameters
-        # ====================================================================
-        
-        Test.@testset "_supported_parameters" begin
-            supported = Strategies._supported_parameters(Modelers.ADNLP)
-            Test.@test supported == (Strategies.CPU,)
-            Test.@test Strategies.CPU in supported
-            Test.@test Strategies.GPU ∉ supported
-        end
-        
-        Test.@testset "validate_supported_parameter" begin
-            # CPU should be valid
-            Test.@test_nowarn Strategies.validate_supported_parameter(
-                Modelers.ADNLP, Strategies.CPU
-            )
-            
-            # GPU should be invalid
-            Test.@test_throws Exceptions.IncorrectArgument Strategies.validate_supported_parameter(
-                Modelers.ADNLP, Strategies.GPU
-            )
         end
         
         # ====================================================================

--- a/test/suite/solvers/test_ipopt_parameter_validation.jl
+++ b/test/suite/solvers/test_ipopt_parameter_validation.jl
@@ -44,32 +44,14 @@ function test_ipopt_parameter_validation()
             Test.@test Strategies.id(Solvers.Ipopt{Strategies.CPU}) == :ipopt
         end
         
-        Test.@testset "_supported_parameters" begin
-            supported = Strategies._supported_parameters(Solvers.Ipopt)
-            Test.@test supported == (Strategies.CPU,)
-            Test.@test Strategies.CPU in supported
-            Test.@test Strategies.GPU ∉ supported
-        end
-        
-        Test.@testset "validate_supported_parameter" begin
-            # CPU should be valid
-            Test.@test_nowarn Strategies.validate_supported_parameter(
-                Solvers.Ipopt, Strategies.CPU
-            )
-            
-            # GPU should be invalid
-            Test.@test_throws Exceptions.IncorrectArgument Strategies.validate_supported_parameter(
-                Solvers.Ipopt, Strategies.GPU
-            )
-        end
         
         # ====================================================================
         # UNIT TESTS - Constructor Validation (without extension)
         # ====================================================================
         
         Test.@testset "Constructor validation without extension" begin
-            # GPU parameter should fail with IncorrectArgument
-            Test.@test_throws Exceptions.IncorrectArgument Solvers.Ipopt{Strategies.GPU}()
+            # GPU parameter should fail with TypeError (compile-time validation)
+            Test.@test_throws TypeError Solvers.Ipopt{Strategies.GPU}()
         end
         
         # Note: Detailed error message testing removed - the important validation
@@ -79,8 +61,8 @@ function test_ipopt_parameter_validation()
         # ====================================================================
         
         Test.@testset "metadata() validation without extension" begin
-            # GPU parameter should fail with IncorrectArgument
-            Test.@test_throws Exceptions.IncorrectArgument Strategies.metadata(Solvers.Ipopt{Strategies.GPU})
+            # GPU parameter should fail with TypeError (compile-time validation)
+            Test.@test_throws TypeError Strategies.metadata(Solvers.Ipopt{Strategies.GPU})
         end
         
         # ====================================================================

--- a/test/suite/strategies/test_cpu_only_parameters_integration.jl
+++ b/test/suite/strategies/test_cpu_only_parameters_integration.jl
@@ -175,9 +175,6 @@ function test_cpu_only_parameters_integration()
             Test.@test Strategies._default_parameter(Modelers.ADNLP) == Strategies.CPU
             Test.@test Strategies._default_parameter(Solvers.Ipopt) == Strategies.CPU
             
-            # Verify supported parameters
-            Test.@test Strategies._supported_parameters(Modelers.ADNLP) == (Strategies.CPU,)
-            Test.@test Strategies._supported_parameters(Solvers.Ipopt) == (Strategies.CPU,)
         end
         
         # ====================================================================
@@ -216,26 +213,11 @@ function test_cpu_only_parameters_integration()
             ]
             
             for (strategy_type, name) in strategies_to_test
-                # CPU should be supported
-                Test.@test_nowarn Strategies.validate_supported_parameter(
-                    strategy_type, Strategies.CPU
-                )
-                
-                # GPU should not be supported
-                Test.@test_throws Exceptions.IncorrectArgument Strategies.validate_supported_parameter(
-                    strategy_type, Strategies.GPU
-                )
-                
-                # Custom parameter should not be supported
-                Test.@test_throws Exceptions.IncorrectArgument Strategies.validate_supported_parameter(
-                    strategy_type, FakeParam
-                )
-                
                 # Default parameter should be CPU
                 Test.@test Strategies._default_parameter(strategy_type) == Strategies.CPU
                 
-                # Supported parameters should be (CPU,)
-                Test.@test Strategies._supported_parameters(strategy_type) == (Strategies.CPU,)
+                # Type constraints enforce parameter validation at compile-time
+                # GPU and custom parameters will throw TypeError when attempting to construct
             end
         end
     end

--- a/test/suite/strategies/test_parameter_contract.jl
+++ b/test/suite/strategies/test_parameter_contract.jl
@@ -3,7 +3,7 @@ module TestParameterContract
 using Test
 using CTSolvers
 using CTSolvers.Strategies
-using CTSolvers.Strategies: _supported_parameters, _default_parameter
+using CTSolvers.Strategies: _default_parameter
 using CTBase.Exceptions
 
 const VERBOSE = isdefined(Main, :TestOptions) ? Main.TestOptions.VERBOSE : true
@@ -23,8 +23,7 @@ struct FakeStrategyWithoutContract <: AbstractStrategy
     options::StrategyOptions
 end
 
-# Intentionally DO NOT implement _supported_parameters or _default_parameter
-# to test the fallback behavior
+# Intentionally DO NOT implement _default_parameter to test the fallback behavior
 
 # ============================================================================
 # Test function
@@ -48,20 +47,6 @@ function test_parameter_contract()
         # ====================================================================
         
         Test.@testset "Fallback implementations throw NotImplemented" begin
-            Test.@testset "_supported_parameters fallback" begin
-                err = try
-                    _supported_parameters(FakeStrategyWithoutContract)
-                catch e
-                    e
-                end
-                
-                Test.@test err isa NotImplemented
-                Test.@test occursin("must implement _supported_parameters", err.msg)
-                Test.@test occursin("Strategies._supported_parameters", err.required_method)
-                Test.@test occursin("Strategies._supported_parameters", err.suggestion)
-                Test.@test occursin("parameter contract", lowercase(err.context))
-            end
-            
             Test.@testset "_default_parameter fallback" begin
                 err = try
                     _default_parameter(FakeStrategyWithoutContract)
@@ -84,23 +69,22 @@ function test_parameter_contract()
         Test.@testset "All real strategies implement the contract" begin
             # List of all parameterized strategies
             strategies = [
-                (CTSolvers.Modelers.ADNLP, "ADNLP", (CPU,)),
-                (CTSolvers.Modelers.Exa, "Exa", (CPU, GPU)),
-                (CTSolvers.Solvers.Ipopt, "Ipopt", (CPU,)),
-                (CTSolvers.Solvers.Knitro, "Knitro", (CPU,)),
-                (CTSolvers.Solvers.MadNLP, "MadNLP", (CPU, GPU)),
-                (CTSolvers.Solvers.MadNCL, "MadNCL", (CPU, GPU))
+                (CTSolvers.Modelers.ADNLP, "ADNLP"),
+                (CTSolvers.Modelers.Exa, "Exa"),
+                (CTSolvers.Solvers.Ipopt, "Ipopt"),
+                (CTSolvers.Solvers.Knitro, "Knitro"),
+                (CTSolvers.Solvers.MadNLP, "MadNLP"),
+                (CTSolvers.Solvers.MadNCL, "MadNCL")
             ]
             
-            for (strategy_type, name, expected_params) in strategies
+            for (strategy_type, name) in strategies
                 Test.@testset "$name implements contract" begin
                     # Should not throw NotImplemented
-                    supported = Test.@test_nowarn _supported_parameters(strategy_type)
-                    Test.@test supported == expected_params
-                    
                     default = Test.@test_nowarn _default_parameter(strategy_type)
-                    Test.@test default ∈ supported
                     Test.@test default == CPU  # All current strategies default to CPU
+                    
+                    # Type constraints enforce parameter validation at compile-time
+                    # No runtime _supported_parameters() needed
                 end
             end
         end
@@ -111,9 +95,8 @@ function test_parameter_contract()
         
         Test.@testset "Contract enforcement prevents invalid usage" begin
             Test.@testset "Cannot use FakeStrategyWithoutContract in registry" begin
-                # Attempting to query parameters for a strategy without contract
+                # Attempting to query default parameter for a strategy without contract
                 # should fail with NotImplemented
-                Test.@test_throws NotImplemented _supported_parameters(FakeStrategyWithoutContract)
                 Test.@test_throws NotImplemented _default_parameter(FakeStrategyWithoutContract)
             end
         end


### PR DESCRIPTION
Replace runtime validation using _supported_parameters() and validate_supported_parameter() with compile-time type constraints directly in struct definitions.

Changes:
- Update struct definitions to use specific type constraints:
  * CPU-only strategies: P<:CPU (ADNLP, Ipopt, Knitro)
  * CPU+GPU strategies: P<:Union{CPU, GPU} (Exa, MadNLP, MadNCL)
- Remove _supported_parameters() and validate_supported_parameter() functions
- Remove validation calls from constructors and metadata() functions
- Update extensions to remove validation calls
- Update tests to expect TypeError instead of IncorrectArgument
- Remove tests for deleted validation functions

Benefits:
- ~150 lines of code removed
- Earlier error detection (compile-time vs runtime)
- Simpler and more robust validation mechanism
- Clearer intent with type constraints visible in struct definitions

All 2895 tests pass successfully.