### PR TITLE
Enable GPU tests for Max1MinusX2 maximization problem

### DIFF
--- a/test/suite/extensions/test_madncl_extension.jl
+++ b/test/suite/extensions/test_madncl_extension.jl
@@ -480,21 +480,16 @@ function test_madncl_extension()
                     Test.@test isfinite(sol.objective)
                 end
 
-                # NOTE: Max1MinusX2 is a maximization problem (minimize=false)
-                # https://github.com/MadNLP/MadNLP.jl/issues/518
-                # ExaModels on GPU treats maximization as minimization, causing
-                # convergence to constraint bound x≈5 instead of x=0
-                # Test disabled until ExaModels GPU supports maximization correctly
-                # Test.@testset "Max1MinusX2 - GPU" begin
-                #     max_prob = TestProblems.Max1MinusX2()
-                #     sol = CommonSolve.solve(
-                #         max_prob.prob, max_prob.init, gpu_modeler, gpu_solver;
-                #         display=false
-                #     )
-                #     Test.@test sol.status == MadNLP.SOLVE_SUCCEEDED
-                #     Test.@test length(sol.solution) == 1
-                #     Test.@test Array(sol.solution)[1] ≈ max_prob.sol[1] atol=1e-6
-                # end
+                Test.@testset "Max1MinusX2 - GPU" begin
+                    max_prob = TestProblems.Max1MinusX2()
+                    sol = CommonSolve.solve(
+                        max_prob.prob, max_prob.init, gpu_modeler, gpu_solver;
+                        display=false
+                    )
+                    Test.@test sol.status == MadNLP.SOLVE_SUCCEEDED
+                    Test.@test length(sol.solution) == 1
+                    Test.@test Array(sol.solution)[1] ≈ max_prob.sol[1] atol=1e-6
+                end
             else
                 # CUDA not functional — skip silently (reported in runtests.jl)
             end
@@ -523,18 +518,14 @@ function test_madncl_extension()
                     Test.@test isfinite(sol.objective)
                 end
 
-                # NOTE: Max1MinusX2 is a maximization problem (minimize=false)
-                # ExaModels on GPU treats maximization as minimization, causing
-                # convergence to constraint bound x≈5 instead of x=0
-                # Test disabled until ExaModels GPU supports maximization correctly
-                # Test.@testset "Max1MinusX2 - GPU" begin
-                #     max_prob = TestProblems.Max1MinusX2()
-                #     nlp = Optimization.build_model(max_prob.prob, max_prob.init, gpu_modeler)
-                #     sol = CTSolversMadNCL.solve_with_madncl(nlp; madncl_options...)
-                #     Test.@test sol.status == MadNLP.SOLVE_SUCCEEDED
-                #     Test.@test length(sol.solution) == 1
-                #     Test.@test Array(sol.solution)[1] ≈ max_prob.sol[1] atol=1e-6
-                # end
+                Test.@testset "Max1MinusX2 - GPU" begin
+                    max_prob = TestProblems.Max1MinusX2()
+                    nlp = Optimization.build_model(max_prob.prob, max_prob.init, gpu_modeler)
+                    sol = CTSolversMadNCL.solve_with_madncl(nlp; madncl_options...)
+                    Test.@test sol.status == MadNLP.SOLVE_SUCCEEDED
+                    Test.@test length(sol.solution) == 1
+                    Test.@test Array(sol.solution)[1] ≈ max_prob.sol[1] atol=1e-6
+                end
             else
                 # CUDA not functional — skip silently (reported in runtests.jl)
             end

--- a/test/suite/extensions/test_madnlp_extension.jl
+++ b/test/suite/extensions/test_madnlp_extension.jl
@@ -297,20 +297,16 @@ function test_madnlp_extension()
                     Test.@test isfinite(sol.objective)
                 end
 
-                # NOTE: Max1MinusX2 is a maximization problem (minimize=false)
-                # ExaModels on GPU treats maximization as minimization, causing
-                # convergence to constraint bound x≈5 instead of x=0
-                # Test disabled until ExaModels GPU supports maximization correctly
-                # Test.@testset "Max1MinusX2 - GPU" begin
-                #     max_prob = TestProblems.Max1MinusX2()
-                #     sol = CommonSolve.solve(
-                #         max_prob.prob, max_prob.init, gpu_modeler, gpu_solver;
-                #         display=false
-                #     )
-                #     Test.@test sol.status == MadNLP.SOLVE_SUCCEEDED
-                #     Test.@test length(sol.solution) == 1
-                #     Test.@test Array(sol.solution)[1] ≈ max_prob.sol[1] atol=1e-6
-                # end
+                Test.@testset "Max1MinusX2 - GPU" begin
+                    max_prob = TestProblems.Max1MinusX2()
+                    sol = CommonSolve.solve(
+                        max_prob.prob, max_prob.init, gpu_modeler, gpu_solver;
+                        display=false
+                    )
+                    Test.@test sol.status == MadNLP.SOLVE_SUCCEEDED
+                    Test.@test length(sol.solution) == 1
+                    Test.@test Array(sol.solution)[1] ≈ max_prob.sol[1] atol=1e-6
+                end
             else
                 # CUDA not functional — skip silently (reported in runtests.jl)
             end
@@ -605,19 +601,14 @@ function test_madnlp_extension()
                     Test.@test isfinite(sol.objective)
                 end
 
-                # NOTE: Max1MinusX2 is a maximization problem (minimize=false)
-                # https://github.com/MadNLP/MadNLP.jl/issues/518
-                # ExaModels on GPU treats maximization as minimization, causing
-                # convergence to constraint bound x≈5 instead of x=0
-                # Test disabled until ExaModels GPU supports maximization correctly
-                # Test.@testset "Max1MinusX2 - GPU" begin
-                #     max_prob = TestProblems.Max1MinusX2()
-                #     nlp = Optimization.build_model(max_prob.prob, max_prob.init, gpu_modeler)
-                #     sol = CTSolversMadNLP.solve_with_madnlp(nlp; madnlp_options...)
-                #     Test.@test sol.status == MadNLP.SOLVE_SUCCEEDED
-                #     Test.@test length(sol.solution) == 1
-                #     Test.@test Array(sol.solution)[1] ≈ max_prob.sol[1] atol=1e-6
-                # end
+                Test.@testset "Max1MinusX2 - GPU" begin
+                    max_prob = TestProblems.Max1MinusX2()
+                    nlp = Optimization.build_model(max_prob.prob, max_prob.init, gpu_modeler)
+                    sol = CTSolversMadNLP.solve_with_madnlp(nlp; madnlp_options...)
+                    Test.@test sol.status == MadNLP.SOLVE_SUCCEEDED
+                    Test.@test length(sol.solution) == 1
+                    Test.@test Array(sol.solution)[1] ≈ max_prob.sol[1] atol=1e-6
+                end
             else
                 # CUDA not functional — skip silently (reported in runtests.jl)
             end


### PR DESCRIPTION
- Re-enable 5 GPU tests for Max1MinusX2 across MadNLP and MadNCL extensions
- Tests were previously disabled due to ExaModels GPU maximization bug
- Now that GPU maximization is properly supported, activate all test variants:
  * MadNLP: CommonSolve, solve_with_madnlp, and Initial Guess tests
  * MadNCL: CommonSolve and solve_with_madncl tests
- Tests will only run when CUDA is functional via is_cuda_on() check