### PR TITLE
Route to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.14] - 2026-04-12
+
+### Added
+
+- **Positional syntax for route_to()** - New method `route_to(args::Vararg{Any})` accepting alternating Symbol-value pairs
+  - Alternative to keyword syntax: `route_to(:solver, 100, :modeler, 50)` instead of `route_to(solver=100, modeler=50)`
+  - Both syntaxes are equivalent and produce identical `RoutedOption` results
+  - Validates even number of arguments and Symbol types for strategy identifiers
+  - Clear error messages for invalid inputs (odd count, non-Symbol identifiers, no arguments)
+
+### Changed
+
+- **Internal refactoring** - Added `_route_to_from_namedtuple()` helper function to avoid code duplication
+  - Both keyword and positional methods delegate to shared internal helper
+  - Reduced code duplication while maintaining identical behavior
+  - Improved maintainability and consistency
+
+### Improved
+
+- **Documentation** - Updated docstrings for both `route_to()` methods to show both syntaxes
+  - Examples demonstrate keyword and positional syntax equivalence
+  - Clear notes on when to use each syntax
+  - Comprehensive error documentation with suggestions
+
+### Tests
+
+- **Positional syntax test coverage** - Added 23 new tests covering:
+  - Single and multiple strategy routing
+  - Different value types (Integer, Float, String, Boolean, Symbol)
+  - Error cases (no arguments, odd count, non-Symbol identifiers)
+  - Syntax equivalence between keyword and positional forms
+
+---
+
 ## [0.4.13] - 2026-04-07
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTSolvers"
 uuid = "d3e8d392-8e4b-4d9b-8e92-d7d4e3650ef6"
-version = "0.4.13"
+version = "0.4.14"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]

--- a/src/Strategies/api/disambiguation.jl
+++ b/src/Strategies/api/disambiguation.jl
@@ -68,6 +68,21 @@ struct RoutedOption
     end
 end
 
+# Internal helper function - creates RoutedOption from NamedTuple
+function _route_to_from_namedtuple(routes::NamedTuple)
+    if isempty(routes)
+        throw(
+            Exceptions.PreconditionError(
+                "route_to requires at least one strategy-value pair";
+                reason="empty routes NamedTuple provided",
+                suggestion="Use route_to(solver=100) or route_to(:solver, 100)",
+                context="route_to - internal helper precondition",
+            ),
+        )
+    end
+    return RoutedOption(routes)
+end
+
 """
 $(TYPEDSIGNATURES)
 
@@ -99,6 +114,10 @@ RoutedOption((solver = 100,))
 julia> # Multiple strategies with different values
 julia> route_to(solver=100, modeler=50)
 RoutedOption((solver = 100, modeler = 50))
+
+julia> # Alternative positional syntax
+julia> route_to(:solver, 100, :modeler, 50)
+RoutedOption((solver = 100, modeler = 50))
 ```
 
 # Usage in solve()
@@ -106,38 +125,124 @@ RoutedOption((solver = 100, modeler = 50))
 # Without disambiguation - error if max_iter exists in multiple strategies
 solve(ocp, method; max_iter=100)  # ❌ Ambiguous!
 
-# With disambiguation - explicit routing
-solve(ocp, method; 
+# With disambiguation - explicit routing (keyword syntax)
+solve(ocp, method;
     max_iter = route_to(solver=100)              # Only solver gets 100
 )
 
-solve(ocp, method; 
+solve(ocp, method;
     max_iter = route_to(solver=100, modeler=50)  # Different values for each
+)
+
+# With disambiguation - explicit routing (positional syntax)
+solve(ocp, method;
+    max_iter = route_to(:solver, 100, :modeler, 50)  # Different values for each
 )
 ```
 
 # Notes
 - Strategy identifiers must match the actual strategy IDs in your method tuple
 - You can route to one or multiple strategies in a single call
+- Alternative positional syntax: `route_to(:solver, 100, :modeler, 50)`
+- Both syntaxes are equivalent; choose based on preference
 - This is the recommended way to disambiguate options
 - The orchestration layer will validate that the strategy IDs exist
 
 See also: `RoutedOption`, `route_all_options`
 """
 function route_to(; kwargs...)
-    if isempty(kwargs)
+    return _route_to_from_namedtuple(NamedTuple(kwargs))
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Create a disambiguated option value using positional arguments.
+
+This is an alternative syntax to the keyword argument version. Accepts
+alternating strategy identifier (Symbol) and value pairs.
+
+# Arguments
+- `args::Vararg{Any}`: Alternating strategy_id (Symbol) and value pairs.
+  Must have an even number of arguments. Odd-numbered arguments must be Symbols.
+
+# Returns
+- `RoutedOption`: A routed option containing the strategy => value mappings
+
+# Throws
+- `Exceptions.PreconditionError`: If no arguments provided, odd number of arguments,
+  or odd-numbered arguments are not Symbols
+
+# Example
+```julia-repl
+julia> using CTSolvers.Strategies
+
+julia> # Single strategy
+julia> route_to(:solver, 100)
+RoutedOption((solver = 100,))
+
+julia> # Multiple strategies
+julia> route_to(:solver, 100, :modeler, 50)
+RoutedOption((solver = 100, modeler = 50))
+```
+
+# Notes
+- This is equivalent to the keyword syntax: `route_to(solver=100, modeler=50)`
+- Strategy identifiers must be Symbols (e.g., `:solver`, not `"solver"`)
+- The number of arguments must be even (pairs of Symbol-value)
+
+See also: `route_to(; kwargs...)`, `RoutedOption`
+"""
+function route_to(args::Vararg{Any})
+    # Validate at least one pair
+    if isempty(args)
         throw(
             Exceptions.PreconditionError(
-                "route_to requires at least one strategy argument";
-                reason="no strategy arguments provided",
-                suggestion="Use route_to(solver=100) or route_to(solver=100, modeler=50)",
-                context="route_to - function call precondition",
+                "route_to requires at least one strategy-value pair";
+                reason="no arguments provided",
+                suggestion="Use route_to(:solver, 100) or route_to(:solver, 100, :modeler, 50)",
+                context="route_to - positional syntax precondition",
             ),
         )
     end
 
-    # Convert Base.Pairs to NamedTuple - super clean!
-    return RoutedOption(NamedTuple(kwargs))
+    # Validate even number of arguments (each Symbol must have a value)
+    if length(args) % 2 != 0
+        throw(
+            Exceptions.PreconditionError(
+                "route_to requires an even number of arguments (Symbol-value pairs)";
+                got="$(length(args)) arguments (odd number)",
+                expected="even number of arguments (e.g., 2 for one strategy, 4 for two strategies)",
+                suggestion="Ensure each strategy Symbol has a corresponding value: route_to(:solver, 100) or route_to(:solver, 100, :modeler, 50)",
+                context="route_to - positional syntax precondition",
+            ),
+        )
+    end
+
+    # Build NamedTuple from pairs
+    pairs = NamedTuple()
+    for i in 1:2:length(args)
+        strategy_id = args[i]
+        value = args[i + 1]
+
+        # Validate strategy_id is a Symbol
+        if !(strategy_id isa Symbol)
+            throw(
+                Exceptions.PreconditionError(
+                    "Strategy identifier must be a Symbol";
+                    got="strategy_id = $strategy_id (type: $(typeof(strategy_id)))",
+                    expected="Symbol (e.g., :solver, :modeler)",
+                    suggestion="Use Symbols for strategy identifiers: route_to(:solver, 100)",
+                    context="route_to - positional syntax precondition",
+                ),
+            )
+        end
+
+        pairs = merge(pairs, NamedTuple{(strategy_id,)}((value,)))
+    end
+
+    # Delegate to internal helper
+    return _route_to_from_namedtuple(pairs)
 end
 
 # ============================================================================

--- a/test/suite/strategies/test_disambiguation.jl
+++ b/test/suite/strategies/test_disambiguation.jl
@@ -55,6 +55,77 @@ function test_disambiguation()
         end
 
         # ====================================================================
+        # UNIT TESTS - route_to() Positional Syntax
+        # ====================================================================
+
+        Test.@testset "route_to() Positional Syntax - Single Strategy" begin
+            result = Strategies.route_to(:solver, 100)
+            Test.@test result isa Strategies.RoutedOption
+            Test.@test length(result) == 1
+            Test.@test result[:solver] == 100
+        end
+
+        Test.@testset "route_to() Positional Syntax - Multiple Strategies" begin
+            result = Strategies.route_to(:solver, 100, :modeler, 50)
+            Test.@test result isa Strategies.RoutedOption
+            Test.@test length(result) == 2
+            Test.@test result[:solver] == 100
+            Test.@test result[:modeler] == 50
+        end
+
+        Test.@testset "route_to() Positional Syntax - Three Strategies" begin
+            result = Strategies.route_to(:solver, 100, :modeler, 50, :discretizer, 200)
+            Test.@test length(result) == 3
+            Test.@test result[:solver] == 100
+            Test.@test result[:modeler] == 50
+            Test.@test result[:discretizer] == 200
+        end
+
+        Test.@testset "route_to() Positional Syntax - Different Value Types" begin
+            # Integer
+            result = Strategies.route_to(:modeler, 42)
+            Test.@test result[:modeler] == 42
+
+            # Float
+            result = Strategies.route_to(:solver, 1.5e-6)
+            Test.@test result[:solver] == 1.5e-6
+
+            # String
+            result = Strategies.route_to(:optimizer, "ipopt")
+            Test.@test result[:optimizer] == "ipopt"
+
+            # Boolean
+            result = Strategies.route_to(:solver, true)
+            Test.@test result[:solver] == true
+
+            # Symbol
+            result = Strategies.route_to(:modeler, :auto)
+            Test.@test result[:modeler] == :auto
+        end
+
+        Test.@testset "route_to() Positional Syntax - Error Cases" begin
+            # No arguments
+            Test.@test_throws Exception Strategies.route_to()
+
+            # Odd number of arguments
+            Test.@test_throws Exception Strategies.route_to(:solver)
+
+            # Non-Symbol strategy identifier
+            Test.@test_throws Exception Strategies.route_to("solver", 100)
+            Test.@test_throws Exception Strategies.route_to(1, 100)
+        end
+
+        Test.@testset "route_to() Syntax Equivalence" begin
+            # Both syntaxes should produce identical results
+            kw_result = Strategies.route_to(solver=100, modeler=50)
+            pos_result = Strategies.route_to(:solver, 100, :modeler, 50)
+
+            Test.@test collect(pairs(kw_result)) == collect(pairs(pos_result))
+            Test.@test kw_result[:solver] == pos_result[:solver]
+            Test.@test kw_result[:modeler] == pos_result[:modeler]
+        end
+
+        # ====================================================================
         # UNIT TESTS - Different Value Types
         # ====================================================================
 


### PR DESCRIPTION
## Summary

This PR adds a positional argument syntax to the `route_to()` function as an alternative to the existing keyword argument syntax.

## Changes

### New Feature
- **Positional syntax**: `route_to(:solver, 100, :modeler, 50)` as alternative to `route_to(solver=100, modeler=50)`
- Both syntaxes are equivalent and produce identical `RoutedOption` results
- Validates even number of arguments and Symbol types for strategy identifiers
- Clear error messages for invalid inputs (odd count, non-Symbol identifiers, no arguments)

### Refactoring
- Added internal helper function `_route_to_from_namedtuple()` to avoid code duplication
- Both keyword and positional methods delegate to shared internal helper
- Improved maintainability and consistency

### Documentation
- Updated docstrings for both `route_to()` methods to show both syntaxes
- Examples demonstrate keyword and positional syntax equivalence
- Comprehensive error documentation with suggestions

### Tests
- Added 23 new tests covering:
  - Single and multiple strategy routing
  - Different value types (Integer, Float, String, Boolean, Symbol)
  - Error cases (no arguments, odd count, non-Symbol identifiers)
  - Syntax equivalence between keyword and positional forms
- All 72 tests passing

## Example Usage

```julia
# Keyword syntax (existing)
route_to(solver=100, modeler=50)

# Positional syntax (new)
route_to(:solver, 100, :modeler, 50)
```

## Version
- Bumped to 0.4.14
- CHANGELOG.md updated