### PR TITLE
Improve unknown option error messages with registry search

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -5,6 +5,50 @@ and provides migration guides for users upgrading between versions.
 
 ---
 
+## v0.4.14 (2026-04-12)
+
+**No breaking changes.**
+
+This release improves unknown option error messages with registry search functionality.
+
+### Summary - v0.4.14
+
+- Enhanced error messages when an option doesn't belong to any strategy in the current method
+- Added `_find_option_in_registry()` helper function to search for options across all registered strategies
+- Error messages now suggest if an option exists in other strategies not in the current method
+- Lists all matching strategies with their IDs and family names
+- Added comprehensive test coverage for registry search functionality
+
+### Migration - v0.4.14
+
+**No action required.** All existing code continues to work without changes.
+
+**Improved behavior:**
+
+When users provide an unknown option that doesn't exist in any strategy of the current method, the error message now includes helpful suggestions if the option exists in other registered strategies.
+
+**Example:**
+
+```julia
+# Before: Generic error message
+solve(ocp, :collocation, :adnlp, :ipopt; custom_opt=123)
+# → Error: "Option :custom_opt doesn't belong to any strategy in method (:collocation, :adnlp, :ipopt). Available options: ..."
+
+# After: Enhanced error with registry match
+solve(ocp, :collocation, :adnlp, :ipopt; custom_opt=123)
+# → Error: "Option :custom_opt doesn't belong to any strategy in method (:collocation, :adnlp, :ipopt).
+#         This option exists in other strategies: :madnlp (solver).
+#         Perhaps you selected the wrong strategy? Consider using a different method."
+```
+
+**Benefits:**
+
+- **Better UX**: Users get actionable guidance when they may have chosen the wrong strategy
+- **Faster debugging**: Identifies alternative strategies that support the requested option
+- **No API changes**: Purely an enhancement of error messages
+
+---
+
 ## v0.4.13 (2026-04-07)
 
 ### Display Changes (Non-Breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Clear notes on when to use each syntax
   - Comprehensive error documentation with suggestions
 
+- **Unknown option error messages** - Enhanced error messages when an option doesn't belong to any strategy in the current method
+  - Searches the registry for strategies not in the current method that have the option
+  - Suggests the user may have selected the wrong strategy if the option exists elsewhere
+  - Lists all matching strategies with their IDs and family names
+  - Example: "This option exists in other strategies: :madnlp (solver). Perhaps you selected the wrong strategy? Consider using a different method."
+
 ### Tests
 
 - **Positional syntax test coverage** - Added 23 new tests covering:
@@ -39,6 +45,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Different value types (Integer, Float, String, Boolean, Symbol)
   - Error cases (no arguments, odd count, non-Symbol identifiers)
   - Syntax equivalence between keyword and positional forms
+
+- **Registry search error messages** - Added 5 new tests for `_find_option_in_registry()`:
+  - Option exists in other strategies
+  - Option doesn't exist in registry
+  - Option only in current method strategies
+  - Option exists in multiple strategies across families
+  - Method with different strategy selection
+
+- **Integration test** - Added test verifying error message includes registry match suggestion
 
 ---
 

--- a/src/Orchestration/routing.jl
+++ b/src/Orchestration/routing.jl
@@ -501,8 +501,79 @@ end
 """
 $(TYPEDSIGNATURES)
 
+Search for an option in all strategies of the registry, excluding strategies in the current method.
+
+This helper function checks if an unknown option exists in strategies that are not part of the
+current method, enabling helpful error messages that suggest the user may have chosen the wrong strategy.
+
+# Arguments
+- `key::Symbol`: The option name to search for
+- `resolved::ResolvedMethod`: Resolved method containing current strategy IDs
+- `families::NamedTuple`: NamedTuple mapping family names to family types
+- `registry::Strategies.StrategyRegistry`: Strategy registry containing all registered strategies
+
+# Returns
+- `Vector{Tuple{Symbol, Symbol}}`: Vector of (strategy_id, family_name) tuples for strategies that have this option
+
+# Notes
+- Strategies in the current method are excluded from the search
+- Uses try/catch around metadata() for robustness against incomplete strategy definitions
+- Results are not ordered; caller should sort if needed
+"""
+function _find_option_in_registry(
+    key::Symbol,
+    resolved::ResolvedMethod,
+    families::NamedTuple,
+    registry::Strategies.StrategyRegistry,
+)::Vector{Tuple{Symbol,Symbol}}
+    # Get set of strategy IDs in current method
+    current_strategy_ids = Set(collect(resolved.ids_by_family))
+
+    # Search all strategies in registry
+    matches = Tuple{Symbol,Symbol}[]
+    for (family_type, strategy_types) in registry.families
+        # Find the family name for this family_type
+        family_name = nothing
+        for (fname, ftype) in pairs(families)
+            if ftype === family_type
+                family_name = fname
+                break
+            end
+        end
+        if family_name === nothing
+            continue  # This family_type is not in current families, skip
+        end
+
+        for strategy_type in strategy_types
+            strategy_id = Strategies.id(strategy_type)
+            # Skip if this strategy is in current method
+            if strategy_id in current_strategy_ids
+                continue
+            end
+            # Check if option exists in this strategy's metadata
+            try
+                meta = Strategies.metadata(strategy_type)
+                if haskey(meta, key)
+                    push!(matches, (strategy_id, family_name))
+                end
+            catch
+                # Skip if metadata fails (robustness)
+            end
+        end
+    end
+
+    return matches
+end
+
+"""
+$(TYPEDSIGNATURES)
+
 Helper to throw an informative error when an option doesn't belong to any strategy.
 Lists all available options for the active strategies to help the user.
+
+# Notes
+- Also searches the registry for strategies not in the current method that have this option,
+  suggesting the user may have chosen the wrong strategy.
 """
 function _error_unknown_option(
     key::Symbol,
@@ -542,8 +613,22 @@ function _error_unknown_option(
         )
     end
 
+    # Then, check if option exists in other strategies in registry
+    registry_matches = _find_option_in_registry(key, resolved, families, registry)
+    if !isempty(registry_matches)
+        if !isempty(all_suggestions)
+            push!(suggestion_parts, "\n")
+        end
+        matches_str = join([" :$sid ($family)" for (sid, family) in registry_matches], ", ")
+        push!(
+            suggestion_parts,
+            "This option exists in other strategies:$matches_str.\n" *
+            "Perhaps you selected the wrong strategy? Consider using a different method.",
+        )
+    end
+
     # Then, suggest bypass if user is confident about the option
-    if !isempty(all_suggestions)
+    if !isempty(all_suggestions) || !isempty(registry_matches)
         push!(suggestion_parts, "\n")
     end
     push!(

--- a/test/suite/orchestration/test_routing_internals.jl
+++ b/test/suite/orchestration/test_routing_internals.jl
@@ -50,11 +50,25 @@ function Strategies.metadata(::Type{InternalIpopt})
     )
 end
 
+# Additional strategy for testing registry search
+struct InternalMadNLP <: InternalTestSolver end
+Strategies.id(::Type{InternalMadNLP}) = :madnlp
+function Strategies.metadata(::Type{InternalMadNLP})
+    Strategies.StrategyMetadata(
+        Options.OptionDefinition(;
+            name=:max_iter, type=Int, default=1000, description="Max iterations"
+        ),
+        Options.OptionDefinition(;
+            name=:custom_opt, type=Int, default=42, description="Custom option for testing"
+        ),
+    )
+end
+
 # Test registry and families
 const INTERNAL_REGISTRY = Strategies.create_registry(
     InternalTestDiscretizer => (InternalCollocation,),
     InternalTestModeler => (InternalADNLP,),
-    InternalTestSolver => (InternalIpopt,),
+    InternalTestSolver => (InternalIpopt, InternalMadNLP),
 )
 
 const INTERNAL_FAMILIES = (
@@ -443,6 +457,52 @@ function test_routing_internals()
             Test.@test result.strategies.discretizer.method == :trapezoid
             Test.@test result.strategies.solver.max_iter == 500
             Test.@test result.strategies.solver.tol == 1e-6
+        end
+
+        Test.@testset "_find_option_in_registry" begin
+            # Test with option that exists in other strategies
+            resolved = Orchestration.resolve_method(
+                INTERNAL_METHOD, INTERNAL_FAMILIES, INTERNAL_REGISTRY
+            )
+            # :custom_opt exists in InternalMadNLP but not in current method (ipopt)
+            matches = Orchestration._find_option_in_registry(
+                :custom_opt, resolved, INTERNAL_FAMILIES, INTERNAL_REGISTRY
+            )
+            Test.@test length(matches) == 1
+            Test.@test matches[1] == (:madnlp, :solver)
+
+            # Test with option that doesn't exist in registry
+            matches = Orchestration._find_option_in_registry(
+                :totally_unknown, resolved, INTERNAL_FAMILIES, INTERNAL_REGISTRY
+            )
+            Test.@test isempty(matches)
+
+            # Test with option that only exists in current method strategies
+            # :grid_size exists in InternalCollocation which is in current method
+            matches = Orchestration._find_option_in_registry(
+                :grid_size, resolved, INTERNAL_FAMILIES, INTERNAL_REGISTRY
+            )
+            Test.@test isempty(matches)  # Should be empty since it's in current method
+
+            # Test with option that exists in multiple strategies across families
+            # :backend exists in both InternalADNLP and InternalIpopt, but both are in current method
+            # So result should be empty
+            matches = Orchestration._find_option_in_registry(
+                :backend, resolved, INTERNAL_FAMILIES, INTERNAL_REGISTRY
+            )
+            Test.@test isempty(matches)
+
+            # Test with method that doesn't use MadNLP
+            alt_method = (:collocation, :adnlp, :madnlp)
+            resolved_alt = Orchestration.resolve_method(
+                alt_method, INTERNAL_FAMILIES, INTERNAL_REGISTRY
+            )
+            # :max_iter exists in InternalIpopt (not in current method)
+            matches = Orchestration._find_option_in_registry(
+                :max_iter, resolved_alt, INTERNAL_FAMILIES, INTERNAL_REGISTRY
+            )
+            Test.@test length(matches) == 1
+            Test.@test matches[1] == (:ipopt, :solver)
         end
 
         # ====================================================================

--- a/test/suite/orchestration/test_routing_validation.jl
+++ b/test/suite/orchestration/test_routing_validation.jl
@@ -36,12 +36,23 @@ struct MySolver <: TestSolverFamily end
 Strategies.id(::Type{MySolver}) = :test_solver
 Strategies.metadata(::Type{MySolver}) = Strategies.StrategyMetadata()
 
+# Additional strategy for testing registry search
+struct MyOtherSolver <: TestSolverFamily end
+Strategies.id(::Type{MyOtherSolver}) = :test_other_solver
+function Strategies.metadata(::Type{MyOtherSolver})
+    Strategies.StrategyMetadata(
+        Options.OptionDefinition(;
+            name=:custom_opt, type=Int, default=42, description="Custom option"
+        ),
+    )
+end
+
 function create_test_setup()
     # Create a simple registry with test strategies
     registry = Strategies.create_registry(
         TestDiscretizerFamily => (MyDiscretizer,),
         TestModelerFamily => (MyModeler,),
-        TestSolverFamily => (MySolver,),
+        TestSolverFamily => (MySolver, MyOtherSolver),
     )
 
     # Define families
@@ -192,6 +203,33 @@ function test_routing_validation()
             Test.@test_throws Exceptions.IncorrectArgument Orchestration.route_all_options(
                 method, families, action_defs, kwargs, registry
             )
+        end
+
+        # ====================================================================
+        # INTEGRATION TESTS - Registry Match Suggestions
+        # ====================================================================
+
+        Test.@testset "Unknown option with registry match suggestion" begin
+            registry, families, action_defs = create_test_setup()
+            method = (:test_discretizer, :test_modeler, :test_solver)
+
+            # :custom_opt exists in MyOtherSolver but not in current method (test_solver)
+            kwargs = (custom_opt=123,)
+
+            err = try
+                Orchestration.route_all_options(
+                    method, families, action_defs, kwargs, registry
+                )
+                Test.@test false  # Should not reach here
+            catch e
+                e
+            end
+
+            # Verify the error message mentions the registry match
+            Test.@test err isa Exceptions.IncorrectArgument
+            Test.@test occursin("This option exists in other strategies", err.suggestion)
+            Test.@test occursin(":test_other_solver (solver)", err.suggestion)
+            Test.@test occursin("Perhaps you selected the wrong strategy", err.suggestion)
         end
     end
 end


### PR DESCRIPTION
- Add _find_option_in_registry() helper to search for options across all registered strategies
- Enhance _error_unknown_option() to suggest alternative strategies when option exists elsewhere
- Error messages now list matching strategies with IDs and family names
- Add comprehensive test coverage for registry search functionality
- Update CHANGELOG.md and BREAKING.md for v0.4.14