### PR TITLE
refactor: weak-dependency policy for NLPModels, ADNLPModels, ExaModels, KernelAbstractions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.22-beta] - 2026-06-27
+
+### Changed
+
+- **Weak-dependency policy for interchange formats** — `NLPModels`, `ADNLPModels`,
+  `ExaModels`, and `KernelAbstractions` are now *weak* dependencies (moved from
+  `[deps]` to `[weakdeps]`). `SolverCore` remains a hard dependency.
+  - Two new extensions added: `CTSolversADNLPModels` (triggered by `ADNLPModels`)
+    and `CTSolversExaModels` (triggered by `ExaModels` + `KernelAbstractions`).
+  - Solver extensions (`CTSolversIpopt`, `CTSolversKnitro`, `CTSolversMadNLP`,
+    `CTSolversMadNCL`, `CTSolversUno`) now co-trigger on `NLPModels` (in addition to
+    their existing solver-backend trigger) since they dispatch on
+    `NLPModels.AbstractNLPModel`.
+  - Core modeler stubs follow the Ipopt tag-dispatch pattern:
+    `build_adnlp_modeler` / `build_exa_modeler` throw `ExtensionError` when their
+    respective extension is not loaded; `Strategies.metadata` stubs do the same.
+  - `validate_backend_override` in core is rewritten to use two tag-dispatch helpers
+    (`__is_adbackend_type` / `__is_adbackend_instance`) so it no longer references
+    `ADNLPModels.ADBackend` directly; `CTSolversADNLPModels` overrides these to `true`.
+  - All direct `NLPModels`, `ADNLPModels`, `ExaModels`, `KernelAbstractions` `using`
+    statements removed from core source files (`DOCP/DOCP.jl`,
+    `Optimization/Optimization.jl`, `Solvers/Solvers.jl`, `Modelers/Modelers.jl`).
+
+---
+
 ## [0.4.21-beta] - 2026-06-27
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,39 +1,41 @@
 name = "CTSolvers"
 uuid = "d3e8d392-8e4b-4d9b-8e92-d7d4e3650ef6"
-version = "0.4.21-beta"
+version = "0.4.22-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]
-ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
 CTBase = "54762871-cc72-4466-b8e8-f6c8b58076cd"
 CTModels = "34c4fa32-2049-4079-8329-de33c2a22e2d"
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-ExaModels = "1037b233-b668-4ce9-9b63-f9f681f55dd2"
-KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
-NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 SolverCore = "ff4d7338-4cf1-434d-91df-b86cb86fb843"
 
 [weakdeps]
+ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+ExaModels = "1037b233-b668-4ce9-9b63-f9f681f55dd2"
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 MadNCL = "434a0bcb-5a7c-42b2-a9d3-9e3f760e7af0"
 MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
 MadNLPGPU = "d72a61cc-809d-412f-99be-fd81f4b8a598"
+NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 NLPModelsIpopt = "f4238b75-b362-5c4c-b852-0801c9a21d71"
 NLPModelsKnitro = "bec4dd0d-7755-52d5-9a02-22f0ffc7efcb"
 UnoSolver = "1baa60ac-02f7-4b39-a7a8-2f4f58486b05"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [extensions]
+CTSolversADNLPModels = "ADNLPModels"
 CTSolversCUDA = "CUDA"
 CTSolversEnzyme = "Enzyme"
-CTSolversIpopt = "NLPModelsIpopt"
-CTSolversKnitro = "NLPModelsKnitro"
-CTSolversMadNCL = ["MadNCL", "MadNLP"]
-CTSolversMadNLP = ["MadNLP"]
+CTSolversExaModels = ["ExaModels", "KernelAbstractions"]
+CTSolversIpopt = ["NLPModels", "NLPModelsIpopt"]
+CTSolversKnitro = ["NLPModels", "NLPModelsKnitro"]
+CTSolversMadNCL = ["MadNCL", "MadNLP", "NLPModels"]
+CTSolversMadNLP = ["MadNLP", "NLPModels"]
 CTSolversMadNLPGPU = "MadNLPGPU"
-CTSolversUno = "UnoSolver"
+CTSolversUno = ["NLPModels", "UnoSolver"]
 CTSolversZygote = "Zygote"
 
 [compat]
@@ -63,13 +65,17 @@ Zygote = "0.7"
 julia = "1.10"
 
 [extras]
+ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+ExaModels = "1037b233-b668-4ce9-9b63-f9f681f55dd2"
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 MadNCL = "434a0bcb-5a7c-42b2-a9d3-9e3f760e7af0"
 MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
 MadNLPGPU = "d72a61cc-809d-412f-99be-fd81f4b8a598"
+NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 NLPModelsIpopt = "f4238b75-b362-5c4c-b852-0801c9a21d71"
 NLPModelsKnitro = "bec4dd0d-7755-52d5-9a02-22f0ffc7efcb"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
@@ -79,4 +85,4 @@ UnoSolver = "1baa60ac-02f7-4b39-a7a8-2f4f58486b05"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "CUDA", "Enzyme", "MadNCL", "MadNLP", "MadNLPGPU", "NLPModelsIpopt", "OrderedCollections", "Random", "Test", "UnoSolver", "Zygote"]
+test = ["ADNLPModels", "Aqua", "BenchmarkTools", "CUDA", "Enzyme", "ExaModels", "KernelAbstractions", "MadNCL", "MadNLP", "MadNLPGPU", "NLPModels", "NLPModelsIpopt", "OrderedCollections", "Random", "Test", "UnoSolver", "Zygote"]

--- a/ext/CTSolversADNLPModels.jl
+++ b/ext/CTSolversADNLPModels.jl
@@ -1,0 +1,220 @@
+"""
+CTSolversADNLPModels Extension
+
+Extension providing ADNLP modeler metadata and constructor implementation.
+Triggered when ADNLPModels is loaded; implements the complete Modelers.ADNLP
+functionality that requires ADNLPModels types.
+"""
+module CTSolversADNLPModels
+
+import DocStringExtensions: TYPEDSIGNATURES
+import CTSolvers.Modelers
+import CTBase.Strategies
+import CTBase.Core
+import CTBase.Exceptions
+using ADNLPModels: ADNLPModels
+
+using CTBase.Strategies: CPU, AbstractStrategyParameter
+
+# ============================================================================
+# ADBackend type-check helpers (override weak-dep stubs in core)
+# ============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Return `true` for types that are subtypes of `ADNLPModels.ADBackend`.
+
+Overrides the core stub in `CTSolvers.Modelers` when `ADNLPModels` is loaded.
+
+# Returns
+- `Bool`: `true`
+
+See also: [`CTSolvers.Modelers.__is_adbackend_type`](@ref),
+[`CTSolvers.Modelers.__is_adbackend_instance`](@ref)
+"""
+Modelers.__is_adbackend_type(::Type{<:ADNLPModels.ADBackend}) = true
+
+"""
+$(TYPEDSIGNATURES)
+
+Return `true` for instances of `ADNLPModels.ADBackend`.
+
+Overrides the core stub in `CTSolvers.Modelers` when `ADNLPModels` is loaded.
+
+# Returns
+- `Bool`: `true`
+
+See also: [`CTSolvers.Modelers.__is_adbackend_instance`](@ref),
+[`CTSolvers.Modelers.__is_adbackend_type`](@ref)
+"""
+Modelers.__is_adbackend_instance(x::ADNLPModels.ADBackend) = true
+
+# ============================================================================
+# Available backends (override weak-dep stub in core)
+# ============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the list of available AD backends for `Modelers.ADNLP` using `ADNLPModels`.
+
+Overrides the core stub; called via [`CTSolvers.Modelers.get_adnlp_available_backends`](@ref).
+Includes all predefined backends from `ADNLPModels.predefined_backend` plus `:manual`.
+
+# Returns
+- `Vector{Symbol}`: available backend names (e.g. `:default`, `:optimized`, `:manual`)
+
+See also: [`CTSolvers.Modelers.get_adnlp_available_backends`](@ref),
+[`CTSolvers.Modelers.ADNLPTag`](@ref)
+"""
+function Modelers.__get_adnlp_available_backends(::Type{Modelers.ADNLPTag})
+    backends = collect(keys(ADNLPModels.predefined_backend))
+    push!(backends, :manual)
+    return backends
+end
+
+# ============================================================================
+# Metadata definition
+# ============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Return metadata defining all options for `Modelers.ADNLP{P}` modelers.
+
+Overrides the core `ExtensionError` stub when `ADNLPModels` is loaded. Covers
+basic options (`:show_time`, `:backend`, `:matrix_free`, `:name`) and expert-level
+AD backend overrides for individual derivative operations.
+
+# Returns
+- `CTBase.Strategies.StrategyMetadata`: metadata object with all option definitions
+
+See also: [`CTSolvers.Modelers.ADNLP`](@ref),
+[`CTSolvers.Modelers.build_adnlp_modeler`](@ref)
+"""
+function Strategies.metadata(::Type{Modelers.ADNLP{P}}) where {P<:CPU}
+    return Strategies.StrategyMetadata(
+        # === Basic Options ===
+        Strategies.OptionDefinition(;
+            name=:show_time,
+            type=Bool,
+            default=Core.NotProvided,
+            description="Whether to show timing information while building the ADNLP model",
+        ),
+        Strategies.OptionDefinition(;
+            name=:backend,
+            type=Symbol,
+            default=Modelers.__adnlp_model_backend(),
+            description="Automatic differentiation backend used by ADNLPModels.\nAvailable: $(join(Modelers.get_adnlp_available_backends(), ", ", " and ")).",
+            validator=Modelers.get_validate_adnlp_backend(Modelers.ADNLPTag),
+            aliases=(:adnlp_backend,),
+        ),
+
+        # === High-Priority Options ===
+        Strategies.OptionDefinition(;
+            name=:matrix_free,
+            type=Bool,
+            default=Core.NotProvided,
+            description="Enable matrix-free mode (avoids explicit Hessian/Jacobian matrices)",
+            validator=Modelers.validate_matrix_free,
+        ),
+        Strategies.OptionDefinition(;
+            name=:name,
+            type=String,
+            default=Core.NotProvided,
+            description="Name of the optimization model for identification",
+            validator=Modelers.validate_model_name,
+        ),
+
+        # === Advanced Backend Overrides (expert users) ===
+        Strategies.OptionDefinition(;
+            name=:gradient_backend,
+            type=Union{Nothing,Type{<:ADNLPModels.ADBackend},ADNLPModels.ADBackend},
+            default=Core.NotProvided,
+            description="Override backend for gradient computation (advanced users only)",
+            validator=Modelers.validate_backend_override,
+        ),
+        Strategies.OptionDefinition(;
+            name=:hprod_backend,
+            type=Union{Nothing,Type{<:ADNLPModels.ADBackend},ADNLPModels.ADBackend},
+            default=Core.NotProvided,
+            description="Override backend for Hessian-vector product (advanced users only)",
+            validator=Modelers.validate_backend_override,
+        ),
+        Strategies.OptionDefinition(;
+            name=:jprod_backend,
+            type=Union{Nothing,Type{<:ADNLPModels.ADBackend},ADNLPModels.ADBackend},
+            default=Core.NotProvided,
+            description="Override backend for Jacobian-vector product (advanced users only)",
+            validator=Modelers.validate_backend_override,
+        ),
+        Strategies.OptionDefinition(;
+            name=:jtprod_backend,
+            type=Union{Nothing,Type{<:ADNLPModels.ADBackend},ADNLPModels.ADBackend},
+            default=Core.NotProvided,
+            description="Override backend for transpose Jacobian-vector product (advanced users only)",
+            validator=Modelers.validate_backend_override,
+        ),
+        Strategies.OptionDefinition(;
+            name=:jacobian_backend,
+            type=Union{Nothing,Type{<:ADNLPModels.ADBackend},ADNLPModels.ADBackend},
+            default=Core.NotProvided,
+            description="Override backend for Jacobian matrix computation (advanced users only)",
+            validator=Modelers.validate_backend_override,
+        ),
+        Strategies.OptionDefinition(;
+            name=:hessian_backend,
+            type=Union{Nothing,Type{<:ADNLPModels.ADBackend},ADNLPModels.ADBackend},
+            default=Core.NotProvided,
+            description="Override backend for Hessian matrix computation (advanced users only)",
+            validator=Modelers.validate_backend_override,
+        ),
+        Strategies.OptionDefinition(;
+            name=:ghjvprod_backend,
+            type=Union{Nothing,Type{<:ADNLPModels.ADBackend},ADNLPModels.ADBackend},
+            default=Core.NotProvided,
+            description="Override backend for g^T ∇²c(x)v computation (advanced users only)",
+            validator=Modelers.validate_backend_override,
+        ),
+    )
+end
+
+# ============================================================================
+# Constructor implementation (override tag-dispatch stub in core)
+# ============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Build a `Modelers.ADNLP{parameter}` modeler with validated options.
+
+Overrides the core `ExtensionError` stub when `ADNLPModels` is loaded.
+Whenever the deprecated keyword `:adnlp_backend` is passed, a warning is issued
+and `:backend` should be used instead.
+
+# Arguments
+- `parameter::Type{<:AbstractStrategyParameter}`: strategy parameter type (e.g. `CPU`)
+- `mode::Symbol`: validation mode, `:strict` (default) or `:permissive`
+- `kwargs...`: options forwarded to [`CTBase.Strategies.build_strategy_options`](@extref)
+
+# Returns
+- `CTSolvers.Modelers.ADNLP{parameter}`: configured modeler instance
+
+See also: [`CTSolvers.Modelers.ADNLP`](@ref),
+[`CTSolvers.Modelers.build_adnlp_modeler`](@ref)
+"""
+function Modelers.build_adnlp_modeler(
+    ::Type{Modelers.ADNLPTag},
+    parameter::Type{<:AbstractStrategyParameter};
+    mode::Symbol=:strict,
+    kwargs...,
+)
+    if haskey(kwargs, :adnlp_backend)
+        @warn "adnlp_backend is deprecated, use backend instead" maxlog=1
+    end
+    opts = Strategies.build_strategy_options(Modelers.ADNLP{parameter}; mode=mode, kwargs...)
+    return Modelers.ADNLP{parameter}(opts)
+end
+
+end # module CTSolversADNLPModels

--- a/ext/CTSolversExaModels.jl
+++ b/ext/CTSolversExaModels.jl
@@ -1,0 +1,104 @@
+"""
+CTSolversExaModels Extension
+
+Extension providing Exa modeler metadata and constructor implementation.
+Triggered when ExaModels is loaded; implements the complete Modelers.Exa
+functionality that requires ExaModels/KernelAbstractions types.
+"""
+module CTSolversExaModels
+
+import DocStringExtensions: TYPEDSIGNATURES
+import CTSolvers.Modelers
+import CTBase.Strategies
+import CTBase.Core
+using ExaModels: ExaModels
+using KernelAbstractions: KernelAbstractions
+
+using CTBase.Strategies: CPU, GPU, AbstractStrategyParameter
+
+# ============================================================================
+# Metadata definition
+# ============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Return metadata defining all options for `Modelers.Exa{P}` modelers.
+
+Overrides the core `ExtensionError` stub when `ExaModels` and `KernelAbstractions`
+are loaded. Covers `:base_type` (floating-point precision) and `:backend`
+(KernelAbstractions execution backend, validated for consistency with `P`).
+
+# Returns
+- `CTBase.Strategies.StrategyMetadata`: metadata object with all option definitions
+
+See also: [`CTSolvers.Modelers.Exa`](@ref),
+[`CTSolvers.Modelers.build_exa_modeler`](@ref)
+"""
+function Strategies.metadata(::Type{Modelers.Exa{P}}) where {P<:Union{CPU,GPU}}
+    return Strategies.StrategyMetadata(
+        Strategies.OptionDefinition(;
+            name=:base_type,
+            type=DataType,
+            default=Modelers.__exa_model_base_type(),
+            description="Base floating-point type used by ExaModels",
+            validator=Modelers.validate_exa_base_type,
+        ),
+        Strategies.OptionDefinition(;
+            name=:backend,
+            type=Union{Nothing,KernelAbstractions.Backend},
+            default=Modelers.__exa_model_backend(P),
+            description="Execution backend for ExaModels (CPU, GPU, etc.)",
+            computed=true,
+            aliases=(:exa_backend,),
+            validator=function (backend)
+                if !Modelers.__consistent_backend(P, backend)
+                    param_str = P == CPU ? "CPU" : "GPU"
+                    backend_str =
+                        backend === nothing ? "no backend" : string(typeof(backend))
+                    @warn "Inconsistent backend ($backend_str) for $param_str parameter" maxlog=1
+                end
+                return backend
+            end,
+        ),
+    )
+end
+
+# ============================================================================
+# Constructor implementation (override tag-dispatch stub in core)
+# ============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Build a `Modelers.Exa{parameter}` modeler with validated options.
+
+Overrides the core `ExtensionError` stub when `ExaModels` and `KernelAbstractions`
+are loaded. Whenever the deprecated keyword `:exa_backend` is passed, a warning
+is issued and `:backend` should be used instead.
+
+# Arguments
+- `parameter::Type{<:AbstractStrategyParameter}`: strategy parameter type (e.g. `CPU`, `GPU`)
+- `mode::Symbol`: validation mode, `:strict` (default) or `:permissive`
+- `kwargs...`: options forwarded to [`CTBase.Strategies.build_strategy_options`](@extref)
+
+# Returns
+- `CTSolvers.Modelers.Exa{parameter}`: configured modeler instance
+
+See also: [`CTSolvers.Modelers.Exa`](@ref),
+[`CTSolvers.Modelers.build_exa_modeler`](@ref)
+"""
+function Modelers.build_exa_modeler(
+    ::Type{Modelers.ExaTag},
+    parameter::Type{<:AbstractStrategyParameter};
+    mode::Symbol=:strict,
+    kwargs...,
+)
+    if haskey(kwargs, :exa_backend)
+        @warn "exa_backend is deprecated, use backend instead" maxlog=1
+    end
+    opts = Strategies.build_strategy_options(Modelers.Exa{parameter}; mode=mode, kwargs...)
+    return Modelers.Exa{parameter}(opts)
+end
+
+end # module CTSolversExaModels

--- a/src/DOCP/DOCP.jl
+++ b/src/DOCP/DOCP.jl
@@ -17,7 +17,6 @@ module DOCP
 
 # Imports
 import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
-using NLPModels: NLPModels
 using SolverCore: SolverCore
 using CTModels: CTModels
 import CTBase.Core

--- a/src/DOCP/building.jl
+++ b/src/DOCP/building.jl
@@ -28,7 +28,7 @@ See also: `ocp_solution`, `Optimization.build_model`
 """
 function nlp_model(
     prob::DiscretizedModel, initial_guess, modeler::Modelers.AbstractNLPModeler
-)::NLPModels.AbstractNLPModel
+)
     return build_model(prob, initial_guess, modeler)
 end
 

--- a/src/Modelers/Modelers.jl
+++ b/src/Modelers/Modelers.jl
@@ -20,9 +20,6 @@ module Modelers
 import CTBase.Exceptions
 import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 using SolverCore: SolverCore
-using ADNLPModels: ADNLPModels
-using ExaModels: ExaModels
-using KernelAbstractions: KernelAbstractions
 import CTBase.Core
 
 # CTBase generic infrastructure

--- a/src/Modelers/adnlp.jl
+++ b/src/Modelers/adnlp.jl
@@ -27,44 +27,45 @@ __adnlp_model_backend() = :optimized
 """
 $(TYPEDSIGNATURES)
 
+Return the list of available AD backends for `Modelers.ADNLP` via tag dispatch.
+
+Stub — throws [`CTBase.Exceptions.ExtensionError`](@extref) by default.
+Overridden by the `CTSolversADNLPModels` extension for `ADNLPTag`.
+
+# Throws
+- `CTBase.Exceptions.ExtensionError`: always, until overridden by the extension
+
+See also: [`CTSolvers.Modelers.get_adnlp_available_backends`](@ref),
+[`CTSolvers.Modelers.ADNLPTag`](@ref)
+"""
+function __get_adnlp_available_backends(::Type{<:Core.AbstractTag})
+    throw(
+        Exceptions.ExtensionError(
+            :ADNLPModels;
+            message="to list available ADNLP backends",
+            feature="ADNLP backends listing",
+            context="Load ADNLPModels first: using ADNLPModels",
+        ),
+    )
+end
+
+"""
+$(TYPEDSIGNATURES)
+
 Return the list of available automatic differentiation backends for `Modelers.ADNLP`.
 
-The available backends are the predefined backends from ADNLPModels plus `:manual`:
-- `:default`: Default backend selection
-- `:optimized`: Optimized backend (default)
-- `:generic`: Generic backend
-- `:enzyme`: Enzyme backend (requires CTSolversEnzyme extension)
-- `:zygote`: Zygote backend (requires CTSolversZygote extension)
-- `:manual`: Manual backend specification (for advanced users)
+Requires the `CTSolversADNLPModels` extension (`using ADNLPModels`) to be loaded.
 
 # Returns
-- `Vector{Symbol}`: List of available backend symbols
+- `Vector{Symbol}`: available backend names (e.g. `:default`, `:optimized`, `:manual`)
 
-# Example
-```julia-repl
-julia> using CTSolvers.Modelers
+# Throws
+- `CTBase.Exceptions.ExtensionError`: if `ADNLPModels` is not loaded
 
-julia> get_adnlp_available_backends()
-6-element Vector{Symbol}:
- :default
- :optimized
- :generic
- :enzyme
- :zygote
- :manual
-```
-
-# Notes
-- Some backends require optional extensions (e.g., Enzyme, Zygote)
-- The `:manual` backend is for advanced users who want to specify custom backend overrides
-
-See also: `Modelers.ADNLP`, `get_validate_adnlp_backend`
+See also: [`CTSolvers.Modelers.ADNLP`](@ref),
+[`CTSolvers.Modelers.get_validate_adnlp_backend`](@ref)
 """
-function get_adnlp_available_backends()::Vector{Symbol}
-    backends = collect(keys(ADNLPModels.predefined_backend))
-    push!(backends, :manual)
-    return backends
-end
+get_adnlp_available_backends() = __get_adnlp_available_backends(ADNLPTag)
 
 """
 $(TYPEDEF)
@@ -247,136 +248,24 @@ See also: `ADNLP`, `CPU`
 Strategies._default_parameter(::Type{<:Modelers.ADNLP}) = CPU
 
 # Strategy metadata with option definitions (parameterized)
+"""
+$(TYPEDSIGNATURES)
+
+Stub — real implementation provided by the CTSolversADNLPModels extension.
+
+# Throws
+- `CTBase.Exceptions.ExtensionError`: If the ADNLPModels extension is not loaded
+
+See also: `Modelers.ADNLP`, `Strategies.StrategyMetadata`
+"""
 function Strategies.metadata(::Type{<:Modelers.ADNLP{P}}) where {P<:CPU}
-    return Strategies.StrategyMetadata(
-        # === Existing Options (unchanged) ===
-        Strategies.OptionDefinition(;
-            name=:show_time,
-            type=Bool,
-            default=Core.NotProvided,
-            description="Whether to show timing information while building the ADNLP model",
+    throw(
+        Exceptions.ExtensionError(
+            :ADNLPModels;
+            message="to access ADNLP{$P} options metadata",
+            feature="ADNLP metadata",
+            context="Load ADNLPModels first: using ADNLPModels",
         ),
-        Strategies.OptionDefinition(;
-            name=:backend,
-            type=Symbol,
-            default=__adnlp_model_backend(),
-            description="Automatic differentiation backend used by ADNLPModels.\nAvailable: $(join(get_adnlp_available_backends(), ", ", " and ")).",
-            validator=get_validate_adnlp_backend(ADNLPTag),
-            aliases=(:adnlp_backend,),
-        ),
-
-        # === New High-Priority Options ===
-        Strategies.OptionDefinition(;
-            name=:matrix_free,
-            type=Bool,
-            default=Core.NotProvided,
-            description="Enable matrix-free mode (avoids explicit Hessian/Jacobian matrices)",
-            validator=validate_matrix_free,
-        ),
-        Strategies.OptionDefinition(;
-            name=:name,
-            type=String,
-            default=Core.NotProvided,
-            description="Name of the optimization model for identification",
-            validator=validate_model_name,
-        ),
-        # NOTE: minimize option is commented out as it will be automatically set
-        # when building the model based on the problem structure
-        # Strategies.OptionDefinition(;
-        #     name=:minimize,
-        #     type=Bool,
-        #     default=Core.NotProvided,
-        #     description="Optimization direction (true for minimization, false for maximization)",
-        #     validator=validate_optimization_direction
-        # ),
-
-        # === Advanced Backend Overrides (expert users) ===
-        Strategies.OptionDefinition(;
-            name=:gradient_backend,
-            type=Union{Nothing,Type{<:ADNLPModels.ADBackend},ADNLPModels.ADBackend},
-            default=Core.NotProvided,
-            description="Override backend for gradient computation (advanced users only)",
-            validator=validate_backend_override,
-        ),
-        Strategies.OptionDefinition(;
-            name=:hprod_backend,
-            type=Union{Nothing,Type{<:ADNLPModels.ADBackend},ADNLPModels.ADBackend},
-            default=Core.NotProvided,
-            description="Override backend for Hessian-vector product (advanced users only)",
-            validator=validate_backend_override,
-        ),
-        Strategies.OptionDefinition(;
-            name=:jprod_backend,
-            type=Union{Nothing,Type{<:ADNLPModels.ADBackend},ADNLPModels.ADBackend},
-            default=Core.NotProvided,
-            description="Override backend for Jacobian-vector product (advanced users only)",
-            validator=validate_backend_override,
-        ),
-        Strategies.OptionDefinition(;
-            name=:jtprod_backend,
-            type=Union{Nothing,Type{<:ADNLPModels.ADBackend},ADNLPModels.ADBackend},
-            default=Core.NotProvided,
-            description="Override backend for transpose Jacobian-vector product (advanced users only)",
-            validator=validate_backend_override,
-        ),
-        Strategies.OptionDefinition(;
-            name=:jacobian_backend,
-            type=Union{Nothing,Type{<:ADNLPModels.ADBackend},ADNLPModels.ADBackend},
-            default=Core.NotProvided,
-            description="Override backend for Jacobian matrix computation (advanced users only)",
-            validator=validate_backend_override,
-        ),
-        Strategies.OptionDefinition(;
-            name=:hessian_backend,
-            type=Union{Nothing,Type{<:ADNLPModels.ADBackend},ADNLPModels.ADBackend},
-            default=Core.NotProvided,
-            description="Override backend for Hessian matrix computation (advanced users only)",
-            validator=validate_backend_override,
-        ),
-        Strategies.OptionDefinition(;
-            name=:ghjvprod_backend,
-            type=Union{Nothing,Type{<:ADNLPModels.ADBackend},ADNLPModels.ADBackend},
-            default=Core.NotProvided,
-            description="Override backend for g^T ∇²c(x)v computation (advanced users only)",
-            validator=validate_backend_override,
-        ),
-
-        # # === Advanced Backend Overrides for NLS (expert users) ===
-        # Strategies.OptionDefinition(;
-        #     name=:hprod_residual_backend,
-        #     type=Union{Nothing, Type{<:ADNLPModels.ADBackend}, ADNLPModels.ADBackend},
-        #     default=Core.NotProvided,
-        #     description="Override backend for Hessian-vector product of residuals (NLS) (advanced users only)",
-        #     validator=validate_backend_override
-        # ),
-        # Strategies.OptionDefinition(;
-        #     name=:jprod_residual_backend,
-        #     type=Union{Nothing, Type{<:ADNLPModels.ADBackend}, ADNLPModels.ADBackend},
-        #     default=Core.NotProvided,
-        #     description="Override backend for Jacobian-vector product of residuals (NLS) (advanced users only)",
-        #     validator=validate_backend_override
-        # ),
-        # Strategies.OptionDefinition(;
-        #     name=:jtprod_residual_backend,
-        #     type=Union{Nothing, Type{<:ADNLPModels.ADBackend}, ADNLPModels.ADBackend},
-        #     default=Core.NotProvided,
-        #     description="Override backend for transpose Jacobian-vector product of residuals (NLS) (advanced users only)",
-        #     validator=validate_backend_override
-        # ),
-        # Strategies.OptionDefinition(;
-        #     name=:jacobian_residual_backend,
-        #     type=Union{Nothing, Type{<:ADNLPModels.ADBackend}, ADNLPModels.ADBackend},
-        #     default=Core.NotProvided,
-        #     description="Override backend for Jacobian matrix of residuals (NLS) (advanced users only)",
-        #     validator=validate_backend_override
-        # ),
-        # Strategies.OptionDefinition(;
-        #     name=:hessian_residual_backend,
-        #     type=Union{Nothing, Type{<:ADNLPModels.ADBackend}, ADNLPModels.ADBackend},
-        #     default=Core.NotProvided,
-        #     description="Override backend for Hessian matrix of residuals (NLS) (advanced users only)",
-        #     validator=validate_backend_override
-        # )
     )
 end
 
@@ -387,11 +276,16 @@ function Strategies.metadata(::Type{Modelers.ADNLP})
     )
 end
 
-# Parameterized constructor
+# ============================================================================
+# Constructor with Tag Dispatch
+# ============================================================================
+
 """
 $(TYPEDSIGNATURES)
 
 Create a parameterized Modelers.ADNLP with validated options.
+
+Requires the CTSolversADNLPModels extension to be loaded.
 
 # Arguments
 - `mode::Symbol=:strict`: Validation mode (`:strict` or `:permissive`)
@@ -402,32 +296,38 @@ Create a parameterized Modelers.ADNLP with validated options.
 # Returns
 - `Modelers.ADNLP{P}`: Configured modeler instance with specified parameter
 
-# Examples
-```julia
-# Explicit CPU modeler
-modeler = Modelers.ADNLP{CPU}()
-
-# With custom options
-modeler = Modelers.ADNLP{CPU}(backend=:optimized, matrix_free=true)
-
-# With permissive mode
-modeler = Modelers.ADNLP{CPU}(backend=:optimized, custom_option=123; mode=:permissive)
-```
-
 # Throws
+- `CTBase.Exceptions.ExtensionError`: If the ADNLPModels extension is not loaded
 - `CTBase.Exceptions.IncorrectArgument`: If option validation fails
-- `CTBase.Exceptions.IncorrectArgument`: If invalid mode is provided
 
-See also: `Modelers.ADNLP`, `Strategies.build_strategy_options`
+See also: `Modelers.ADNLP`, `build_adnlp_modeler`
 """
 function Modelers.ADNLP{P}(; mode::Symbol=:strict, kwargs...) where {P<:CPU}
-    # Check for deprecated aliases
-    if haskey(kwargs, :adnlp_backend)
-        @warn "adnlp_backend is deprecated, use backend instead" maxlog=1
-    end
+    return build_adnlp_modeler(ADNLPTag, P; mode=mode, kwargs...)
+end
 
-    opts = Strategies.build_strategy_options(Modelers.ADNLP{P}; mode=mode, kwargs...)
-    return Modelers.ADNLP{P}(opts)
+"""
+$(TYPEDSIGNATURES)
+
+Stub function that throws ExtensionError if CTSolversADNLPModels extension is not loaded.
+Real implementation provided by the extension.
+
+# Throws
+- `CTBase.Exceptions.ExtensionError`: Always thrown by this stub implementation
+
+See also: `Modelers.ADNLP`, `Strategies.metadata`
+"""
+function build_adnlp_modeler(
+    ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
+)
+    throw(
+        Exceptions.ExtensionError(
+            :ADNLPModels;
+            message="to create ADNLP, access options, and build NLP models",
+            feature="ADNLP modeler functionality",
+            context="Load ADNLPModels first: using ADNLPModels",
+        ),
+    )
 end
 
 # Simple constructor
@@ -458,10 +358,10 @@ modeler = Modelers.ADNLP(backend=:optimized, custom_option=123; mode=:permissive
 ```
 
 # Throws
+- `CTBase.Exceptions.ExtensionError`: If the ADNLPModels extension is not loaded
 - `CTBase.Exceptions.IncorrectArgument`: If option validation fails
-- `CTBase.Exceptions.IncorrectArgument`: If invalid mode is provided
 
-See also: `Modelers.ADNLP`, `Modelers.ADNLP{CPU}`, `Strategies.build_strategy_options`
+See also: `Modelers.ADNLP`, `Modelers.ADNLP{CPU}`, `build_adnlp_modeler`
 """
 function Modelers.ADNLP(; mode::Symbol=:strict, kwargs...)
     P = Strategies._default_parameter(Modelers.ADNLP)

--- a/src/Modelers/exa.jl
+++ b/src/Modelers/exa.jl
@@ -3,6 +3,17 @@
 # Implementation of `Modelers.Exa` using the `Strategies.AbstractStrategy`
 # contract.
 
+# ============================================================================
+# Tag dispatch infrastructure
+# ============================================================================
+
+"""
+$(TYPEDEF)
+
+Tag type for Exa-specific implementation dispatch.
+"""
+struct ExaTag <: Core.AbstractTag end
+
 # Default option values
 """
 $(TYPEDSIGNATURES)
@@ -247,32 +258,23 @@ See also: `Exa`, `CPU`
 Strategies._default_parameter(::Type{<:Modelers.Exa}) = CPU
 
 # Strategy metadata with option definitions (parameterized)
+"""
+$(TYPEDSIGNATURES)
+
+Stub — real implementation provided by the CTSolversExaModels extension.
+
+# Throws
+- `CTBase.Exceptions.ExtensionError`: If the ExaModels extension is not loaded
+
+See also: `Modelers.Exa`, `Strategies.StrategyMetadata`
+"""
 function Strategies.metadata(::Type{<:Modelers.Exa{P}}) where {P<:Union{CPU,GPU}}
-    return Strategies.StrategyMetadata(
-        # === Existing Options (enhanced) ===
-        Strategies.OptionDefinition(;
-            name=:base_type,
-            type=DataType,
-            default=__exa_model_base_type(),
-            description="Base floating-point type used by ExaModels",
-            validator=validate_exa_base_type,
-        ),
-        Strategies.OptionDefinition(;
-            name=:backend,
-            type=Union{Nothing,KernelAbstractions.Backend},  # More permissive for various backend types
-            default=__exa_model_backend(P),
-            description="Execution backend for ExaModels (CPU, GPU, etc.)",
-            computed=true,  # Default is computed from parameter P
-            aliases=(:exa_backend,),
-            validator=function (backend)
-                if !__consistent_backend(P, backend)
-                    param_str = P == CPU ? "CPU" : "GPU"
-                    backend_str =
-                        backend === nothing ? "no backend" : string(typeof(backend))
-                    @warn "Inconsistent backend ($backend_str) for $param_str parameter" maxlog=1
-                end
-                return backend
-            end,
+    throw(
+        Exceptions.ExtensionError(
+            :ExaModels;
+            message="to access Exa{$P} options metadata",
+            feature="Exa metadata",
+            context="Load ExaModels first: using ExaModels",
         ),
     )
 end
@@ -292,11 +294,16 @@ function Strategies.metadata(::Type{Modelers.Exa})
     return Strategies.metadata(Modelers.Exa{Strategies._default_parameter(Modelers.Exa)})
 end
 
-# Parameterized constructor
+# ============================================================================
+# Constructor with Tag Dispatch
+# ============================================================================
+
 """
 $(TYPEDSIGNATURES)
 
 Create a parameterized Modelers.Exa with validated options.
+
+Requires the CTSolversExaModels extension to be loaded.
 
 # Arguments
 - `mode::Symbol=:strict`: Validation mode (`:strict` or `:permissive`)
@@ -307,38 +314,40 @@ Create a parameterized Modelers.Exa with validated options.
 # Returns
 - `Modelers.Exa{P}`: Configured modeler instance with specified parameter
 
-# Examples
-```julia
-# Explicit CPU modeler
-modeler = Modelers.Exa{CPU}()
-
-# Explicit GPU modeler (requires CUDA.jl)
-modeler = Modelers.Exa{GPU}()
-
-# With custom options
-modeler = Modelers.Exa{GPU}(base_type=Float32)
-
-# With permissive mode
-modeler = Modelers.Exa{GPU}(base_type=Float64, custom_option=123; mode=:permissive)
-```
-
 # Throws
+- `CTBase.Exceptions.ExtensionError`: If the ExaModels extension is not loaded
 - `CTBase.Exceptions.IncorrectArgument`: If option validation fails
-- `CTBase.Exceptions.IncorrectArgument`: If invalid mode is provided
-- `CTBase.Exceptions.ExtensionError`: If GPU parameter used but CUDA not available
 
-See also: `Modelers.Exa`, `Strategies.build_strategy_options`
+See also: `Modelers.Exa`, `build_exa_modeler`
 """
 function Modelers.Exa{P}(;
     mode::Symbol=:strict, kwargs...
 ) where {P<:AbstractStrategyParameter}
-    # Check for deprecated aliases
-    if haskey(kwargs, :exa_backend)
-        @warn "exa_backend is deprecated, use backend instead" maxlog=1
-    end
+    return build_exa_modeler(ExaTag, P; mode=mode, kwargs...)
+end
 
-    opts = Strategies.build_strategy_options(Modelers.Exa{P}; mode=mode, kwargs...)
-    return Modelers.Exa{P}(opts)
+"""
+$(TYPEDSIGNATURES)
+
+Stub function that throws ExtensionError if CTSolversExaModels extension is not loaded.
+Real implementation provided by the extension.
+
+# Throws
+- `CTBase.Exceptions.ExtensionError`: Always thrown by this stub implementation
+
+See also: `Modelers.Exa`, `Strategies.metadata`
+"""
+function build_exa_modeler(
+    ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
+)
+    throw(
+        Exceptions.ExtensionError(
+            :ExaModels;
+            message="to create Exa, access options, and build NLP models",
+            feature="Exa modeler functionality",
+            context="Load ExaModels first: using ExaModels",
+        ),
+    )
 end
 
 # Simple constructor
@@ -346,6 +355,8 @@ end
 $(TYPEDSIGNATURES)
 
 Create an Modelers.Exa with validated options (defaults to CPU).
+
+Requires the CTSolversExaModels extension to be loaded.
 
 # Arguments
 - `mode::Symbol=:strict`: Validation mode (`:strict` or `:permissive`)
@@ -356,23 +367,11 @@ Create an Modelers.Exa with validated options (defaults to CPU).
 # Returns
 - `Modelers.Exa{CPU}`: Configured modeler instance with CPU parameter
 
-# Examples
-```julia
-# Default modeler (CPU)
-modeler = Modelers.Exa()
-
-# With custom options
-modeler = Modelers.Exa(base_type=Float32, backend=nothing)
-
-# With permissive mode
-modeler = Modelers.Exa(base_type=Float64, custom_option=123; mode=:permissive)
-```
-
 # Throws
+- `CTBase.Exceptions.ExtensionError`: If the ExaModels extension is not loaded
 - `CTBase.Exceptions.IncorrectArgument`: If option validation fails
-- `CTBase.Exceptions.IncorrectArgument`: If invalid mode is provided
 
-See also: `Modelers.Exa`, `Modelers.Exa{CPU}`, `Modelers.Exa{GPU}`, `Strategies.build_strategy_options`
+See also: `Modelers.Exa`, `Modelers.Exa{CPU}`, `Modelers.Exa{GPU}`, `build_exa_modeler`
 """
 function Modelers.Exa(; mode::Symbol=:strict, kwargs...)
     P = Strategies._default_parameter(Modelers.Exa)

--- a/src/Modelers/validation.jl
+++ b/src/Modelers/validation.jl
@@ -285,6 +285,42 @@ function validate_optimization_direction(minimize::Bool)
     return minimize
 end
 
+# ============================================================================
+# ADBackend tag-dispatch helpers (ADNLPModels is a weak dep)
+# ============================================================================
+
+"""
+$(TYPEDSIGNATURES)
+
+Return `true` if `T` is a subtype of `ADNLPModels.ADBackend`.
+
+Stub — always returns `false`. Overridden by the `CTSolversADNLPModels` extension
+(triggered when `ADNLPModels` is loaded) for concrete `ADBackend` subtypes.
+
+# Returns
+- `Bool`: `false` (stub); `true` when the extension is active and `T <: ADBackend`
+
+See also: [`CTSolvers.Modelers.__is_adbackend_instance`](@ref),
+[`CTSolvers.Modelers.validate_backend_override`](@ref)
+"""
+__is_adbackend_type(::Type) = false
+
+"""
+$(TYPEDSIGNATURES)
+
+Return `true` if `x` is an instance of `ADNLPModels.ADBackend`.
+
+Stub — always returns `false`. Overridden by the `CTSolversADNLPModels` extension
+(triggered when `ADNLPModels` is loaded) for concrete `ADBackend` instances.
+
+# Returns
+- `Bool`: `false` (stub); `true` when the extension is active and `x isa ADBackend`
+
+See also: [`CTSolvers.Modelers.__is_adbackend_type`](@ref),
+[`CTSolvers.Modelers.validate_backend_override`](@ref)
+"""
+__is_adbackend_instance(x) = false
+
 """
 $(TYPEDSIGNATURES)
 
@@ -312,9 +348,9 @@ function validate_backend_override(backend)
     # nothing means "use default backend"
     backend === nothing && return backend
     # Accept a Type that is a subtype of ADBackend (e.g., ForwardDiffADGradient)
-    isa(backend, Type) && backend <: ADNLPModels.ADBackend && return backend
+    isa(backend, Type) && __is_adbackend_type(backend) && return backend
     # Accept an ADBackend instance (e.g., ForwardDiffADGradient())
-    isa(backend, ADNLPModels.ADBackend) && return backend
+    __is_adbackend_instance(backend) && return backend
     throw(
         Exceptions.IncorrectArgument(
             "Backend override must be nothing, a Type{<:ADBackend}, or an ADBackend instance";

--- a/src/Optimization/Optimization.jl
+++ b/src/Optimization/Optimization.jl
@@ -17,7 +17,6 @@ module Optimization
 # Imports
 import CTBase.Exceptions
 import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
-using NLPModels: NLPModels
 using SolverCore: SolverCore
 
 # Submodules

--- a/src/Solvers/Solvers.jl
+++ b/src/Solvers/Solvers.jl
@@ -43,7 +43,6 @@ module Solvers
 
 # Imports
 import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES, TYPEDFIELDS
-using NLPModels: NLPModels
 using SolverCore: SolverCore
 using CommonSolve: CommonSolve
 import CTBase.Exceptions

--- a/src/Solvers/common_solve_api.jl
+++ b/src/Solvers/common_solve_api.jl
@@ -68,12 +68,13 @@ Mid-level solve: Solve an NLP problem directly.
 
 # Contract
 Concrete solvers implement this method, typically in a backend extension,
-dispatching on the solver type, e.g.
+dispatching on both the problem type and the solver type, e.g.
 `CommonSolve.solve(nlp::NLPModels.AbstractNLPModel, solver::Ipopt; display)` in
 the `CTSolversIpopt` extension. This generic stub throws `NotImplemented`.
+`NLPModels` is a weak dep — the typed method lives in each solver extension.
 
 # Arguments
-- `nlp::NLPModels.AbstractNLPModel`: The NLP problem to solve
+- `nlp`: The NLP problem to solve (type depends on backend)
 - `solver::AbstractNLPSolver`: Solver to use
 - `display::Bool`: Whether to show solver output (default: true)
 
@@ -83,12 +84,12 @@ the `CTSolversIpopt` extension. This generic stub throws `NotImplemented`.
 See also: `AbstractNLPSolver`
 """
 function CommonSolve.solve(
-    nlp::NLPModels.AbstractNLPModel, solver::AbstractNLPSolver; display::Bool=__display()
+    nlp, solver::AbstractNLPSolver; display::Bool=__display()
 )
     throw(
         Exceptions.NotImplemented(
             "Solve not implemented for this solver";
-            required_method="CommonSolve.solve(nlp::NLPModels.AbstractNLPModel, solver::$(typeof(solver)); display)",
+            required_method="CommonSolve.solve(nlp, solver::$(typeof(solver)); display)",
             suggestion="Load the backend extension providing $(typeof(solver)) (e.g. `using NLPModelsIpopt`)",
             context="Solvers.solve - required method implementation",
         ),

--- a/test/suite/modelers/test_coverage_modelers.jl
+++ b/test/suite/modelers/test_coverage_modelers.jl
@@ -7,6 +7,7 @@ import CTBase.Strategies
 import CTBase.Options
 import CTSolvers.Optimization
 using SolverCore: SolverCore
+using ExaModels: ExaModels
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/modelers/test_enhanced_options.jl
+++ b/test/suite/modelers/test_enhanced_options.jl
@@ -13,6 +13,7 @@ const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
 # Import the specific types we need
 using ADNLPModels: ADNLPModels
 import CTSolvers.Modelers
+using ExaModels: ExaModels
 using KernelAbstractions: KernelAbstractions
 import CTBase.Strategies
 

--- a/test/suite/modelers/test_exa_gpu.jl
+++ b/test/suite/modelers/test_exa_gpu.jl
@@ -5,6 +5,8 @@ import CTBase.Exceptions
 import CTSolvers.Modelers
 import CTBase.Strategies
 import CTBase.Options
+using ExaModels: ExaModels
+using KernelAbstractions: KernelAbstractions
 using CUDA: CUDA
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true


### PR DESCRIPTION
## Summary

Demotes `NLPModels`, `ADNLPModels`, `ExaModels`, and `KernelAbstractions` from hard dependencies to weak dependencies. `SolverCore` remains a hard dependency.

This is Part B of the CTSolvers prep-for-integrators roadmap.

---

## New extensions

| Extension | Trigger(s) | Provides |
|-----------|-----------|----------|
| `CTSolversADNLPModels` | `ADNLPModels` | `Strategies.metadata(ADNLP{P})`, `build_adnlp_modeler`, `__is_adbackend_type/instance` overrides |
| `CTSolversExaModels` | `ExaModels` + `KernelAbstractions` | `Strategies.metadata(Exa{P})`, `build_exa_modeler` |

Existing solver extensions (`CTSolversIpopt`, `CTSolversKnitro`, `CTSolversMadNLP`, `CTSolversMadNCL`, `CTSolversUno`) now co-trigger on `NLPModels` since they dispatch on `NLPModels.AbstractNLPModel` in their `solve` methods.

---

## Core changes

### Tag-dispatch stub pattern (same as Ipopt)

- `adnlp.jl`: `build_adnlp_modeler` stub + `__get_adnlp_available_backends(::Type{<:AbstractTag})` stub; `Strategies.metadata` stub throws `ExtensionError` when `ADNLPModels` is not loaded.
- `exa.jl`: `ExaTag` added; `build_exa_modeler` stub; `Strategies.metadata` stub.
- `validation.jl`: `validate_backend_override` rewritten using `__is_adbackend_type` / `__is_adbackend_instance` tag-dispatch helpers, removing the direct `ADNLPModels.ADBackend` reference from core. Both helpers are overridden to `true` by `CTSolversADNLPModels`.

### Removed direct imports

- `src/DOCP/DOCP.jl`, `src/Optimization/Optimization.jl`, `src/Solvers/Solvers.jl`: removed `using NLPModels`
- `src/Modelers/Modelers.jl`: removed `ADNLPModels`, `ExaModels`, `KernelAbstractions`
- `src/Solvers/common_solve_api.jl`: mid-level `solve` stub is now untyped on the `nlp` argument
- `src/DOCP/building.jl`: removed `::NLPModels.AbstractNLPModel` return annotation from `nlp_model`

---

## Tests

Three modeler test files (`test_coverage_modelers.jl`, `test_enhanced_options.jl`, `test_exa_gpu.jl`) previously relied on `ExaModels` being loaded transitively by another test in the same session. Explicit `using ExaModels` (and `KernelAbstractions`) imports added to make them self-contained.

**All 2445 tests pass.**