### PR TITLE
docs: migrate to VitePress and overhaul documentation

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+build/
+node_modules/
+package-lock.json
+Manifest.toml

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,12 +1,16 @@
 [deps]
 CTBase = "54762871-cc72-4466-b8e8-f6c8b58076cd"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-DocumenterMermaid = "a078cd44-4d9c-4618-b545-3ab9d77f9177"
+DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
+DocumenterVitepress = "4710194d-e776-4893-9690-8d956a29c365"
+LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 MarkdownAST = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
 
 [compat]
 CTBase = "0.26"
 Documenter = "1"
-DocumenterMermaid = "0.2"
+DocumenterInterLinks = "1"
+DocumenterVitepress = "0.3"
+LiveServer = "1"
 MarkdownAST = "0.1"
 julia = "1.10"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,6 +5,7 @@ DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 DocumenterVitepress = "4710194d-e776-4893-9690-8d956a29c365"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 MarkdownAST = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
+NLPModelsIpopt = "f4238b75-b362-5c4c-b852-0801c9a21d71"
 
 [compat]
 CTBase = "0.26"
@@ -13,4 +14,5 @@ DocumenterInterLinks = "1"
 DocumenterVitepress = "0.3"
 LiveServer = "1"
 MarkdownAST = "0.1"
+NLPModelsIpopt = "0.10"
 julia = "1.10"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # docs/
 
-Documentation site for CTBase.jl, built with
+Documentation site for CTSolvers.jl, built with
 [DocumenterVitepress](https://github.com/LuxDL/DocumenterVitepress.jl).
 
 Build (from the package root):

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,34 @@
+# docs/
+
+Documentation site for CTBase.jl, built with
+[DocumenterVitepress](https://github.com/LuxDL/DocumenterVitepress.jl).
+
+Build (from the package root):
+
+```bash
+julia --project=. docs/make.jl
+```
+
+Preview after build: `npx serve docs/build/1 --listen 5173`
+
+Documentation conventions and build workflow:
+[control-toolbox Handbook](https://github.com/control-toolbox/Handbook).
+
+## `@repl` vs `@example` — ANSI color rule
+
+DocumenterVitepress processes code block output differently depending on how it is produced:
+
+| Block type | Output fence | ANSI codes | Result |
+| --- | --- | --- | --- |
+| `@example` | ` ```ansi ` | processed by Shiki | **colors render correctly** |
+| `@repl` | ` ```julia ` | parsed as Julia syntax | **raw escape sequences — ugly** |
+
+**Rules:**
+
+- Use **`@example`** when the output comes from a `show` method that uses ANSI colors
+  (strategy instances, `StrategyOptions`, `StrategyMetadata`, `StrategyRegistry`, …).
+- Use **`@repl`** only when the output is a plain scalar value with no custom colored `show`
+  (integers, booleans, symbols, plain strings, tuples of symbols, types).
+- Use **`@repl` + `try/catch # hide` + `showerror(IOContext(stdout, :color => false), e) # hide`**
+  to display exceptions — the `showerror` call produces plain text that renders cleanly inside a
+  `julia`-fenced block.

--- a/docs/api_reference.jl
+++ b/docs/api_reference.jl
@@ -58,6 +58,7 @@ function generate_api_reference(src_dir::String, ext_dir::String)
                 joinpath("Optimization", "Optimization.jl"),
                 joinpath("Optimization", "abstract_types.jl"),
                 joinpath("Optimization", "built_model.jl"),
+                joinpath("Optimization", "building.jl"),
             ),
         ),
         (

--- a/docs/api_reference.jl
+++ b/docs/api_reference.jl
@@ -1,11 +1,9 @@
 # ==============================================================================
-# CTSolvers API Reference Generator
-# ==============================================================================
+# CTSolvers API Reference Manager
 #
-# This file generates the API reference documentation for CTSolvers.
-# It uses CTBase.automatic_reference_documentation to scan source files
-# and generate documentation pages.
-#
+# One CTBase.automatic_reference_documentation call per documented page.
+# Keep the file lists in sync with src/<Submodule>/ and ext/ when files
+# are added, removed, or renamed.
 # ==============================================================================
 
 """
@@ -15,385 +13,137 @@ Generate the API reference documentation for CTSolvers.
 Returns the list of pages.
 """
 function generate_api_reference(src_dir::String, ext_dir::String)
-    # Helper to build absolute paths
     src(files...) = [abspath(joinpath(src_dir, f)) for f in files]
     ext(files...) = [abspath(joinpath(ext_dir, f)) for f in files]
 
-    # Symbols to exclude from documentation
     EXCLUDE_SYMBOLS = Symbol[:include, :eval]
+    EXCLUDE_INTERNALS = vcat(
+        EXCLUDE_SYMBOLS,
+        Symbol[:DOCTYPE_ABSTRACT_TYPE, :DOCTYPE_CONSTANT, :DOCTYPE_FUNCTION,
+               :DOCTYPE_MACRO, :DOCTYPE_MODULE, :DOCTYPE_STRUCT],
+    )
 
-    pages = [
-
-        # ───────────────────────────────────────────────────────────────────
-        # DOCP
-        # ───────────────────────────────────────────────────────────────────
-        CTBase.automatic_reference_documentation(;
-            subdirectory="api",
-            primary_modules=[
-                CTSolvers.DOCP => src(
-                    joinpath("DOCP", "DOCP.jl"),
-                    joinpath("DOCP", "abstract_discretizer.jl"),
-                    joinpath("DOCP", "discretized_model.jl"),
-                    joinpath("DOCP", "contract.jl"),
-                    joinpath("DOCP", "conveniences.jl"),
-                ),
-            ],
-            exclude=EXCLUDE_SYMBOLS,
-            public=true,
-            private=true,
+    # ── Shared config: one entry per submodule ────────────────────────────────
+    modules_config = [
+        (
+            mod=CTSolvers.DOCP,
             title="DOCP",
-            title_in_menu="DOCP",
             filename="docp",
+            files=src(
+                joinpath("DOCP", "DOCP.jl"),
+                joinpath("DOCP", "abstract_discretizer.jl"),
+                joinpath("DOCP", "discretized_model.jl"),
+                joinpath("DOCP", "contract.jl"),
+                joinpath("DOCP", "conveniences.jl"),
+            ),
         ),
-
-        # ───────────────────────────────────────────────────────────────────
-        # Modelers
-        # ───────────────────────────────────────────────────────────────────
-        CTBase.automatic_reference_documentation(;
-            subdirectory="api",
-            primary_modules=[
-                CTSolvers.Modelers => src(
-                    joinpath("Modelers", "Modelers.jl"),
-                    joinpath("Modelers", "abstract_modeler.jl"),
-                    joinpath("Modelers", "contract.jl"),
-                    joinpath("Modelers", "adnlp.jl"),
-                    joinpath("Modelers", "exa.jl"),
-                    joinpath("Modelers", "validation.jl"),
-                ),
-            ],
-            exclude=EXCLUDE_SYMBOLS,
-            public=true,
-            private=true,
+        (
+            mod=CTSolvers.Modelers,
             title="Modelers",
-            title_in_menu="Modelers",
             filename="modelers",
+            files=src(
+                joinpath("Modelers", "Modelers.jl"),
+                joinpath("Modelers", "abstract_modeler.jl"),
+                joinpath("Modelers", "contract.jl"),
+                joinpath("Modelers", "adnlp.jl"),
+                joinpath("Modelers", "exa.jl"),
+                joinpath("Modelers", "validation.jl"),
+            ),
         ),
-
-        # ───────────────────────────────────────────────────────────────────
-        # Optimization
-        # ───────────────────────────────────────────────────────────────────
-        CTBase.automatic_reference_documentation(;
-            subdirectory="api",
-            primary_modules=[
-                CTSolvers.Optimization => src(
-                    joinpath("Optimization", "Optimization.jl"),
-                    joinpath("Optimization", "abstract_types.jl"),
-                    joinpath("Optimization", "built_model.jl"),
-                ),
-            ],
-            exclude=EXCLUDE_SYMBOLS,
-            public=true,
-            private=true,
+        (
+            mod=CTSolvers.Optimization,
             title="Optimization",
-            title_in_menu="Optimization",
             filename="optimization",
+            files=src(
+                joinpath("Optimization", "Optimization.jl"),
+                joinpath("Optimization", "abstract_types.jl"),
+                joinpath("Optimization", "built_model.jl"),
+            ),
         ),
-
-        # ───────────────────────────────────────────────────────────────────
-        # Solvers
-        # ───────────────────────────────────────────────────────────────────
-        CTBase.automatic_reference_documentation(;
-            subdirectory="api",
-            primary_modules=[
-                CTSolvers.Solvers => src(
-                    joinpath("Solvers", "Solvers.jl"),
-                    joinpath("Solvers", "abstract_solver.jl"),
-                    joinpath("Solvers", "contract.jl"),
-                    joinpath("Solvers", "orchestration.jl"),
-                    joinpath("Solvers", "solver_info.jl"),
-                    joinpath("Solvers", "ipopt.jl"),
-                    joinpath("Solvers", "knitro.jl"),
-                    joinpath("Solvers", "madncl.jl"),
-                    joinpath("Solvers", "madnlp.jl"),
-                    joinpath("Solvers", "madnlpsuite.jl"),
-                    joinpath("Solvers", "uno.jl"),
-                ),
-            ],
-            exclude=EXCLUDE_SYMBOLS,
-            public=true,
-            private=true,
+        (
+            mod=CTSolvers.Solvers,
             title="Solvers",
-            title_in_menu="Solvers",
             filename="solvers",
+            files=src(
+                joinpath("Solvers", "Solvers.jl"),
+                joinpath("Solvers", "abstract_solver.jl"),
+                joinpath("Solvers", "contract.jl"),
+                joinpath("Solvers", "orchestration.jl"),
+                joinpath("Solvers", "solver_info.jl"),
+                joinpath("Solvers", "ipopt.jl"),
+                joinpath("Solvers", "knitro.jl"),
+                joinpath("Solvers", "madncl.jl"),
+                joinpath("Solvers", "madnlp.jl"),
+                joinpath("Solvers", "madnlpsuite.jl"),
+                joinpath("Solvers", "uno.jl"),
+            ),
         ),
-
-        # ───────────────────────────────────────────────────────────────────
-        # Integrators
-        # ───────────────────────────────────────────────────────────────────
-        CTBase.automatic_reference_documentation(;
-            subdirectory="api",
-            primary_modules=[
-                CTSolvers.Integrators => src(
-                    joinpath("Integrators", "Integrators.jl"),
-                    joinpath("Integrators", "abstract_integrator.jl"),
-                    joinpath("Integrators", "integration_result.jl"),
-                    joinpath("Integrators", "sciml.jl"),
-                    joinpath("Integrators", "contract.jl"),
-                    joinpath("Integrators", "conveniences.jl"),
-                    joinpath("Integrators", "internal_norm.jl"),
-                ),
-            ],
-            exclude=EXCLUDE_SYMBOLS,
-            public=true,
-            private=true,
+        (
+            mod=CTSolvers.Integrators,
             title="Integrators",
-            title_in_menu="Integrators",
             filename="integrators",
+            files=src(
+                joinpath("Integrators", "Integrators.jl"),
+                joinpath("Integrators", "abstract_integrator.jl"),
+                joinpath("Integrators", "integration_result.jl"),
+                joinpath("Integrators", "sciml.jl"),
+                joinpath("Integrators", "contract.jl"),
+                joinpath("Integrators", "conveniences.jl"),
+                joinpath("Integrators", "internal_norm.jl"),
+            ),
         ),
-
     ]
 
-    # ───────────────────────────────────────────────────────────────────
-    # Extension: Ipopt
-    # ───────────────────────────────────────────────────────────────────
-    CTSolversIpopt = Base.get_extension(CTSolvers, :CTSolversIpopt)
-    if !isnothing(CTSolversIpopt)
-        push!(
-            pages,
-            CTBase.automatic_reference_documentation(;
-                subdirectory="api",
-                primary_modules=[CTSolversIpopt => ext("CTSolversIpopt.jl")],
-                external_modules_to_document=[CTSolvers],
-                exclude=EXCLUDE_SYMBOLS,
-                public=true,
-                private=true,
-                title="Ipopt Extension",
-                title_in_menu="Ipopt",
-                filename="ext_ipopt",
-            ),
-        )
+    # ── Public pages: one flat page per submodule ─────────────────────────────
+    pages = [
+        CTBase.automatic_reference_documentation(;
+            subdirectory="api",
+            primary_modules=[cfg.mod => cfg.files],
+            external_modules_to_document=[CTSolvers],
+            exclude=EXCLUDE_SYMBOLS,
+            public=true,
+            private=false,
+            title=cfg.title,
+            title_in_menu=cfg.title,
+            filename=cfg.filename,
+        ) for cfg in modules_config
+    ]
+
+    # ── Internals: all private symbols in one page, sections by module ────────
+    internals_modules = Any[cfg.mod => cfg.files for cfg in modules_config]
+
+    for (sym, files) in [
+        (:CTSolversIpopt,              ext("CTSolversIpopt.jl")),
+        (:CTSolversMadNLP,             ext("CTSolversMadNLP.jl")),
+        (:CTSolversMadNCL,             ext("CTSolversMadNCL.jl")),
+        (:CTSolversKnitro,             ext("CTSolversKnitro.jl")),
+        (:CTSolversUno,                ext("CTSolversUno.jl")),
+        (:CTSolversEnzyme,             ext("CTSolversEnzyme.jl")),
+        (:CTSolversCUDA,               ext("CTSolversCUDA.jl")),
+        (:CTSolversMadNLPGPU,          ext("CTSolversMadNLPGPU.jl")),
+        (:CTSolversZygote,             ext("CTSolversZygote.jl")),
+        (:CTSolversSciMLIntegrator,    ext("CTSolversSciMLIntegrator.jl")),
+        (:CTSolversForwardDiff,        ext("CTSolversForwardDiff.jl")),
+        (:CTSolversOrdinaryDiffEqTsit5, ext("CTSolversOrdinaryDiffEqTsit5.jl")),
+    ]
+        extmod = Base.get_extension(CTSolvers, sym)
+        isnothing(extmod) || push!(internals_modules, extmod => files)
     end
 
-    # ───────────────────────────────────────────────────────────────────
-    # Extension: MadNLP
-    # ───────────────────────────────────────────────────────────────────
-    CTSolversMadNLP = Base.get_extension(CTSolvers, :CTSolversMadNLP)
-    if !isnothing(CTSolversMadNLP)
-        push!(
-            pages,
-            CTBase.automatic_reference_documentation(;
-                subdirectory="api",
-                primary_modules=[CTSolversMadNLP => ext("CTSolversMadNLP.jl")],
-                external_modules_to_document=[CTSolvers],
-                exclude=EXCLUDE_SYMBOLS,
-                public=true,
-                private=true,
-                title="MadNLP Extension",
-                title_in_menu="MadNLP",
-                filename="ext_madnlp",
-            ),
-        )
-    end
-
-    # ───────────────────────────────────────────────────────────────────
-    # Extension: MadNCL
-    # ───────────────────────────────────────────────────────────────────
-    CTSolversMadNCL = Base.get_extension(CTSolvers, :CTSolversMadNCL)
-    if !isnothing(CTSolversMadNCL)
-        push!(
-            pages,
-            CTBase.automatic_reference_documentation(;
-                subdirectory="api",
-                primary_modules=[CTSolversMadNCL => ext("CTSolversMadNCL.jl")],
-                external_modules_to_document=[CTSolvers],
-                exclude=EXCLUDE_SYMBOLS,
-                public=true,
-                private=true,
-                title="MadNCL Extension",
-                title_in_menu="MadNCL",
-                filename="ext_madncl",
-            ),
-        )
-    end
-
-    # ───────────────────────────────────────────────────────────────────
-    # Extension: Knitro
-    # ───────────────────────────────────────────────────────────────────
-    CTSolversKnitro = Base.get_extension(CTSolvers, :CTSolversKnitro)
-    if !isnothing(CTSolversKnitro)
-        push!(
-            pages,
-            CTBase.automatic_reference_documentation(;
-                subdirectory="api",
-                primary_modules=[CTSolversKnitro => ext("CTSolversKnitro.jl")],
-                external_modules_to_document=[CTSolvers],
-                exclude=EXCLUDE_SYMBOLS,
-                public=true,
-                private=true,
-                title="Knitro Extension",
-                title_in_menu="Knitro",
-                filename="ext_knitro",
-            ),
-        )
-    end
-
-    # ───────────────────────────────────────────────────────────────────
-    # Extension: Uno
-    # ─────────────────────────────────────────────────────────────────--
-    CTSolversUno = Base.get_extension(CTSolvers, :CTSolversUno)
-    if !isnothing(CTSolversUno)
-        push!(
-            pages,
-            CTBase.automatic_reference_documentation(;
-                subdirectory="api",
-                primary_modules=[CTSolversUno => ext("CTSolversUno.jl")],
-                external_modules_to_document=[CTSolvers],
-                exclude=EXCLUDE_SYMBOLS,
-                public=true,
-                private=true,
-                title="Uno Extension",
-                title_in_menu="Uno",
-                filename="ext_uno",
-            ),
-        )
-    end
-
-    # ───────────────────────────────────────────────────────────────────
-    # Extension: Enzyme
-    # ─────────────────────────────────────────────────────────────────--
-    CTSolversEnzyme = Base.get_extension(CTSolvers, :CTSolversEnzyme)
-    if !isnothing(CTSolversEnzyme)
-        push!(
-            pages,
-            CTBase.automatic_reference_documentation(;
-                subdirectory="api",
-                primary_modules=[CTSolversEnzyme => ext("CTSolversEnzyme.jl")],
-                external_modules_to_document=[CTSolvers],
-                exclude=EXCLUDE_SYMBOLS,
-                public=true,
-                private=true,
-                title="Enzyme Extension",
-                title_in_menu="Enzyme",
-                filename="ext_enzyme",
-            ),
-        )
-    end
-
-    # ───────────────────────────────────────────────────────────────────
-    # Extension: CUDA
-    # ─────────────────────────────────────────────────────────────────--
-    CTSolversCUDA = Base.get_extension(CTSolvers, :CTSolversCUDA)
-    if !isnothing(CTSolversCUDA)
-        push!(
-            pages,
-            CTBase.automatic_reference_documentation(;
-                subdirectory="api",
-                primary_modules=[CTSolversCUDA => ext("CTSolversCUDA.jl")],
-                external_modules_to_document=[CTSolvers],
-                exclude=EXCLUDE_SYMBOLS,
-                public=true,
-                private=true,
-                title="CUDA Extension",
-                title_in_menu="CUDA",
-                filename="ext_cuda",
-            ),
-        )
-    end
-
-    # ───────────────────────────────────────────────────────────────────
-    # Extension: MadNLPGPU
-    # ─────────────────────────────────────────────────────────────────--
-    CTSolversMadNLPGPU = Base.get_extension(CTSolvers, :CTSolversMadNLPGPU)
-    if !isnothing(CTSolversMadNLPGPU)
-        push!(
-            pages,
-            CTBase.automatic_reference_documentation(;
-                subdirectory="api",
-                primary_modules=[CTSolversMadNLPGPU => ext("CTSolversMadNLPGPU.jl")],
-                external_modules_to_document=[CTSolvers],
-                exclude=EXCLUDE_SYMBOLS,
-                public=true,
-                private=true,
-                title="MadNLPGPU Extension",
-                title_in_menu="MadNLPGPU",
-                filename="ext_madnlpgpu",
-            ),
-        )
-    end
-
-    # ─────────────────────────────────────────────────────────────────--
-    # Extension: Zygote
-    # ─────────────────────────────────────────────────────────────────--
-    CTSolversZygote = Base.get_extension(CTSolvers, :CTSolversZygote)
-    if !isnothing(CTSolversZygote)
-        push!(
-            pages,
-            CTBase.automatic_reference_documentation(;
-                subdirectory="api",
-                primary_modules=[CTSolversZygote => ext("CTSolversZygote.jl")],
-                external_modules_to_document=[CTSolvers],
-                exclude=EXCLUDE_SYMBOLS,
-                public=true,
-                private=true,
-                title="Zygote Extension",
-                title_in_menu="Zygote",
-                filename="ext_zygote",
-            ),
-        )
-    end
-
-    # ─────────────────────────────────────────────────────────────────--
-    # Extension: SciML Integrator
-    # ─────────────────────────────────────────────────────────────────--
-    CTSolversSciMLIntegrator = Base.get_extension(CTSolvers, :CTSolversSciMLIntegrator)
-    if !isnothing(CTSolversSciMLIntegrator)
-        push!(
-            pages,
-            CTBase.automatic_reference_documentation(;
-                subdirectory="api",
-                primary_modules=[CTSolversSciMLIntegrator => ext("CTSolversSciMLIntegrator.jl")],
-                external_modules_to_document=[CTSolvers],
-                exclude=EXCLUDE_SYMBOLS,
-                public=true,
-                private=true,
-                title="SciML Integrator Extension",
-                title_in_menu="SciML Integrator",
-                filename="ext_sciml_integrator",
-            ),
-        )
-    end
-
-    # ─────────────────────────────────────────────────────────────────--
-    # Extension: ForwardDiff
-    # ─────────────────────────────────────────────────────────────────--
-    CTSolversForwardDiff = Base.get_extension(CTSolvers, :CTSolversForwardDiff)
-    if !isnothing(CTSolversForwardDiff)
-        push!(
-            pages,
-            CTBase.automatic_reference_documentation(;
-                subdirectory="api",
-                primary_modules=[CTSolversForwardDiff => ext("CTSolversForwardDiff.jl")],
-                external_modules_to_document=[CTSolvers],
-                exclude=EXCLUDE_SYMBOLS,
-                public=true,
-                private=true,
-                title="ForwardDiff Extension",
-                title_in_menu="ForwardDiff",
-                filename="ext_forwarddiff",
-            ),
-        )
-    end
-
-    # ─────────────────────────────────────────────────────────────────--
-    # Extension: OrdinaryDiffEqTsit5
-    # ─────────────────────────────────────────────────────────────────--
-    CTSolversOrdinaryDiffEqTsit5 = Base.get_extension(CTSolvers, :CTSolversOrdinaryDiffEqTsit5)
-    if !isnothing(CTSolversOrdinaryDiffEqTsit5)
-        push!(
-            pages,
-            CTBase.automatic_reference_documentation(;
-                subdirectory="api",
-                primary_modules=[CTSolversOrdinaryDiffEqTsit5 => ext("CTSolversOrdinaryDiffEqTsit5.jl")],
-                external_modules_to_document=[CTSolvers],
-                exclude=EXCLUDE_SYMBOLS,
-                public=true,
-                private=true,
-                title="OrdinaryDiffEqTsit5 Extension",
-                title_in_menu="OrdinaryDiffEqTsit5",
-                filename="ext_ordinarydiffeqtsit5",
-            ),
-        )
-    end
+    push!(
+        pages,
+        CTBase.automatic_reference_documentation(;
+            subdirectory="api",
+            primary_modules=internals_modules,
+            external_modules_to_document=[CTSolvers],
+            exclude=EXCLUDE_INTERNALS,
+            public=false,
+            private=true,
+            title="Internals",
+            title_in_menu="Internals",
+            filename="internals",
+        ),
+    )
 
     return pages
 end
@@ -408,24 +158,19 @@ function with_api_reference(f::Function, src_dir::String, ext_dir::String)
     try
         f(pages)
     finally
-        # Clean up generated files
         docs_src = abspath(joinpath(@__DIR__, "src"))
-        _cleanup_pages(docs_src, pages)
-    end
-end
-
-function _cleanup_pages(docs_src::String, pages)
-    for p in pages
-        val = last(p)
-        if val isa AbstractString
-            fname = endswith(val, ".md") ? val : val * ".md"
-            full_path = joinpath(docs_src, fname)
-            if isfile(full_path)
-                rm(full_path)
-                println("Removed temporary API doc: $full_path")
+        function cleanup(pages)
+            for p in pages
+                content = last(p)
+                if content isa AbstractString
+                    fname = endswith(content, ".md") ? content : content * ".md"
+                    full_path = joinpath(docs_src, fname)
+                    isfile(full_path) && rm(full_path)
+                elseif content isa Vector
+                    cleanup(content)
+                end
             end
-        elseif val isa AbstractVector
-            _cleanup_pages(docs_src, val)
         end
+        cleanup(pages)
     end
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,15 @@
-# julia --project -e 'include("docs/make.jl")'
+# to run the documentation generation: julia --project=docs docs/make.jl
+# to serve the documentation (option 1 — handles clean URLs natively):
+#   npx serve docs/build/1 --listen 5173
+# to serve the documentation (option 2 — Julia only):
+#   julia --project=docs -e 'using LiveServer; LiveServer.serve(dir="docs/build/1", single_page=true)'
+# note: single_page=true is required so that reloading /getting-started serves the correct HTML
 pushfirst!(LOAD_PATH, joinpath(@__DIR__))
 pushfirst!(LOAD_PATH, joinpath(@__DIR__, ".."))
 
 using Documenter
-using DocumenterMermaid
+using DocumenterVitepress
+using DocumenterInterLinks
 using CTSolvers
 using CTBase
 using Markdown
@@ -12,10 +18,24 @@ using MarkdownAST: MarkdownAST
 # ═══════════════════════════════════════════════════════════════════════════════
 # Configuration
 # ═══════════════════════════════════════════════════════════════════════════════
-draft = false  # Draft mode: if true, @example blocks in markdown are not executed
+draft = false # Draft mode: if true, @example blocks in markdown are not executed
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Load extensions
+# Cross-package links (InterLinks)
+# ═══════════════════════════════════════════════════════════════════════════════
+links = InterLinks(
+    "CTBase" => (
+        "https://control-toolbox.org/CTBase.jl/dev/",
+        "https://control-toolbox.org/CTBase.jl/dev/objects.inv",
+    ),
+    "CTModels" => (
+        "https://control-toolbox.org/CTModels.jl/dev/",
+        "https://control-toolbox.org/CTModels.jl/dev/objects.inv",
+    ),
+)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Extensions
 # ═══════════════════════════════════════════════════════════════════════════════
 const DocumenterReference = Base.get_extension(CTBase, :DocumenterReference)
 
@@ -37,33 +57,39 @@ include("api_reference.jl")
 # Build documentation
 # ═══════════════════════════════════════════════════════════════════════════════
 with_api_reference(src_dir, ext_dir) do api_pages
-    makedocs(;
+    return makedocs(;
         draft=draft,
-        remotes=nothing, # Disable remote links. Needed for DocumenterReference
-        warnonly=true,
+        remotes=nothing,
+        warnonly=[:cross_references, :external_cross_references],
         sitename="CTSolvers.jl",
-        format=Documenter.HTML(;
-            repolink="https://" * repo_url,
-            prettyurls=false,
-            assets=[
-                asset("https://control-toolbox.org/assets/css/documentation.css"),
-                asset("https://control-toolbox.org/assets/js/documentation.js"),
-            ],
+        format=DocumenterVitepress.MarkdownVitepress(;
+            repo=repo_url, devbranch="main", devurl="dev", sidebar_drawer=true
         ),
         pages=[
-            "Introduction" => "index.md",
-            "Architecture" => "architecture.md",
+            # index.md is the VitePress root — not listed here
+            "Getting Started"  => "getting-started.md",
+            "Architecture"     => "architecture.md",
             "Developer Guides" => [
-                "Implementing a Solver" => "guides/implementing_a_solver.md",
-                "Implementing an Integrator" => "guides/implementing_an_integrator.md",
-                "Implementing a Modeler" => "guides/implementing_a_modeler.md",
+                "Implementing a Solver"                => "guides/implementing_a_solver.md",
+                "Implementing an Integrator"           => "guides/implementing_an_integrator.md",
+                "Implementing a Modeler"               => "guides/implementing_a_modeler.md",
                 "Implementing an Optimization Problem" => "guides/implementing_an_optimization_problem.md",
-                "Error Messages Reference" => "guides/error_messages.md",
+                "Error Messages Reference"             => "guides/error_messages.md",
             ],
-            "API Reference" => api_pages,
+            "API Reference"    => api_pages,
         ],
+        plugins=[links],
     )
 end
 
 # ═══════════════════════════════════════════════════════════════════════════════
-deploydocs(; repo=repo_url * ".git", devbranch="main")
+# Deploy documentation to GitHub Pages
+# ═══════════════════════════════════════════════════════════════════════════════
+bases_file = joinpath(@__DIR__, "build", "bases.txt")
+if isfile(bases_file)
+    DocumenterVitepress.deploydocs(;
+        repo=repo_url * ".git", devbranch="main", push_preview=true
+    )
+else
+    @info "Skipping deployment: no bases were built (prerelease with existing higher stable release)."
+end

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,20 @@
+{
+  "devDependencies": {
+    "@types/node": "^25.3.5",
+    "@types/markdown-it-footnote": "^3.0.4"
+  },
+  "scripts": {
+    "docs:dev": "vitepress dev build/.documenter",
+    "docs:build": "vitepress build build/.documenter",
+    "docs:preview": "vitepress preview build/.documenter"
+  },
+  "dependencies": {
+    "@nolebase/vitepress-plugin-enhanced-readabilities": "^2.18.2",
+    "@mdit/plugin-mathjax": "^0.26.1",
+    "@mdit/plugin-tex": "^0.24.1",
+    "markdown-it-footnote": "^4.0.0",
+    "markdown-it": "^14.1.0",
+    "vitepress": "^1.6.4",
+    "vitepress-plugin-tabs": "^0.8.0"
+  }
+}

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -1,0 +1,102 @@
+import { defineConfig } from 'vitepress'
+import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs'
+import { mathjaxPlugin } from './mathjax-plugin'
+import { juliaReplTransformer } from './julia-repl-transformer'
+import footnote from "markdown-it-footnote";
+import path from 'path'
+
+const mathjax = mathjaxPlugin()
+
+function getBaseRepository(base: string): string {
+  if (!base || base === '/') return '/';
+  const parts = base.split('/').filter(Boolean);
+  return parts.length > 0 ? `/${parts[0]}/` : '/';
+}
+
+const baseTemp = {
+  base: 'REPLACE_ME_DOCUMENTER_VITEPRESS',// TODO: replace this in makedocs!
+}
+
+const nav = [
+  { text: 'Home', link: '/index' },
+  { component: 'VersionPicker' }
+]
+
+// https://vitepress.dev/reference/site-config
+export default defineConfig({
+  base: 'REPLACE_ME_DOCUMENTER_VITEPRESS',// TODO: replace this in makedocs!
+  title: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
+  description: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
+  lastUpdated: true,
+  cleanUrls: true,
+  ignoreDeadLinks: true,
+  outDir: 'REPLACE_ME_DOCUMENTER_VITEPRESS', // This is required for MarkdownVitepress to work correctly...
+  head: [
+    ['link', { rel: 'icon', href: 'REPLACE_ME_DOCUMENTER_VITEPRESS_FAVICON' }],
+    ['link', { rel: 'stylesheet', href: 'https://control-toolbox.org/assets/css/vitepress-documentation.css' }],
+    ['script', {src: `${getBaseRepository(baseTemp.base)}versions.js`}],
+    ['script', {src: 'https://control-toolbox.org/assets/js/vitepress-documentation.js'}],
+    ['script', {src: `${baseTemp.base}siteinfo.js`}]
+  ],
+
+  markdown: {
+    codeTransformers: [juliaReplTransformer()],
+    config(md) {
+      md.use(tabsMarkdownPlugin);
+      md.use(footnote);
+      mathjax.markdownConfig(md);
+    },
+    theme: {
+      light: "github-light",
+      dark: "github-dark"
+    },
+  },
+  vite: {
+    plugins: [
+      mathjax.vitePlugin,
+    ],
+    define: {
+      __DEPLOY_ABSPATH__: JSON.stringify('REPLACE_ME_DOCUMENTER_VITEPRESS_DEPLOY_ABSPATH'),
+    },
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, '../components')
+      }
+    },
+    optimizeDeps: {
+      exclude: [
+        '@nolebase/vitepress-plugin-enhanced-readabilities/client',
+        'vitepress',
+        '@nolebase/ui',
+      ],
+    },
+    ssr: {
+      noExternal: [
+        // If there are other packages that need to be processed by Vite, you can add them here.
+        '@nolebase/vitepress-plugin-enhanced-readabilities',
+        '@nolebase/ui',
+      ],
+    },
+  },
+  themeConfig: {
+    outline: 'deep',
+    logo: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
+    search: {
+      provider: 'local',
+      options: {
+        detailedView: true
+      }
+    },
+    nav,
+    sidebar: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
+    sidebarDrawer: 'REPLACE_ME_DOCUMENTER_VITEPRESS_SIDEBAR_DRAWER',
+    editLink: 'REPLACE_ME_DOCUMENTER_VITEPRESS',
+    socialLinks: [
+      { icon: 'github', link: 'REPLACE_ME_DOCUMENTER_VITEPRESS' }
+    ],
+    footer: {
+      message: 'Made with <a href="https://luxdl.github.io/DocumenterVitepress.jl/dev/" target="_blank"><strong>DocumenterVitepress.jl</strong></a><br>',
+      copyright: `© Copyright ${new Date().getUTCFullYear()}.`
+    }
+  }
+})

--- a/docs/src/.vitepress/julia-repl-transformer.ts
+++ b/docs/src/.vitepress/julia-repl-transformer.ts
@@ -1,0 +1,54 @@
+import type { ShikiTransformer } from "shiki"
+
+type PromptKind = "julia" | "pkg" | null
+
+export function juliaReplTransformer(): ShikiTransformer {
+  let promptInfoByLine: Array<{ len: number; kind: PromptKind }> = []
+  let isJuliaBlock = false
+  const rules: Array<{ kind: PromptKind; re: RegExp }> = [
+    { kind: "julia", re: /^julia>/ },
+    { kind: "pkg", re: /^(\([^)]*\)\s*)?pkg>/ },  // handles (@v1.9) pkg>
+  ]
+
+  function classify(line: string): { len: number; kind: PromptKind } {
+    for (const r of rules) {
+      const m = line.match(r.re)
+      if (m) return { len: m[0].length, kind: r.kind }
+    }
+
+    return { len: 0, kind: null }
+  }
+
+  return {
+    name: "julia-repl-prompts",
+
+    preprocess(code, options) {
+      isJuliaBlock = options.lang === "julia"
+      return code
+    },
+
+    tokens(tokens) {
+      if (!isJuliaBlock) {
+        promptInfoByLine = []
+        return
+      }
+
+      promptInfoByLine = tokens.map((lineTokens) => {
+        const line = lineTokens.map((t) => t.content).join("")
+        return classify(line)
+      })
+    },
+
+    span(node, line, col) {
+      if (!isJuliaBlock) return
+
+      const info = promptInfoByLine[line - 1]
+      if (!info || !info.kind || info.len <= 0) return
+
+      if (col < info.len) {
+        this.addClassToHast(node, "repl-prompt")
+        this.addClassToHast(node, `repl-prompt-${info.kind}`)
+      }
+    },
+  }
+}

--- a/docs/src/.vitepress/mathjax-plugin.ts
+++ b/docs/src/.vitepress/mathjax-plugin.ts
@@ -1,0 +1,142 @@
+// adapter from https://github.com/orgs/vuepress-theme-hope/discussions/5178#discussioncomment-15642629
+// mathjax-plugin.ts
+// @ts-ignore
+import MathJax from '@mathjax/src'
+import type { Plugin as VitePlugin } from 'vite'
+import type MarkdownIt from 'markdown-it'
+import { tex as mdTex } from '@mdit/plugin-tex'
+
+const mathjaxStyleModuleID = 'virtual:mathjax-styles.css'
+
+interface MathJaxOptions {
+  font?: string
+}
+
+async function initializeMathJax(options: MathJaxOptions = {}) {
+  const font = options.font || 'mathjax-newcm'
+
+  const config: any = {
+    loader: {
+      load: [
+        'input/tex',
+        'output/svg',
+        '[tex]/boldsymbol',
+        '[tex]/braket',
+        '[tex]/mathtools',
+      ],
+      paths: { mathjax: '@mathjax/src/bundle' },
+    },
+    tex: {
+      tags: 'ams',
+      packages: {
+        '[+]': ['boldsymbol', 'braket', 'mathtools'],
+      },
+    },
+    output: {
+      font,
+      displayOverflow: 'linebreak',
+      mtextInheritFont: true,
+    },
+    svg: {
+      fontCache: 'none', // critical: avoids async font loading
+    },
+  }
+
+  await MathJax.init(config)
+  await MathJax.startup.document.outputJax.font.loadDynamicFiles()
+}
+
+export function mathjaxPlugin(options: MathJaxOptions = {}) {
+  let adaptor: any
+  let initialized = false
+
+  async function ensureInitialized() {
+    if (!initialized) {
+      await initializeMathJax(options)
+      adaptor = MathJax.startup.adaptor
+      initialized = true
+    }
+  }
+
+  function renderMath(content: string, displayMode: boolean): string {
+    if (!initialized) {
+      throw new Error('MathJax not initialized')
+    }
+
+    const node = MathJax.tex2svg(content, { display: displayMode })
+
+    // Prevent Vue from touching MathJax output
+    adaptor.setAttribute(node, 'v-pre', '')
+
+    let html = adaptor.outerHTML(node)
+
+    // Preserve spaces inside mjx-break (SVG only)
+    html = html.replace(
+      /<mjx-break(.*?)>(.*?)<\/mjx-break>/g,
+      (_: string, attr: string, inner: string) =>
+        `<mjx-break${attr}>${inner.replace(/ /g, '&nbsp;')}</mjx-break>`,
+    )
+
+    // Wrap only display equations (not inline math)
+    html = html.replace(
+      /(<mjx-container[^>]*display="true"[^>]*>)([\s\S]*?)(<\/mjx-container>)/,
+      '<div class="mjx-scroll-wrapper">$1$2$3</div>'
+    )
+
+    return html
+  }
+
+  function getMathJaxStyles(): string {
+    return initialized
+      ? adaptor.textContent(MathJax.svgStylesheet()) || ''
+      : ''
+  }
+
+  function resetMathJax(): void {
+    if (!initialized) return
+    MathJax.texReset()
+    MathJax.typesetClear()
+  }
+
+  function viteMathJax(): VitePlugin {
+    const virtualModuleID = '\0' + mathjaxStyleModuleID
+
+    return {
+      name: 'mathjax-styles',
+
+      resolveId(id) {
+        if (id === mathjaxStyleModuleID) {
+          return virtualModuleID
+        }
+      },
+
+      async load(id) {
+        if (id === virtualModuleID) {
+          await ensureInitialized()
+          return getMathJaxStyles()
+        }
+      },
+    }
+  }
+
+  function mdMathJax(md: MarkdownIt): void {
+    mdTex(md, {
+      render: renderMath,
+    })
+
+    const orig = md.render
+    md.render = function (...args) {
+      resetMathJax()
+      return orig.apply(this, args)
+    }
+  }
+
+  const init = ensureInitialized()
+
+  return {
+    vitePlugin: viteMathJax(),
+    markdownConfig: mdMathJax,
+    styleModuleID: mathjaxStyleModuleID,
+    init,
+  }
+}

--- a/docs/src/.vitepress/theme/docstrings.css
+++ b/docs/src/.vitepress/theme/docstrings.css
@@ -1,0 +1,51 @@
+.jldocstring.custom-block {
+    border: 1px solid var(--vp-c-gray-2);
+    color: var(--vp-c-text-1);
+    overflow: hidden;
+}
+
+.jldocstring.custom-block summary {
+    font-weight: 700;
+    cursor: pointer;
+    user-select: none;
+    margin: 0 0 8px;
+}
+.jldocstring.custom-block summary a {
+  pointer-events: none;
+  text-decoration: none;
+}
+
+.jldocstring.custom-block .source-link {
+  border: 1px solid var(--vp-c-gray-2);
+  border-radius: 4px;
+  text-decoration: none;
+  background-color: #414040;
+  float: right;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-5px);
+  transition: all 0.5s cubic-bezier(0.25, 0.1, 0.25, 1);
+}
+
+.jldocstring.custom-block .source-link a {
+  text-decoration: none;
+  color: #e5e5e5;
+}
+
+.jldocstring.custom-block .source-link a:hover {
+  text-decoration: underline;
+}
+
+.jldocstring.custom-block:hover .source-link {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+@media (max-width: 768px) {
+  .jldocstring.custom-block .source-link {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
+}

--- a/docs/src/.vitepress/theme/index.ts
+++ b/docs/src/.vitepress/theme/index.ts
@@ -1,0 +1,43 @@
+// .vitepress/theme/index.ts
+import { h } from 'vue'
+import DefaultTheme from 'vitepress/theme'
+import type { Theme as ThemeConfig } from 'vitepress'
+import 'virtual:mathjax-styles.css';
+
+import {
+  NolebaseEnhancedReadabilitiesMenu,
+  NolebaseEnhancedReadabilitiesScreenMenu,
+} from '@nolebase/vitepress-plugin-enhanced-readabilities/client'
+
+import VersionPicker from "@/VersionPicker.vue"
+import AuthorBadge from '@/AuthorBadge.vue'
+import Authors from '@/Authors.vue'
+import SidebarDrawerToggle from '@/SidebarDrawerToggle.vue'
+
+import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client'
+
+import '@nolebase/vitepress-plugin-enhanced-readabilities/client/style.css'
+import './style.css' // You could setup your own, or else a default will be copied.
+import './docstrings.css' // You could setup your own, or else a default will be copied.
+
+export const Theme: ThemeConfig = {
+  extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      'nav-bar-content-after': () => [
+        h(NolebaseEnhancedReadabilitiesMenu), // Enhanced Readabilities menu
+      ],
+      // A enhanced readabilities menu for narrower screens (usually smaller than iPad Mini)
+      'nav-screen-content-after': () => h(NolebaseEnhancedReadabilitiesScreenMenu),
+      // Sidebar drawer toggle button (to the left of search bar)
+      'nav-bar-content-before': () => h(SidebarDrawerToggle),
+    })
+  },
+  enhanceApp({ app, router, siteData }) {
+    enhanceAppWithTabs(app);
+    app.component('VersionPicker', VersionPicker);
+    app.component('AuthorBadge', AuthorBadge)
+    app.component('Authors', Authors)
+  }
+}
+export default Theme

--- a/docs/src/.vitepress/theme/style.css
+++ b/docs/src/.vitepress/theme/style.css
@@ -1,0 +1,323 @@
+/* Customize default theme styling by overriding CSS variables:
+https://github.com/vuejs/vitepress/blob/main/src/client/theme-default/styles/vars.css */
+/* Example */
+/* https://github.com/vuejs/vitepress/blob/main/template/.vitepress/theme/style.css */
+
+.VPHero .clip {
+  white-space: pre;
+  max-width: 600px;
+}
+
+/* Fonts */
+@font-face {
+  font-family: JuliaMono-Regular;
+  src: url("https://cdn.jsdelivr.net/gh/cormullion/juliamono/webfonts/JuliaMono-Regular.woff2");
+}
+
+:root {
+scroll-behavior: smooth;
+/* Typography */
+--vp-font-family-base: "Barlow", "Inter var experimental", "Inter var",
+  -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+  Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+
+/* Code Snippet font */
+--vp-font-family-mono: JuliaMono-Regular, monospace;
+}
+
+/* Disable contextual alternates (kind of like ligatures but different) in monospace, 
+ which turns `/>` to an up arrow and `|>` (the Julia pipe symbol) to an up arrow as well. */
+.mono-no-substitutions {
+font-family: "JuliaMono-Regular", monospace;
+font-feature-settings: "calt" off;
+}
+
+.mono-no-substitutions-alt {
+font-family: "JuliaMono-Regular", monospace;
+font-variant-ligatures: none;
+}
+
+pre, code {
+font-family: "JuliaMono-Regular", monospace;
+font-feature-settings: "calt" off;
+}
+
+/* Colors */
+:root {
+  --julia-blue: #4063D8;
+  --julia-purple: #9558B2;
+  --julia-red: #CB3C33;
+  --julia-green: #389826;
+
+  --vp-c-brand: #0087d7;
+  --vp-c-brand-1: #0890df;
+  --vp-c-brand-2: #0599ef;
+  --vp-c-brand-3: #0c9ff4;
+  --vp-c-brand-light: #0087d7;
+  --vp-c-brand-dark: #5fd7ff;
+  --vp-c-brand-dimm: #212425;
+
+  /* Greens */
+  --vp-dark-green: #155f3e; /* Main accent green */
+  --vp-dark-green-dark: #2b855c;
+  --vp-dark-green-light: #42d392;
+  --vp-dark-green-lighter: #35eb9a;
+    /* Complementary Colors */
+  --vp-dark-gray: #1e1e1e;
+  --vp-dark-gray-soft: #2a2a2a;
+  --vp-dark-gray-mute: #242424;
+  --vp-light-gray: #d1d5db;
+  --vp-tip-bg: rgb(254, 254, 254);
+
+  /* Text Colors */
+  --vp-dark-text: #e5e5e5; /* Primary text color */
+  --vp-dark-subtext: #c1c1c1; /* Subtle text */
+  --vp-source-text: #e5e5e5;
+  /* custom tip */
+  --vp-custom-block-tip-border: var(--vp-c-brand-light);
+  --vp-custom-block-tip-bg: var(--vp-tip-bg);
+}
+
+ /* Component: Button */
+:root {
+  --vp-button-brand-border: var(--vp-light-gray);
+  --vp-button-brand-bg: var(--vp-c-brand-light);
+  --vp-button-brand-hover-border: var(--vp-c-bg-alt);
+  --vp-button-brand-hover-bg: var(--julia-blue);
+}
+
+/* Component: Home */
+:root {
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: -webkit-linear-gradient(
+    120deg,
+    #9558B2 30%,
+    #CB3C33
+  );
+
+  --vp-home-hero-image-background-image: linear-gradient(
+    -145deg,
+    #9558b282 30%,
+    #3798269a 30%,
+    #cb3d33e3 
+  );
+  --vp-home-hero-image-filter: blur(40px);
+}
+
+/* Hero Section */
+:root.dark {
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: -webkit-linear-gradient(
+    120deg,
+    var(--julia-purple) 15%,
+    var(--vp-dark-green-light),
+    var(--vp-dark-green)
+
+  );
+  --vp-home-hero-image-background-image: linear-gradient(
+    -45deg,
+    var(--vp-dark-green) 30%,
+    var(--vp-dark-green-light),
+    var(--vp-dark-gray) 30%
+  );
+  --vp-home-hero-image-filter: blur(56px);
+}
+
+:root.dark {
+  /* custom tip */
+  --vp-custom-block-tip-border: var(--vp-dark-green-dark);
+  --vp-custom-block-tip-text: var(--vp-dark-subtext);
+  --vp-custom-block-tip-bg: var(--vp-dark-gray-mute);
+}
+
+/**
+ * Colors links
+ * -------------------------------------------------------------------------- */
+
+.dark {
+  --vp-c-brand: var(--vp-dark-green-light);
+  --vp-button-brand-border: var(--vp-dark-green-lighter);
+  --vp-button-brand-bg: var(--vp-dark-green);
+  --vp-c-brand-1: var(--vp-dark-green-light);
+  --vp-c-brand-2: var(--vp-dark-green-lighter);
+  --vp-c-brand-3: var(--vp-dark-green);
+}
+
+@media (min-width: 640px) {
+  :root {
+    --vp-home-hero-image-filter: blur(56px);
+  }
+}
+
+@media (min-width: 960px) {
+  :root {
+    --vp-home-hero-image-filter: blur(72px);
+  }
+}
+/* Component: MathJax */
+
+
+.mjx-scroll-wrapper {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  text-align: center;
+}
+
+mjx-container {
+  display: inline-block;
+  padding: 0.5rem 0;
+  margin: auto 2px -2px;
+  overflow: visible !important;  /* Override MathJax's overflow */
+  text-align: left;
+}
+
+mjx-container > svg {
+  display: inline-block;
+  height: auto;
+}
+
+mjx-container > svg[data-labels="true"] {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+/* @mdit/plugin-mathjax theming refs */
+
+mjx-container svg path {
+  fill: currentColor !important;
+  stroke: currentColor !important;
+}
+
+.MathJax_ref {
+  color: var(--vp-c-brand-1);
+}
+
+.MathJax_ref:hover {
+  color: var(--vp-c-brand-2);
+  cursor: pointer;
+}
+
+/* ===== Custom colors for input and output code blocks ===== */
+:root {
+  /* --vp-c-bg-input: #eef0f3; */
+  --vp-c-bg-output: #fbfbfb;
+  --vp-c-bg-output-outline: #e2e2e3;
+}
+
+.dark {
+  /* --vp-c-bg-input: #1a1a1a; */
+  --vp-c-bg-output: #1a1a1a;
+  --vp-c-bg-output-outline: #2e2e32;
+}
+
+/*
+.language-julia {
+  background-color: var(--vp-c-bg-input) !important;
+}
+*/
+
+.language- {
+  background-color: var(--vp-c-bg-output) !important;
+  outline: 1px solid var(--vp-c-bg-output-outline);
+}
+
+/* Julia REPL prompt syntax highlighting */
+/* prompt token behavior */
+.vp-doc .shiki .repl-prompt {
+  opacity: 1.0;
+  user-select: none;
+}
+
+:root:not(.dark) .vp-doc .shiki .repl-prompt-julia {
+  color: var(--vp-dark-green);
+}
+
+:root:not(.dark) .vp-doc .shiki .repl-prompt-pkg {
+  color: var(--vp-c-brand-light);
+}
+
+.dark .vp-doc .shiki .repl-prompt-julia {
+  color: var(--vp-dark-green-light);
+}
+
+.dark .vp-doc .shiki .repl-prompt-pkg {
+  color: var(--vp-c-brand-dark);
+}
+
+/* ===== Sidebar Drawer Toggle ===== */
+/* Smooth transitions for sidebar collapse/expand on desktop */
+@media (min-width: 960px) {
+  .VPSidebar {
+    transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1),
+                opacity 0.25s ease;
+  }
+
+  .VPContent.has-sidebar {
+    transition: padding-left 0.35s cubic-bezier(0.4, 0, 0.2, 1),
+                padding-right 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  /* Smooth transitions for navbar elements (needed for expand-back too) */
+  .VPNavBar.has-sidebar .content {
+    transition: padding-left 0.35s cubic-bezier(0.4, 0, 0.2, 1) !important;
+  }
+
+  .VPNavBar.has-sidebar .divider {
+    transition: padding-left 0.35s cubic-bezier(0.4, 0, 0.2, 1) !important;
+  }
+
+  .VPNavBar.has-sidebar .title {
+    transition: width 0.35s cubic-bezier(0.4, 0, 0.2, 1),
+                padding 0.35s cubic-bezier(0.4, 0, 0.2, 1),
+                opacity 0.25s ease !important;
+  }
+
+  /* Collapsed state: zero the sidebar width variable so all layout formulas
+     (VitePress defaults + Enhanced Readabilities plugin) adjust automatically */
+  html.sidebar-drawer-collapsed {
+    --vp-sidebar-width: 0px !important;
+  }
+
+  html.sidebar-drawer-collapsed .VPSidebar {
+    transform: translateX(-100%);
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  /* Original width mode only: let content fill space up to the aside */
+  html.sidebar-drawer-collapsed
+    body:not(.VPNolebaseEnhancedReadabilitiesLayoutSwitchFullWidth):not(.VPNolebaseEnhancedReadabilitiesLayoutSwitchSidebarWidthAdjustableOnly):not(.VPNolebaseEnhancedReadabilitiesLayoutSwitchBothWidthAdjustable)
+    .VPDoc.has-sidebar .container {
+    display: flex;
+    justify-content: center;
+    max-width: 992px;
+  }
+
+  html.sidebar-drawer-collapsed
+    body:not(.VPNolebaseEnhancedReadabilitiesLayoutSwitchFullWidth):not(.VPNolebaseEnhancedReadabilitiesLayoutSwitchSidebarWidthAdjustableOnly):not(.VPNolebaseEnhancedReadabilitiesLayoutSwitchBothWidthAdjustable)
+    .VPDoc.has-sidebar .content-container {
+    max-width: none;
+  }
+
+  /* Collapse the navbar title area (site logo + name) */
+  html.sidebar-drawer-collapsed .VPNavBar.has-sidebar .title,
+  html.sidebar-drawer-collapsed .VPNavBar.has-sidebar > .wrapper > .container > .title {
+    width: 0 !important;
+    overflow: hidden;
+    opacity: 0;
+    padding: 0 !important;
+    pointer-events: none;
+  }
+
+  /* Move drawer button closer to the edge */
+  html.sidebar-drawer-collapsed .VPNavBar.has-sidebar .content,
+  html.sidebar-drawer-collapsed .VPNavBar.has-sidebar > .wrapper > .container > .content {
+    padding-left: 8px !important;
+  }
+}

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -16,18 +16,19 @@ CTSolvers relies on **CTBase** for its generic infrastructure and adds CTSolvers
 
 | Module | Responsibility |
 |--------|---------------|
-| **CTBase.Options** | Configuration primitives: `OptionDefinition`, `OptionValue`, extraction, validation |
-| **CTBase.Strategies** | Strategy contract (`AbstractStrategy`), registry, metadata, options building |
-| **CTBase.Orchestration** | Multi-strategy option routing and disambiguation |
+| `CTBase.Options` | Configuration primitives: `OptionDefinition`, `OptionValue`, extraction, validation |
+| `CTBase.Strategies` | Strategy contract (`AbstractStrategy`), registry, metadata, options building |
+| `CTBase.Orchestration` | Multi-strategy option routing and disambiguation |
 
 ### CTSolvers-specific modules, loaded in dependency order
 
 | # | Module | Responsibility |
 |---|--------|---------------|
-| 1 | **Optimization** | Abstract optimization types (`AbstractOptimizationProblem`), builders, `build_model`/`build_solution` |
-| 2 | **Modelers** | NLP model backends: `Modelers.ADNLP`, `Modelers.Exa` |
-| 3 | **DOCP** | `DiscretizedModel` — bridges CTModels and CTSolvers |
-| 4 | **Solvers** | Solver integration: `Solvers.Ipopt`, `Solvers.MadNLP`, `Solvers.MadNCL`, `Solvers.Knitro`, CommonSolve API |
+| 1 | `Optimization` | Abstract optimization types (`AbstractOptimizationProblem`), builders, `build_model`/`build_solution` |
+| 2 | `Modelers` | NLP model backends: `Modelers.ADNLP`, `Modelers.Exa` |
+| 3 | `DOCP` | `DiscretizedModel` — bridges CTModels and CTSolvers |
+| 4 | `Solvers` | Solver integration: `Solvers.Ipopt`, `Solvers.MadNLP`, `Solvers.MadNCL`, `Solvers.Knitro`, CommonSolve API |
+| 5 | `Integrators` | ODE integration: `Integrators.SciML` — wraps the SciML stack |
 
 All access is **qualified** — neither CTBase nor CTSolvers export symbols at the top level:
 
@@ -36,7 +37,7 @@ using CTSolvers
 using CTBase
 
 # Correct: qualified access
-CTBase.Strategies.id(MyStrategy)
+CTBase.Strategies.id(CTSolvers.Solvers.Ipopt)
 CTBase.Options.OptionDefinition(name=:x, type=Int, default=1, description="...")
 
 # Wrong: not exported
@@ -47,151 +48,107 @@ id(MyStrategy)  # ERROR: UndefVarError
 
 ### Strategy Branch
 
-All configurable components (modelers, solvers) in CTSolvers are **strategies**. They share a common contract defined by `AbstractStrategy`.
+All configurable components (modelers, solvers, integrators) in CTSolvers are **strategies**.
+They share a common contract defined by `AbstractStrategy`:
 
-```mermaid
-classDiagram
-    direction TB
-    class AbstractStrategy {
-        <<abstract>>
-        id(::Type)::Symbol
-        metadata(::Type)::StrategyMetadata
-        options(instance)::StrategyOptions
-    }
-
-    AbstractStrategy <|-- AbstractNLPModeler
-    AbstractStrategy <|-- AbstractNLPSolver
-
-    class AbstractNLPModeler {
-        <<abstract>>
-        (modeler)(prob, x0) → NLP
-        (modeler)(prob, stats) → Solution
-    }
-    AbstractNLPModeler <|-- Modelers.ADNLP
-    AbstractNLPModeler <|-- Modelers.Exa
-
-    class AbstractNLPSolver {
-        <<abstract>>
-        (solver)(nlp; display) → Stats
-    }
-    AbstractNLPSolver <|-- Solvers.Ipopt
-    AbstractNLPSolver <|-- Solvers.MadNLP
-    AbstractNLPSolver <|-- Solvers.MadNCL
-    AbstractNLPSolver <|-- Solvers.Knitro
+```text
+AbstractStrategy
+├─ id(::Type)       → Symbol
+├─ metadata(::Type) → StrategyMetadata
+├─ options(inst)    → StrategyOptions
+│
+├─► AbstractNLPModeler
+│       ├─ (modeler)(prob, x0)    → NLP model
+│       ├─ (modeler)(prob, stats) → Solution
+│       ├─► Modelers.ADNLP
+│       └─► Modelers.Exa
+│
+├─► AbstractNLPSolver
+│       ├─ (solver)(nlp; display) → ExecutionStats
+│       ├─► Solvers.Ipopt
+│       ├─► Solvers.MadNLP
+│       ├─► Solvers.MadNCL
+│       ├─► Solvers.Knitro
+│       └─► Solvers.Uno
+│
+└─► AbstractIntegrator
+        ├─ solve(prob, integ) → AbstractIntegrationResult
+        └─► AbstractSciMLIntegrator
+                └─► Integrators.SciML
 ```
-
-- **`AbstractNLPModeler`** (in `Modelers`): converts problems into NLP models and back into solutions.
-- **`AbstractNLPSolver`** (in `Solvers`): solves NLP models via backend libraries.
 
 !!! note "External Strategy Families"
     Other packages in the control-toolbox ecosystem define additional strategy families:
-    - **`AbstractDiscretizer`** (in [CTDirect.jl](https://github.com/control-toolbox/CTDirect.jl)): discretizes continuous-time OCP into finite-dimensional problems (e.g., `Collocation`, `DirectShooting`).
-
-    These external strategies follow the same `AbstractStrategy` contract. See the Implementing a Strategy guide in CTBase.jl documentation for a complete tutorial.
+    **`AbstractDiscretizer`** (in [CTDirect.jl](https://github.com/control-toolbox/CTDirect.jl))
+    discretizes continuous-time OCP into finite-dimensional problems (e.g., `Collocation`, `DirectShooting`).
+    These external strategies follow the same `AbstractStrategy` contract.
+    See the Implementing a Strategy guide in CTBase.jl documentation for a complete tutorial.
 
 ### Optimization / Builder Branch
 
 The optimization module defines the **problem–builder** pattern: problems provide builders, modelers use them.
 
-```mermaid
-classDiagram
-    direction TB
-    class AbstractOptimizationProblem {
-        <<abstract>>
-        get_adnlp_model_builder()
-        get_exa_model_builder()
-        get_adnlp_solution_builder()
-        get_exa_solution_builder()
-    }
-    AbstractOptimizationProblem <|-- DiscretizedModel
+```text
+AbstractOptimizationProblem
+├─ get_adnlp_model_builder(prob)     → AbstractModelBuilder
+├─ get_exa_model_builder(prob)       → AbstractModelBuilder
+├─ get_adnlp_solution_builder(prob)  → AbstractSolutionBuilder
+├─ get_exa_solution_builder(prob)    → AbstractSolutionBuilder
+└─► DiscretizedModel  (concrete implementation, in DOCP)
 
-    class AbstractBuilder {
-        <<abstract>>
-    }
-    AbstractBuilder <|-- AbstractModelBuilder
-    AbstractBuilder <|-- AbstractSolutionBuilder
-
-    class AbstractModelBuilder {
-        <<abstract>>
-        (builder)(x0; kwargs...) → NLP
-    }
-    AbstractModelBuilder <|-- ADNLPModelBuilder
-    AbstractModelBuilder <|-- ExaModelBuilder
-
-    class AbstractSolutionBuilder {
-        <<abstract>>
-    }
-    AbstractSolutionBuilder <|-- AbstractOCPSolutionBuilder
-    AbstractOCPSolutionBuilder <|-- ADNLPSolutionBuilder
-    AbstractOCPSolutionBuilder <|-- ExaSolutionBuilder
+AbstractBuilder
+├─► AbstractModelBuilder
+│       ├─ (builder)(x0; kwargs...) → NLP
+│       ├─► ADNLPModelBuilder
+│       └─► ExaModelBuilder
+└─► AbstractSolutionBuilder
+        └─► AbstractOCPSolutionBuilder
+                ├─► ADNLPSolutionBuilder
+                └─► ExaSolutionBuilder
 ```
-
-- **`AbstractOptimizationProblem`**: any problem that can provide builders for NLP model construction and solution conversion.
-- **`AbstractModelBuilder`**: callable that constructs an NLP model (ADNLPModel or ExaModel).
-- **`AbstractSolutionBuilder`**: callable that converts NLP solver results into problem-specific solutions.
-- **`DiscretizedModel`** (in `DOCP`): the concrete implementation that bridges CTModels OCP with CTSolvers builders.
 
 ## Module Dependencies
 
-```mermaid
-flowchart LR
-    subgraph CTBase
-        Options --> Strategies
-        Strategies --> Orchestration
-    end
-    Strategies --> Optimization
-    Strategies --> Modelers
-    Strategies --> Solvers
-    Options --> Modelers
-    Options --> Solvers
-    Optimization --> Modelers
-    Optimization --> DOCP
-    Optimization --> Solvers
-    Modelers --> Solvers
+The loading order is strict and acyclic:
+
+```text
+CTBase: Options → Strategies → Orchestration
+                                    │
+                         ┌──────────┴──────────┐
+                         ▼                     ▼
+                    Optimization           Integrators
+                         │
+               ┌─────────┼─────────┐
+               ▼         ▼         ▼
+           Modelers     DOCP     Solvers
 ```
 
-The loading order is: CTBase loads Options → Strategies → Orchestration first; then CTSolvers loads:
-
-```
-Optimization → Modelers → DOCP → Solvers
-```
-
-Each module only depends on modules loaded before it. This strict ordering ensures:
-- No circular dependencies
-- Types are available when needed
-- Extensions can target specific modules
+Each module only depends on modules loaded before it. This strict ordering ensures
+no circular dependencies and makes extensions straightforward to reason about.
 
 ## Data Flow
 
-The complete resolution pipeline transforms an optimal control problem into a solution through a sequence of well-defined steps:
+The complete resolution pipeline, from user call to optimal control solution:
 
-```mermaid
-sequenceDiagram
-    participant User
-    participant Solve as CommonSolve.solve
-    participant Modeler as AbstractNLPModeler
-    participant Problem as AbstractOptimizationProblem
-    participant Builder as AbstractModelBuilder
-    participant Solver as AbstractNLPSolver
-    participant SolBuilder as AbstractSolutionBuilder
-
-    User->>Solve: solve(problem, x0, modeler, solver)
-    Solve->>Modeler: build_model(problem, x0, modeler)
-    Modeler->>Problem: get_adnlp_model_builder(problem)
-    Problem-->>Modeler: ADNLPModelBuilder
-    Modeler->>Builder: builder(x0; options...)
-    Builder-->>Modeler: NLP model
-    Modeler-->>Solve: NLP model
-    Solve->>Solver: solve(nlp, solver)
-    Solver->>Solver: solver(nlp; display)
-    Solver-->>Solve: ExecutionStats
-    Solve->>Modeler: build_solution(problem, stats, modeler)
-    Modeler->>Problem: get_adnlp_solution_builder(problem)
-    Problem-->>Modeler: ADNLPSolutionBuilder
-    Modeler->>SolBuilder: builder(stats)
-    SolBuilder-->>Modeler: OCP Solution
-    Modeler-->>Solve: OCP Solution
-    Solve-->>User: OCP Solution
+```text
+User
+ │
+ ▼  solve(docp, x0, modeler, solver)
+CommonSolve.solve
+ │
+ ├─► build_model(docp, x0, modeler)
+ │       │
+ │       ├─► get_adnlp_model_builder(docp)  →  ADNLPModelBuilder
+ │       └─► builder(x0; options...)        →  ADNLPModel (NLP)
+ │
+ ├─► solve(nlp, solver)
+ │       │
+ │       └─► solver(nlp; display)           →  ExecutionStats
+ │
+ └─► build_solution(docp, stats, modeler)
+         │
+         ├─► get_adnlp_solution_builder(docp)  →  ADNLPSolutionBuilder
+         └─► builder(stats)                    →  OCP Solution
 ```
 
 The three levels of `CommonSolve.solve`:
@@ -208,55 +165,42 @@ The three levels of `CommonSolve.solve`:
 
 Every strategy implements a **two-level contract** separating static metadata from dynamic configuration:
 
-```mermaid
-flowchart TB
-    subgraph TypeLevel["Type-Level (static)"]
-        id["id(::Type{<:MyStrategy}) → :my_id"]
-        meta["metadata(::Type{<:MyStrategy}) → StrategyMetadata"]
-    end
-
-    subgraph InstanceLevel["Instance-Level (dynamic)"]
-        opts["options(strategy) → StrategyOptions"]
-    end
-
-    TypeLevel -->|"introspection without instantiation"| Registry["Registry & Routing"]
-    TypeLevel -->|"validation before construction"| Constructor["Constructor"]
-    Constructor --> InstanceLevel
-    InstanceLevel -->|"configured state"| Execution["Execution"]
+```text
+Type-Level (static, called on the type itself)
+├─ id(::Type{MyStrategy})       → :my_strategy  (unique symbol identifier)
+└─ metadata(::Type{MyStrategy}) → StrategyMetadata (option definitions, defaults)
+        │
+        ▼  used for: introspection, routing, validation before construction
+Constructor
+        │
+        ▼
+Instance-Level (dynamic, called on a constructed instance)
+└─ options(strategy)            → StrategyOptions (actual values with provenance)
+        │
+        ▼  used for: backend call, options_dict extraction
+Execution
 ```
 
-- **Type-level methods** (`id`, `metadata`) are called on the **type** — they enable introspection, routing, and validation without creating objects.
-- **Instance-level methods** (`options`) are called on **instances** — they provide the actual configuration with provenance tracking.
+- **Type-level methods** (`id`, `metadata`) are called on the **type** — they enable
+  introspection, routing, and validation without creating objects.
+- **Instance-level methods** (`options`) are called on **instances** — they provide
+  the actual configuration with provenance tracking.
 
 See the Implementing a Strategy guide in CTBase.jl documentation for a step-by-step tutorial.
 
 ### Strategy Parameters (Overview)
 
-Strategies can be **parameterized** to specialize behavior based on execution context (e.g., CPU vs GPU):
+Strategies can be **parameterized** to specialize behavior based on execution context
+(e.g., CPU vs GPU). Parameters are singleton types enabling compile-time dispatch:
 
-```mermaid
-flowchart TB
-    subgraph Parameters["Strategy Parameters"]
-        CPU["CPU <: AbstractStrategyParameter"]
-        GPU["GPU <: AbstractStrategyParameter"]
-    end
-    
-    subgraph Metadata["Parameterized Metadata"]
-        MetaCPU["metadata(Solvers.MadNLP, CPU) → CPU defaults"]
-        MetaGPU["metadata(Solvers.MadNLP, GPU) → GPU defaults"]
-    end
-    
-    CPU --> MetaCPU
-    GPU --> MetaGPU
-    MetaCPU --> InstanceCPU["MadNLP(CPU; max_iter=1000)"]
-    MetaGPU --> InstanceGPU["MadNLP(GPU; max_iter=1000)"]
+```text
+AbstractStrategyParameter
+├─► CPU  (singleton type)
+└─► GPU  (singleton type)
+
+metadata(Solvers.MadNLP, CPU)  →  CPU defaults  →  MadNLP(CPU; max_iter=1000)
+metadata(Solvers.MadNLP, GPU)  →  GPU defaults  →  MadNLP(GPU; max_iter=1000)
 ```
-
-**Key features:**
-
-- **Singleton types** for compile-time dispatch
-- **Specialized defaults** per parameter (e.g., different linear solvers for CPU/GPU)
-- **Type-based metadata** via `metadata(::Type{<:Strategy}, ::Type{<:Parameter})`
 
 See the Strategy Parameters guide in CTBase.jl documentation for a complete guide.
 
@@ -273,40 +217,38 @@ julia> CTBase.Strategies.id(IncompleteStrategy)
 #   Suggestion: Implement id(::Type{<:IncompleteStrategy}) to return a unique Symbol identifier
 ```
 
-This pattern ensures that:
-- Missing implementations are detected immediately with clear guidance
-- Error messages tell the developer exactly what to implement
-- No silent failures or incorrect defaults
+This pattern ensures that missing implementations are detected immediately with clear guidance —
+no silent failures or incorrect defaults.
 
 ### Tag Dispatch
 
-Solvers use **Tag Dispatch** to separate type definitions (in `src/Solvers/`) from backend implementations (in `ext/`):
+Solvers (and integrators) use **Tag Dispatch** to separate type definitions (in `src/Solvers/`)
+from backend implementations (in `ext/`):
 
-```mermaid
-flowchart LR
-    subgraph src["src/Solvers/"]
-        SolverType["Solvers.Ipopt <: AbstractNLPSolver"]
-        Tag["IpoptTag <: AbstractTag"]
-        Callable["(solver)(nlp) → _solve(IpoptTag(), nlp, opts)"]
-    end
-
-    subgraph ext["ext/CTSolversIpopt/"]
-        Impl["_solve(::IpoptTag, nlp, opts) → ipopt(nlp; opts...)"]
-    end
-
-    Callable -->|"dispatch on tag type"| Impl
+```text
+src/Solvers/ipopt.jl                    ext/CTSolversIpopt.jl
+─────────────────────                   ─────────────────────
+Solvers.Ipopt <: AbstractNLPSolver      metadata(::Type{<:Solvers.Ipopt})
+IpoptTag      <: AbstractTag              → StrategyMetadata(option defs...)
+                                        build_ipopt_solver(::IpoptTag; kwargs...)
+Solvers.Ipopt(; kwargs...)                → Solvers.Ipopt(validated_opts)
+  → build_ipopt_solver(IpoptTag(); …)   (solver::Solvers.Ipopt)(nlp; display)
+                                          → ipopt(nlp; opts...)
+build_ipopt_solver(::AbstractTag; …)
+  → ExtensionError(:NLPModelsIpopt)
 ```
 
-- **`src/Solvers/`**: defines the solver type, its options, and a callable that dispatches on a tag.
-- **`ext/CTSolversXxx/`**: implements the actual backend call, loaded only when the backend package is available.
-- This keeps CTSolvers lightweight — backend dependencies are optional.
+- **`src/Solvers/`**: defines the solver type, its id, and a constructor that dispatches on a tag.
+- **`ext/CTSolversXxx/`**: implements metadata, the real constructor, and the callable.
+  Loaded only when the backend package is available.
+- This keeps CTSolvers lightweight — backend dependencies are optional weak deps.
 
 ### Qualified Access
 
 CTSolvers does **not** export symbols at the top level. All access goes through qualified module paths:
 
 ```julia
-CTBase.Strategies.id(MyStrategy)
+CTBase.Strategies.id(CTSolvers.Solvers.Ipopt)
 CTBase.Options.OptionDefinition(...)
 CTSolvers.Optimization.build_model(problem, x0, modeler)
 ```

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -4,44 +4,34 @@
 CurrentModule = CTSolvers
 ```
 
-CTSolvers is the **resolution layer** of the [control-toolbox](https://github.com/control-toolbox) ecosystem. It transforms optimal control problems (defined in [CTModels.jl](https://github.com/control-toolbox/CTModels.jl)) into NLP models, solves them, and converts the results back into optimal control solutions.
+CTSolvers provides the **resolution infrastructure** of the [control-toolbox](https://github.com/control-toolbox) ecosystem — solvers, modelers, integrators, and abstract problem types — consumed by [CTDirect.jl](https://github.com/control-toolbox/CTDirect.jl) (direct methods) and [CTFlows.jl](https://github.com/control-toolbox/CTFlows.jl) (flows for indirect methods).
 
 This page provides the complete architectural overview. Read it before diving into any specific guide.
 
 ## Module Overview
 
-CTSolvers relies on **CTBase** for its generic infrastructure and adds CTSolvers-specific modules:
-
-### Generic infrastructure (provided by CTBase)
-
-| Module | Responsibility |
-|--------|---------------|
-| `CTBase.Options` | Configuration primitives: `OptionDefinition`, `OptionValue`, extraction, validation |
-| `CTBase.Strategies` | Strategy contract (`AbstractStrategy`), registry, metadata, options building |
-| `CTBase.Orchestration` | Multi-strategy option routing and disambiguation |
-
-### CTSolvers-specific modules, loaded in dependency order
+CTSolvers modules, loaded in dependency order:
 
 | # | Module | Responsibility |
 |---|--------|---------------|
-| 1 | `Optimization` | Abstract optimization types (`AbstractOptimizationProblem`), builders, `build_model`/`build_solution` |
-| 2 | `Modelers` | NLP model backends: `Modelers.ADNLP`, `Modelers.Exa` |
-| 3 | `DOCP` | `DiscretizedModel` — bridges CTModels and CTSolvers |
-| 4 | `Solvers` | Solver integration: `Solvers.Ipopt`, `Solvers.MadNLP`, `Solvers.MadNCL`, `Solvers.Knitro`, CommonSolve API |
-| 5 | `Integrators` | ODE integration: `Integrators.SciML` — wraps the SciML stack |
+| 1 | `Optimization` | Abstract problem types (`AbstractOptimizationProblem`), `BuiltModel`/`NoCache`, `build_model`/`build_solution` |
+| 2 | `Modelers` | NLP backend adapters: `Modelers.ADNLP`, `Modelers.Exa` |
+| 3 | `DOCP` | `DiscretizedModel` — pairs an OCP with its discretizer (provided by CTDirect) |
+| 4 | `Solvers` | NLP solver wrappers: `Solvers.Ipopt`, `Solvers.MadNLP`, `Solvers.MadNCL`, `Solvers.Knitro`, `Solvers.Uno` |
+| 5 | `Integrators` | ODE integrator wrapper: `Integrators.SciML` |
 
-All access is **qualified** — neither CTBase nor CTSolvers export symbols at the top level:
+CTSolvers relies on **CTBase** for its generic infrastructure (`CTBase.Options`, `CTBase.Strategies`, `CTBase.Orchestration`). See the [CTBase documentation](https://control-toolbox.org/CTBase.jl/dev/) for details on the strategy contract, option system, and orchestration.
+
+All access is **qualified** — CTSolvers does not export symbols at the top level:
 
 ```julia
 using CTSolvers
-using CTBase
 
-# Correct: qualified access
-CTBase.Strategies.id(CTSolvers.Solvers.Ipopt)
-CTBase.Options.OptionDefinition(name=:x, type=Int, default=1, description="...")
+CTSolvers.Solvers.Ipopt(max_iter = 1000)           # ✓ qualified
+CTBase.Strategies.id(CTSolvers.Solvers.Ipopt)      # ✓ qualified
+CTSolvers.Optimization.build_model(docp, x0, m)    # ✓ qualified
 
-# Wrong: not exported
-id(MyStrategy)  # ERROR: UndefVarError
+id(CTSolvers.Solvers.Ipopt)   # ERROR: UndefVarError — not exported
 ```
 
 ## Type Hierarchies
@@ -58,16 +48,16 @@ AbstractStrategy
 ├─ options(inst)    → StrategyOptions
 │
 ├─► AbstractNLPModeler
-│       ├─ (modeler)(prob, x0)    → NLP model
-│       ├─ (modeler)(prob, stats) → Solution
-│       ├─► Modelers.ADNLP
-│       └─► Modelers.Exa
+│       ├─ build_model(prob, x0, modeler)           → BuiltModel
+│       ├─ build_solution(built, stats, modeler)    → OCP Solution
+│       ├─► Modelers.ADNLP{P<:CPU}
+│       └─► Modelers.Exa{P<:Union{CPU,GPU}}
 │
 ├─► AbstractNLPSolver
-│       ├─ (solver)(nlp; display) → ExecutionStats
-│       ├─► Solvers.Ipopt
-│       ├─► Solvers.MadNLP
-│       ├─► Solvers.MadNCL
+│       ├─ solve(nlp, solver; display) → ExecutionStats
+│       ├─► Solvers.Ipopt{P<:CPU}
+│       ├─► Solvers.MadNLP{P<:Union{CPU,GPU}}
+│       ├─► Solvers.MadNCL{P<:Union{CPU,GPU}}
 │       ├─► Solvers.Knitro
 │       └─► Solvers.Uno
 │
@@ -84,27 +74,24 @@ AbstractStrategy
     These external strategies follow the same `AbstractStrategy` contract.
     See the Implementing a Strategy guide in CTBase.jl documentation for a complete tutorial.
 
-### Optimization / Builder Branch
+### Optimization Branch
 
-The optimization module defines the **problem–builder** pattern: problems provide builders, modelers use them.
+`AbstractOptimizationProblem` is a **marker type** with no required methods. The
+`build_model` / `build_solution` contract is satisfied by multiple dispatch: external
+packages (e.g. CTDirect) implement the typed methods for their own problem types.
 
 ```text
-AbstractOptimizationProblem
-├─ get_adnlp_model_builder(prob)     → AbstractModelBuilder
-├─ get_exa_model_builder(prob)       → AbstractModelBuilder
-├─ get_adnlp_solution_builder(prob)  → AbstractSolutionBuilder
-├─ get_exa_solution_builder(prob)    → AbstractSolutionBuilder
-└─► DiscretizedModel  (concrete implementation, in DOCP)
+AbstractOptimizationProblem                 (marker — no interface methods)
+└─► DiscretizedModel  (in DOCP module, concrete implementation from CTDirect)
 
-AbstractBuilder
-├─► AbstractModelBuilder
-│       ├─ (builder)(x0; kwargs...) → NLP
-│       ├─► ADNLPModelBuilder
-│       └─► ExaModelBuilder
-└─► AbstractSolutionBuilder
-        └─► AbstractOCPSolutionBuilder
-                ├─► ADNLPSolutionBuilder
-                └─► ExaSolutionBuilder
+build_model(prob, x0, modeler)    → BuiltModel   (generic stub; CTDirect provides typed methods)
+build_solution(built, stats, modeler) → Solution  (generic stub; CTDirect provides typed methods)
+
+BuiltModel{TP, TN, TC}                      (problem + NLP + cache, immutable)
+├─ .problem  → TP <: AbstractOptimizationProblem
+├─ .nlp      → TN  (backend NLP model, e.g. ADNLPModel)
+└─ .cache    → TC <: AbstractCache
+       └─► NoCache  (for backends needing no auxiliary storage)
 ```
 
 ## Module Dependencies
@@ -133,22 +120,17 @@ The complete resolution pipeline, from user call to optimal control solution:
 ```text
 User
  │
- ▼  solve(docp, x0, modeler, solver)
+ ▼  solve(docp, x0, modeler, solver)          ← orchestration.jl
 CommonSolve.solve
  │
- ├─► build_model(docp, x0, modeler)
- │       │
- │       ├─► get_adnlp_model_builder(docp)  →  ADNLPModelBuilder
- │       └─► builder(x0; options...)        →  ADNLPModel (NLP)
+ ├─► build_model(docp, x0, modeler)           →  BuiltModel
+ │       (CTDirect provides typed method for DiscretizedModel + modeler pair)
  │
- ├─► solve(nlp, solver)
- │       │
- │       └─► solver(nlp; display)           →  ExecutionStats
+ ├─► CommonSolve.solve(built.nlp, solver)     →  ExecutionStats
+ │       (backend extension provides typed method, e.g. CTSolversIpopt)
  │
- └─► build_solution(docp, stats, modeler)
-         │
-         ├─► get_adnlp_solution_builder(docp)  →  ADNLPSolutionBuilder
-         └─► builder(stats)                    →  OCP Solution
+ └─► build_solution(built, stats, modeler)    →  OCP Solution
+         (CTDirect provides typed method for DiscretizedModel + modeler pair)
 ```
 
 The three levels of `CommonSolve.solve`:
@@ -156,8 +138,7 @@ The three levels of `CommonSolve.solve`:
 | Level | Signature | Purpose |
 |-------|-----------|---------|
 | **High** | `solve(problem, x0, modeler, solver)` | Full pipeline: build NLP → solve → build solution |
-| **Mid** | `solve(nlp, solver)` | Solve an NLP model directly |
-| **Low** | `solve(any, solver)` | Flexible dispatch for custom types |
+| **Mid** | `CommonSolve.solve(nlp, solver; display)` | Solve an NLP directly; implemented by each backend extension |
 
 ## Architectural Patterns
 
@@ -198,9 +179,12 @@ AbstractStrategyParameter
 ├─► CPU  (singleton type)
 └─► GPU  (singleton type)
 
-metadata(Solvers.MadNLP, CPU)  →  CPU defaults  →  MadNLP(CPU; max_iter=1000)
-metadata(Solvers.MadNLP, GPU)  →  GPU defaults  →  MadNLP(GPU; max_iter=1000)
+metadata(Solvers.MadNLP{CPU})  →  CPU defaults  →  Solvers.MadNLP{CPU}(max_iter=1000)
+metadata(Solvers.MadNLP{GPU})  →  GPU defaults  →  Solvers.MadNLP{GPU}(max_iter=1000)
 ```
+
+The parameter is a **type parameter** of the strategy (`Solvers.MadNLP{P}`), not a separate
+argument. `Solvers.MadNLP(...)` resolves `P` from `_default_parameter` (here `CPU`).
 
 See the Strategy Parameters guide in CTBase.jl documentation for a complete guide.
 
@@ -223,25 +207,37 @@ no silent failures or incorrect defaults.
 ### Tag Dispatch
 
 Solvers (and integrators) use **Tag Dispatch** to separate type definitions (in `src/Solvers/`)
-from backend implementations (in `ext/`):
+from backend implementations (in `ext/`).
 
-```text
-src/Solvers/ipopt.jl                    ext/CTSolversIpopt.jl
-─────────────────────                   ─────────────────────
-Solvers.Ipopt <: AbstractNLPSolver      metadata(::Type{<:Solvers.Ipopt})
-IpoptTag      <: AbstractTag              → StrategyMetadata(option defs...)
-                                        build_ipopt_solver(::IpoptTag; kwargs...)
-Solvers.Ipopt(; kwargs...)                → Solvers.Ipopt(validated_opts)
-  → build_ipopt_solver(IpoptTag(); …)   (solver::Solvers.Ipopt)(nlp; display)
-                                          → ipopt(nlp; opts...)
-build_ipopt_solver(::AbstractTag; …)
-  → ExtensionError(:NLPModelsIpopt)
+**`src/Solvers/ipopt.jl`** — type definition and stubs (always loaded):
+
+```julia
+struct Ipopt{P<:CPU} <: AbstractNLPSolver
+    options::StrategyOptions
+end
+struct IpoptTag <: Core.AbstractTag end
+
+CTBase.Strategies.id(::Type{<:Solvers.Ipopt}) = :ipopt
+CTBase.Strategies._default_parameter(::Type{<:Solvers.Ipopt}) = CPU
+
+# Constructor chain: resolve P, then dispatch on the tag and parameter TYPES
+Solvers.Ipopt(; kwargs...) =
+    Solvers.Ipopt{CTBase.Strategies._default_parameter(Solvers.Ipopt)}(; kwargs...)
+Solvers.Ipopt{P}(; kwargs...) where {P<:CPU} = build_ipopt_solver(IpoptTag, P; kwargs...)
+build_ipopt_solver(::Type{<:Core.AbstractTag}, ::Type{<:AbstractStrategyParameter}; kwargs...) =
+    throw(ExtensionError(:NLPModelsIpopt))
 ```
 
-- **`src/Solvers/`**: defines the solver type, its id, and a constructor that dispatches on a tag.
-- **`ext/CTSolversXxx/`**: implements metadata, the real constructor, and the callable.
-  Loaded only when the backend package is available.
-- This keeps CTSolvers lightweight — backend dependencies are optional weak deps.
+**`ext/CTSolversIpopt.jl`** — real implementations (loaded only with `using NLPModelsIpopt`):
+
+```julia
+metadata(::Type{Solvers.Ipopt{P}}) where {P<:CPU} = StrategyMetadata(...)
+build_ipopt_solver(::Type{Solvers.IpoptTag}, P::Type{<:AbstractStrategyParameter}; kwargs...) =
+    Solvers.Ipopt{P}(validated_opts)
+CommonSolve.solve(nlp, solver::Solvers.Ipopt; display) = ipopt(nlp; options_dict(solver)...)
+```
+
+This keeps CTSolvers lightweight — backend dependencies are optional weak deps loaded on demand.
 
 ### Qualified Access
 
@@ -249,56 +245,7 @@ CTSolvers does **not** export symbols at the top level. All access goes through 
 
 ```julia
 CTBase.Strategies.id(CTSolvers.Solvers.Ipopt)
-CTBase.Options.OptionDefinition(...)
 CTSolvers.Optimization.build_model(problem, x0, modeler)
 ```
 
 This ensures namespace clarity, avoids conflicts with other packages, and makes dependencies explicit.
-
-## Conventions
-
-### Naming
-
-- **Types**: `PascalCase` — `StrategyOptions`, `ADNLPModelBuilder`
-- **Modules**: `PascalCase` — `Options`, `Strategies`, `Orchestration`
-- **Functions**: `snake_case` — `build_strategy_options`, `option_value`
-- **Strategy IDs**: `snake_case` symbols — `:collocation`, `:adnlp`, `:ipopt`
-- **Private defaults**: `__name()` pattern — `__grid_size()`, `__scheme()`
-
-### Constructor Pattern
-
-Every strategy constructor follows the same pattern:
-
-```julia
-function MyStrategy(; mode::Symbol = :strict, kwargs...)
-    opts = CTBase.Strategies.build_strategy_options(MyStrategy; mode = mode, kwargs...)
-    return MyStrategy(opts)
-end
-```
-
-- `mode = :strict` (default): rejects unknown options with Levenshtein suggestions.
-- `mode = :permissive`: accepts unknown options with a warning.
-
-### OptionDefinition Pattern
-
-Options are declared via `OptionDefinition` in the `metadata` method:
-
-```julia
-CTBase.Strategies.metadata(::Type{<:MyStrategy}) = CTBase.Strategies.StrategyMetadata(
-    CTBase.Options.OptionDefinition(
-        name = :max_iter,
-        type = Int,
-        default = 1000,
-        description = "Maximum number of iterations",
-    ),
-    CTBase.Options.OptionDefinition(
-        name = :tol,
-        type = Float64,
-        default = 1e-8,
-        description = "Convergence tolerance",
-        aliases = [:tolerance],
-    ),
-)
-```
-
-Each definition specifies: `name`, `type`, `default`, `description`, and optionally `aliases` and `validator`.

--- a/docs/src/components/AuthorBadge.vue
+++ b/docs/src/components/AuthorBadge.vue
@@ -1,0 +1,139 @@
+<template>
+  <a
+    v-if="link"
+    :href="link"
+    class="badge-link"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    <span class="badge-container">
+      <span class="badge-label">Author</span>
+      <span class="author-badge" :style="{ backgroundColor: getColor(author) }">
+        <img :src="getAvatarUrl" :alt="author" :class="{ 'platform-avatar': !props.avatar }" class="author-avatar">
+        {{ author }}
+      </span>
+    </span>
+  </a>
+  <span v-else class="badge-container">
+    <span class="badge-label">Author</span>
+    <span class="author-badge" :style="{ backgroundColor: getColor(author) }">
+      <img :src="getAvatarUrl"  :alt="author" :class="{ 'platform-avatar': !props.avatar }" class="author-avatar">
+      {{ author }}
+    </span>
+  </span>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  author: {
+    type: String,
+    required: true
+  },
+  avatar: {
+    type: String,
+    default: ''
+  },
+  platform: {
+    type: String,
+    default: 'user'
+  },
+  link: {
+    type: String,
+    default: ''
+  }
+})
+
+// Platform avatars mapping
+const platformAvatars = {
+  github: 'https://img.icons8.com/ios-filled/50/github.png',
+  gitlab: 'https://img.icons8.com/ios-filled/50/gitlab.png',
+  x: 'https://img.icons8.com/ios/50/twitterx--v2.png',
+  linkedin: 'https://img.icons8.com/ios-filled/50/linkedin.png',
+  bluesky: 'https://img.icons8.com/material-sharp/48/bluesky.png',
+  mastodon: 'https://img.icons8.com/windows/64/mastodon.png',
+  user: 'https://img.icons8.com/windows/64/user.png'
+}
+
+const getAvatarUrl = computed(() => {
+  // If custom avatar is provided, use it
+  if (props.avatar) {
+    return props.avatar
+  }
+  // If platform is specified, use platform avatar
+  if (props.platform && platformAvatars[props.platform.toLowerCase()]) {
+    return platformAvatars[props.platform.toLowerCase()]
+  }
+  // Default to user avatar
+  return platformAvatars.user
+})
+
+// Color function remains the same
+const getColor = (name) => {
+  const colors = [
+    '#3eaf7c', // green
+    '#476582', // blue
+    '#c53e3e', // red
+    '#986801', // orange
+    '#8957e5'  // purple
+  ]
+  const hash = name.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
+  return colors[hash % colors.length]
+}
+</script>
+
+<style scoped>
+.badge-container {
+  display: inline-flex;
+  height: 20px;
+  line-height: 24px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 5px;
+  margin-right: 0.5rem;
+  margin-bottom: 0.5rem;
+  overflow: hidden;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  vertical-align: middle;
+}
+
+.badge-label {
+  padding: 0 8px;
+  background-color: #555;
+  color: white;
+  display: flex;
+  align-items: center;
+}
+
+.author-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 8px;
+  color: white;
+}
+
+.author-avatar {
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  margin-right: 0.25rem;
+  margin-left: -0.25rem;
+}
+.platform-avatar {
+  filter: brightness(0) invert(1);
+}
+.badge-link {
+  text-decoration: none;
+  color: inherit;
+}
+
+.badge-link:hover .author-badge {
+  opacity: 0.9;
+}
+
+.badge-link:hover .badge-container {
+  box-shadow: 0 0 0 1.25px rgba(248, 248, 247, 0.4);
+  transition: all 0.2s ease;
+}
+</style>

--- a/docs/src/components/Authors.vue
+++ b/docs/src/components/Authors.vue
@@ -1,0 +1,28 @@
+<template>
+    <div class="authors-container">
+      <AuthorBadge
+        v-for="author in pageAuthors"
+        :key="author.name"
+        :author="author.name"
+        :avatar="author.avatar"
+        :platform="author.platform"
+        :link="author.link"
+      />
+    </div>
+  </template>
+  
+  <script setup>
+  import { useData } from 'vitepress'
+  
+  const { frontmatter } = useData()
+  const pageAuthors = frontmatter.value.authors || []
+  </script>
+  
+  <style scoped>
+  .authors-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 1rem 0;
+  }
+  </style>

--- a/docs/src/components/SidebarDrawerToggle.vue
+++ b/docs/src/components/SidebarDrawerToggle.vue
@@ -1,0 +1,110 @@
+<!--
+  SidebarDrawerToggle.vue
+  A toggle button that collapses/expands the VitePress sidebar on desktop.
+  Sits in the navbar to the left of the search bar.
+  Enabled via `sidebar_drawer = true` in MarkdownVitepress config.
+  Inspired by: https://www.codingnepalweb.com/sidebar-with-dark-light-themes-html-javascript/
+-->
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue'
+import { useData } from 'vitepress'
+
+const { theme, frontmatter } = useData()
+const enabled = computed(() => (theme.value as any).sidebarDrawer === true)
+const isHomePage = computed(() => frontmatter.value.layout === 'home')
+const shouldShow = computed(() => enabled.value && !isHomePage.value)
+const collapsed = ref(false)
+const STORAGE_KEY = 'dv-sidebar-collapsed'
+
+function toggleSidebar() {
+  collapsed.value = !collapsed.value
+  updateDOM()
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, String(collapsed.value))
+  }
+}
+
+function updateDOM() {
+  if (typeof document === 'undefined') return
+  document.documentElement.classList.toggle('sidebar-drawer-collapsed', collapsed.value)
+}
+
+onMounted(() => {
+  if (!enabled.value) return
+  const saved = localStorage.getItem(STORAGE_KEY)
+  if (saved === 'true') {
+    collapsed.value = true
+    updateDOM()
+  }
+})
+</script>
+
+<template>
+  <button
+    v-if="shouldShow"
+    class="sidebar-drawer-btn"
+    :class="{ 'is-collapsed': collapsed }"
+    @click="toggleSidebar"
+    :title="collapsed ? 'Show sidebar' : 'Hide sidebar'"
+    :aria-label="collapsed ? 'Show sidebar' : 'Hide sidebar'"
+  >
+    <!-- "panel left close/open" icon -->
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class="sidebar-drawer-icon"
+    >
+      <!-- Outer frame -->
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <!-- Vertical divider -->
+      <line x1="9" y1="3" x2="9" y2="21" />
+      <!-- Arrow (collapse/expand) -->
+      <polyline :points="collapsed ? '13 9 16 12 13 15' : '16 15 13 12 16 9'" />
+    </svg>
+  </button>
+</template>
+
+<style scoped>
+.sidebar-drawer-btn {
+  display: none; /* Hidden on mobile, shown on desktop */
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  margin-right: -8px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--vp-c-text-1);
+  cursor: pointer;
+  transition: color 0.25s, background-color 0.25s;
+}
+
+.sidebar-drawer-btn:hover {
+  color: var(--vp-c-text-2);
+  background: var(--vp-c-default-soft);
+}
+
+.sidebar-drawer-btn:active {
+  transform: scale(0.92);
+}
+
+.sidebar-drawer-icon {
+  display: block;
+}
+
+/* Only show on desktop (matches VitePress sidebar breakpoint) */
+@media (min-width: 960px) {
+  .sidebar-drawer-btn {
+    display: flex;
+  }
+}
+</style>

--- a/docs/src/components/VersionPicker.vue
+++ b/docs/src/components/VersionPicker.vue
@@ -1,0 +1,125 @@
+<!-- Adapted from https://github.com/MakieOrg/Makie.jl/blob/master/docs/src/.vitepress/theme/VersionPicker.vue -->
+
+<script setup lang="ts">
+import { ref, onMounted, computed} from 'vue'
+import { useData } from 'vitepress'
+import VPNavBarMenuGroup from 'vitepress/dist/client/theme-default/components/VPNavBarMenuGroup.vue'
+import VPNavScreenMenuGroup from 'vitepress/dist/client/theme-default/components/VPNavScreenMenuGroup.vue'
+
+declare global {
+  interface Window {
+    DOC_VERSIONS?: string[];
+    DOCUMENTER_CURRENT_VERSION?: string;
+  }
+}
+
+// from vitepress, MIT
+function joinPath(base: string, path: string) {
+  return `${base}${path}`.replace(/\/+/g, '/')
+}
+
+const absoluteRoot = __DEPLOY_ABSPATH__;
+const siteOrigin = (typeof window === 'undefined' ? '' : window.location.origin);
+
+function absoluteUrl(relative) {
+  const withRoot = joinPath(absoluteRoot, relative);
+  return siteOrigin + withRoot; // don't call `joinPath` on https:// part to not remove double slashes there
+}
+
+const props = defineProps<{ screenMenu?: boolean }>();
+const versions = ref<Array<{ text: string, link: string, class?: string }>>([]);
+const currentVersion = ref('Versions');
+const isClient = ref(false);
+const { site } = useData();
+
+const isLocalBuild = () => {
+  return typeof window !== 'undefined' && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
+};
+
+const waitForScriptsToLoad = () => {
+  return new Promise<boolean>((resolve) => {
+    if (isLocalBuild() || typeof window === 'undefined') {
+      resolve(false);
+      return;
+    }
+    const checkInterval = setInterval(() => {
+      if (window.DOC_VERSIONS && window.DOCUMENTER_CURRENT_VERSION) {
+        clearInterval(checkInterval);
+        resolve(true);
+      }
+    }, 100);
+    setTimeout(() => {
+      clearInterval(checkInterval);
+      resolve(false);
+    }, 5000);
+  });
+};
+
+const loadVersions = async () => {
+  if (typeof window === 'undefined') return;
+
+  try {
+    if (isLocalBuild()) {
+      versions.value = [{ text: 'dev', link: '/' }];
+      currentVersion.value = 'dev';
+    } else {
+      const scriptsLoaded = await waitForScriptsToLoad();
+
+      if (scriptsLoaded && window.DOC_VERSIONS && window.DOCUMENTER_CURRENT_VERSION) {
+        versions.value = window.DOC_VERSIONS.map(v => ({
+          text: v,
+          link: absoluteUrl(`/${v}/`),
+        }));
+        currentVersion.value = window.DOCUMENTER_CURRENT_VERSION;
+      } else {
+        versions.value = [{ text: 'dev', link: absoluteUrl('/dev/') }];
+        currentVersion.value = 'dev';
+      }
+    }
+  } catch (error) {
+    console.warn('Error loading versions:', error);
+    versions.value = [{ text: 'dev', link: absoluteUrl('/dev/') }];
+    currentVersion.value = 'dev';
+  }
+  isClient.value = true;
+};
+
+const versionItems = computed(() => {
+  return versions.value.map((v) => ({
+    text: v.text,
+    link: v.link
+  }));
+});
+
+onMounted(() => {
+  if (typeof window !== 'undefined') {
+    currentVersion.value = window.DOCUMENTER_CURRENT_VERSION ?? 'Versions';
+    loadVersions();
+  }
+});
+</script>
+
+<template>
+  <template v-if="isClient">
+    <VPNavBarMenuGroup
+      v-if="!screenMenu && versions.length > 0"
+      :item="{ text: currentVersion, items: versionItems }"
+      class="VPVersionPicker"
+    />
+    <VPNavScreenMenuGroup
+      v-else-if="screenMenu && versions.length > 0"
+      :text="currentVersion"
+      :items="versionItems"
+      class="VPVersionPicker"
+    />
+  </template>
+</template>
+
+<style scoped>
+.VPVersionPicker :deep(button .text) {
+  color: var(--vp-c-text-1) !important;
+}
+.VPVersionPicker:hover :deep(button .text) {
+  color: var(--vp-c-text-2) !important;
+}
+</style>

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -1,0 +1,116 @@
+# Getting Started
+
+```@meta
+CurrentModule = CTSolvers
+```
+
+## Installation
+
+CTSolvers.jl is typically installed as a dependency of another package in the ecosystem
+(e.g. [OptimalControl.jl](https://github.com/control-toolbox/OptimalControl.jl)).
+To install it directly:
+
+```julia
+import Pkg
+Pkg.add("CTSolvers")
+```
+
+**Requires Julia ≥ 1.10.**
+
+## Mental Model
+
+CTSolvers is the **resolution layer** of the control-toolbox ecosystem. It sits between
+[CTModels.jl](https://github.com/control-toolbox/CTModels.jl) (which defines the problem)
+and the NLP backends (Ipopt, MadNLP, Knitro, …) that do the heavy lifting.
+
+The resolution pipeline has three stages:
+
+```text
+CTModels.Model              CTSolvers                    NLP backend
+(problem definition)  →  (discretize + model)  →  (solve)  →  solution
+```
+
+Two things to keep in mind:
+
+1. **No top-level exports.** `using CTSolvers` loads the package but brings no symbols
+   into scope. Every symbol is accessed via its qualified path:
+   ```julia
+   CTSolvers.Solvers.Ipopt(max_iter = 1000)
+   CTSolvers.Modelers.ADNLP(backend = :optimized)
+   CTBase.Strategies.id(CTSolvers.Solvers.Ipopt)
+   ```
+
+2. **Strategy pattern throughout.** Modelers and solvers are *strategies* — configurable
+   components with validated options and provenance tracking.
+   Options are passed as keyword arguments and rejected with clear errors if unknown.
+
+## Quick Start
+
+Solve a discretized optimal control problem with Ipopt and ADNLPModels:
+
+```julia
+using CTSolvers
+using NLPModelsIpopt       # loads CTSolversIpopt extension → enables Solvers.Ipopt
+using OrdinaryDiffEqTsit5  # loads CTSolversSciMLIntegrator → enables Integrators.SciML
+using CommonSolve
+
+# Build a solver with validated options
+solver = CTSolvers.Solvers.Ipopt(max_iter = 500, tol = 1e-8)
+
+# Build a modeler (NLP backend adapter)
+modeler = CTSolvers.Modelers.ADNLP(backend = :optimized)
+
+# Build an integrator
+integrator = CTSolvers.Integrators.SciML()
+
+# Solve (docp is a CTSolvers.DOCP.DiscretizedModel, x0 is an initial guess)
+solution = solve(docp, x0, modeler, solver)
+```
+
+Extension loading is the key step: nothing from `Solvers.Ipopt`, `Integrators.SciML`,
+or similar requires `NLPModelsIpopt`/`OrdinaryDiffEqTsit5` to be loaded at package load
+time — they are loaded on demand when you `using` the backend package.
+
+## Configuring Options
+
+Every strategy constructor accepts keyword arguments for its options.
+Unknown options are rejected with a Levenshtein suggestion:
+
+```julia
+# Valid option
+solver = CTSolvers.Solvers.Ipopt(max_iter = 1000, tol = 1e-8)
+
+# Typo → error with suggestion
+solver = CTSolvers.Solvers.Ipopt(max_itr = 1000)
+# ERROR: IncorrectArgument: Unknown option :max_itr
+#   Did you mean: :max_iter?
+
+# Permissive mode: accepts unknown options with a warning
+solver = CTSolvers.Solvers.Ipopt(max_itr = 1000; mode = :permissive)
+```
+
+Inspect all available options via `metadata`:
+
+```julia
+CTBase.Strategies.metadata(CTSolvers.Solvers.Ipopt)
+```
+
+## Checking an Installed Instance
+
+```julia
+solver = CTSolvers.Solvers.Ipopt(max_iter = 500)
+CTBase.Strategies.options(solver)      # StrategyOptions with provenance
+CTBase.Strategies.id(CTSolvers.Solvers.Ipopt)  # :ipopt
+```
+
+## Next Steps
+
+| Topic | Where |
+|:------|:------|
+| Module dependencies, type hierarchies, data flow | [Architecture](@ref) |
+| Wrapping a new NLP solver | [Implementing a Solver](@ref) |
+| Wrapping a new ODE integrator | [Implementing an Integrator](@ref) |
+| Adapting a new NLP backend | [Implementing a Modeler](@ref) |
+| Connecting a new problem type | [Implementing an Optimization Problem](@ref) |
+| All exception types with examples | [Error Messages Reference](@ref) |
+| Complete API reference | API Reference (left sidebar) |

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -19,88 +19,104 @@ Pkg.add("CTSolvers")
 
 ## Mental Model
 
-CTSolvers is the **resolution layer** of the control-toolbox ecosystem. It sits between
-[CTModels.jl](https://github.com/control-toolbox/CTModels.jl) (which defines the problem)
-and the NLP backends (Ipopt, MadNLP, Knitro, …) that do the heavy lifting.
+CTSolvers provides the **resolution infrastructure** of the control-toolbox ecosystem,
+consumed by upstream packages:
 
-The resolution pipeline has three stages:
+- [CTDirect.jl](https://github.com/control-toolbox/CTDirect.jl) discretizes OCPs
+  (defined in [CTModels.jl](https://github.com/control-toolbox/CTModels.jl)) and uses
+  CTSolvers' `Solvers` and `Modelers` to solve them.
+- [CTFlows.jl](https://github.com/control-toolbox/CTFlows.jl) uses CTSolvers'
+  `Integrators` to build Hamiltonian flows for indirect methods.
+
+The resolution pipeline once CTDirect has discretized the problem:
 
 ```text
-CTModels.Model              CTSolvers                    NLP backend
-(problem definition)  →  (discretize + model)  →  (solve)  →  solution
+DiscretizedModel    CTSolvers.Modelers     NLP backend      CTSolvers.Solvers
+(docp)          →  (build NLP model)  →  (NLP problem)  →  (solve)  →  solution
 ```
 
-Two things to keep in mind:
+All symbols are accessed via **qualified module paths** — `using CTSolvers` brings
+nothing into scope directly.
 
-1. **No top-level exports.** `using CTSolvers` loads the package but brings no symbols
-   into scope. Every symbol is accessed via its qualified path:
-   ```julia
-   CTSolvers.Solvers.Ipopt(max_iter = 1000)
-   CTSolvers.Modelers.ADNLP(backend = :optimized)
-   CTBase.Strategies.id(CTSolvers.Solvers.Ipopt)
-   ```
+## Extension Loading
 
-2. **Strategy pattern throughout.** Modelers and solvers are *strategies* — configurable
-   components with validated options and provenance tracking.
-   Options are passed as keyword arguments and rejected with clear errors if unknown.
+CTSolvers loads no backend at startup. Each constructor throws `ExtensionError` until
+the corresponding package is loaded:
 
-## Quick Start
+```@example gs
+using CTSolvers
+try # hide
+CTSolvers.Solvers.Ipopt()
+catch e # hide
+showerror(IOContext(stdout, :color => true), e) # hide
+end # hide
+```
 
-Solve a discretized optimal control problem with Ipopt and ADNLPModels:
+```@example gs
+try # hide
+CTSolvers.Integrators.SciML()
+catch e # hide
+showerror(IOContext(stdout, :color => true), e) # hide
+end # hide
+```
+
+Strategy identifiers and type information are always available, without any extension:
+
+```@repl gs
+using CTBase
+CTBase.Strategies.id(CTSolvers.Solvers.Ipopt)
+CTBase.Strategies.id(CTSolvers.Modelers.ADNLP)
+CTBase.Strategies.id(CTSolvers.Integrators.SciML)
+```
+
+Load a backend to unlock its constructor:
 
 ```julia
-using CTSolvers
-using NLPModelsIpopt       # loads CTSolversIpopt extension → enables Solvers.Ipopt
+using NLPModelsIpopt       # loads CTSolversIpopt       → enables Solvers.Ipopt
+using ADNLPModels          # loads CTSolversADNLPModels  → enables Modelers.ADNLP
 using OrdinaryDiffEqTsit5  # loads CTSolversSciMLIntegrator → enables Integrators.SciML
-using CommonSolve
-
-# Build a solver with validated options
-solver = CTSolvers.Solvers.Ipopt(max_iter = 500, tol = 1e-8)
-
-# Build a modeler (NLP backend adapter)
-modeler = CTSolvers.Modelers.ADNLP(backend = :optimized)
-
-# Build an integrator
-integrator = CTSolvers.Integrators.SciML()
-
-# Solve (docp is a CTSolvers.DOCP.DiscretizedModel, x0 is an initial guess)
-solution = solve(docp, x0, modeler, solver)
 ```
-
-Extension loading is the key step: nothing from `Solvers.Ipopt`, `Integrators.SciML`,
-or similar requires `NLPModelsIpopt`/`OrdinaryDiffEqTsit5` to be loaded at package load
-time — they are loaded on demand when you `using` the backend package.
 
 ## Configuring Options
 
-Every strategy constructor accepts keyword arguments for its options.
-Unknown options are rejected with a Levenshtein suggestion:
-
-```julia
-# Valid option
-solver = CTSolvers.Solvers.Ipopt(max_iter = 1000, tol = 1e-8)
-
-# Typo → error with suggestion
-solver = CTSolvers.Solvers.Ipopt(max_itr = 1000)
-# ERROR: IncorrectArgument: Unknown option :max_itr
-#   Did you mean: :max_iter?
-
-# Permissive mode: accepts unknown options with a warning
-solver = CTSolvers.Solvers.Ipopt(max_itr = 1000; mode = :permissive)
+```@setup co
+using CTSolvers
+using NLPModelsIpopt
+using CTBase
+nothing
 ```
 
-Inspect all available options via `metadata`:
+Options are validated at construction. Unknown options are rejected with a Levenshtein
+suggestion; wrong types raise `IncorrectArgument`.
 
-```julia
-CTBase.Strategies.metadata(CTSolvers.Solvers.Ipopt)
+Without `NLPModelsIpopt` loaded, all constructor calls raise `ExtensionError` before
+option validation runs. A valid construction with the extension loaded:
+
+```@example co
+using NLPModelsIpopt
+CTSolvers.Solvers.Ipopt(max_iter = 1000, tol = 1e-8)
 ```
 
-## Checking an Installed Instance
+An unknown option name — with the extension loaded this raises `IncorrectArgument` with
+a Levenshtein suggestion (`Did you mean: :max_iter?`):
 
-```julia
-solver = CTSolvers.Solvers.Ipopt(max_iter = 500)
-CTBase.Strategies.options(solver)      # StrategyOptions with provenance
-CTBase.Strategies.id(CTSolvers.Solvers.Ipopt)  # :ipopt
+```@example co
+try # hide
+CTSolvers.Solvers.Ipopt(max_itr = 1000)
+catch e # hide
+showerror(IOContext(stdout, :color => true), e) # hide
+end # hide
+```
+
+Pass `mode = :permissive` to warn rather than error on unknown options. Introspect the
+full option schema and read back values with provenance:
+
+```@example co
+CTBase.Strategies.metadata(CTSolvers.Solvers.Ipopt)    # inspect all option definitions
+```
+
+```@example co
+CTBase.Strategies.options(CTSolvers.Solvers.Ipopt())   # actual values with provenance
 ```
 
 ## Next Steps

--- a/docs/src/guides/error_messages.md
+++ b/docs/src/guides/error_messages.md
@@ -192,7 +192,7 @@ CTBase.Options.OptionValue(1e-8, :default)
 ### NotProvided display
 
 ```@example errors
-CTBase.Options.NotProvided
+CTBase.Core.NotProvided
 ```
 
 ### Option extraction — successful

--- a/docs/src/guides/error_messages.md
+++ b/docs/src/guides/error_messages.md
@@ -37,7 +37,11 @@ nothing # hide
 ```
 
 ```@repl errors
+try # hide
 CTBase.Strategies.id(IncompleteStrategy)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 **Fix**: Implement the missing method:
@@ -49,23 +53,39 @@ CTBase.Strategies.id(::Type{<:IncompleteStrategy}) = :my_strategy
 ### Strategy contract — missing `metadata`
 
 ```@repl errors
+try # hide
 CTBase.Strategies.metadata(IncompleteStrategy)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
-### Optimization problem contract — missing builder
+### Optimization problem contract — missing build_model
 
-```@example errors
+Define a problem type and a modeler, but no `(problem, modeler)` method. A dedicated block
+label (`optprob`) keeps these throwaway types out of the shared `errors` scope:
+
+```@example optprob
+using CTSolvers
 struct MinimalProblem <: CTSolvers.Optimization.AbstractOptimizationProblem end
+struct MinimalModeler <: CTSolvers.Modelers.AbstractNLPModeler end
 nothing # hide
 ```
 
-```@repl errors
-CTSolvers.Optimization.get_adnlp_model_builder(MinimalProblem())
+The generic stub in `Modelers/contract.jl` throws `NotImplemented` as soon as `build_model`
+is called with a `(problem, modeler)` pair for which no concrete method exists:
+
+```@repl optprob
+try # hide
+CTSolvers.Optimization.build_model(MinimalProblem(), nothing, MinimalModeler())
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
-```@repl errors
-CTSolvers.Optimization.get_exa_model_builder(MinimalProblem())
-```
+**Fix**: Implement `build_model` and `build_solution` in the package providing the
+problem, dispatching on the concrete `(problem, modeler)` pair (see
+[Implementing an Optimization Problem](@ref)).
 
 ### Where it's thrown
 
@@ -74,10 +94,8 @@ CTSolvers.Optimization.get_exa_model_builder(MinimalProblem())
 | `CTBase.Strategies.id(::Type{T})` | Strategy type missing `id` |
 | `CTBase.Strategies.metadata(::Type{T})` | Strategy type missing `metadata` |
 | `CTBase.Strategies.options(strategy)` | Strategy instance has no `options` field and no custom getter |
-| `get_adnlp_model_builder(prob)` | Problem doesn't support ADNLPModels |
-| `get_exa_model_builder(prob)` | Problem doesn't support ExaModels |
-| `get_adnlp_solution_builder(prob)` | Problem doesn't support ADNLP solutions |
-| `get_exa_solution_builder(prob)` | Problem doesn't support Exa solutions |
+| `Optimization.build_model(prob, init, modeler)` | No concrete method for this `(problem, modeler)` pair |
+| `Optimization.build_solution(built, stats, modeler)` | No concrete method for this `(built, modeler)` pair |
 
 ## IncorrectArgument — Invalid Arguments
 
@@ -92,7 +110,11 @@ def = CTBase.Options.OptionDefinition(
     name = :max_iter, type = Integer, default = 100,
     description = "Maximum iterations",
 )
+try # hide
 CTBase.Options.extract_option((max_iter = "hello",), def)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 **Fix**: Provide a value of the correct type.
@@ -117,7 +139,11 @@ nothing # hide
 ```
 
 ```@repl errors
+try # hide
 CTBase.Options.extract_option((tol = -1.0,), bad_def)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 **Fix**: Provide a value that satisfies the validator constraint.
@@ -127,10 +153,14 @@ CTBase.Options.extract_option((tol = -1.0,), bad_def)
 When the default value doesn't match the declared type:
 
 ```@repl errors
+try # hide
 CTBase.Options.OptionDefinition(
     name = :count, type = Integer, default = "hello",
     description = "A count",
 )
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 **Fix**: Ensure the default value matches the declared type.
@@ -138,7 +168,11 @@ CTBase.Options.OptionDefinition(
 ### Invalid OptionValue source
 
 ```@repl errors
+try # hide
 CTBase.Options.OptionValue(42, :invalid_source)
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 **Fix**: Use `:default`, `:user`, or `:computed`.
@@ -148,14 +182,18 @@ CTBase.Options.OptionValue(42, :invalid_source)
 Thrown when a solver requires a package extension that hasn't been loaded.
 
 ```@repl errors
-CTSolvers.Solvers.Ipopt()
+try # hide
+CTSolvers.Solvers.MadNLP()
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 **Fix**: Load the required package before using the solver:
 
 ```julia
-using NLPModelsIpopt  # loads the CTSolversIpopt extension
-solver = Solvers.Ipopt(max_iter = 1000)
+using MadNLP  # loads the CTSolversMadNLP extension
+solver = Solvers.MadNLP(max_iter = 1000)
 ```
 
 ### Where it's thrown
@@ -166,62 +204,6 @@ solver = Solvers.Ipopt(max_iter = 1000)
 | `Solvers.MadNLP` | `MadNLP` |
 | `Solvers.Knitro` | `KNITRO` |
 | `Solvers.MadNCL` | `MadNCL` |
-
-## Display Examples
-
-### OptionDefinition display
-
-```@example errors
-CTBase.Options.OptionDefinition(
-    name = :max_iter, type = Integer, default = 1000,
-    description = "Maximum number of iterations",
-    aliases = (:maxiter,),
-)
-```
-
-### OptionValue display
-
-```@example errors
-CTBase.Options.OptionValue(1000, :user)
-```
-
-```@example errors
-CTBase.Options.OptionValue(1e-8, :default)
-```
-
-### NotProvided display
-
-```@example errors
-CTBase.Core.NotProvided
-```
-
-### Option extraction — successful
-
-```@example errors
-def = CTBase.Options.OptionDefinition(
-    name = :grid_size, type = Int, default = 100,
-    description = "Grid size", aliases = (:n,),
-)
-opt_value, remaining = CTBase.Options.extract_option((n = 200, tol = 1e-6), def)
-println("Extracted: ", opt_value)
-println("Remaining: ", remaining)
-```
-
-### Multiple option extraction
-
-```@example errors
-defs = [
-    CTBase.Options.OptionDefinition(
-        name = :grid_size, type = Int, default = 100, description = "Grid size",
-    ),
-    CTBase.Options.OptionDefinition(
-        name = :tol, type = Float64, default = 1e-6, description = "Tolerance",
-    ),
-]
-extracted, remaining = CTBase.Options.extract_options((grid_size = 200, max_iter = 1000), defs)
-println("Extracted: ", extracted)
-println("Remaining: ", remaining)
-```
 
 ## Best Practices for Error Messages
 

--- a/docs/src/guides/implementing_a_modeler.md
+++ b/docs/src/guides/implementing_a_modeler.md
@@ -4,18 +4,17 @@
 CurrentModule = CTSolvers
 ```
 
-This guide explains how to implement an optimization modeler in CTSolvers. Modelers are strategies that convert `AbstractOptimizationProblem` instances into NLP backend models and convert NLP solver results back into problem-specific solutions. We use **Modelers.ADNLP** and **Modelers.Exa** as reference examples.
+This guide explains how to implement an optimization modeler in CTSolvers. Modelers are strategies that select and configure the NLP backend (ADNLPModels, ExaModels, …) used to turn an `AbstractOptimizationProblem` into an NLP model. We use **Modelers.ADNLP** and **Modelers.Exa** as reference examples.
 
 !!! tip "Prerequisites"
-    Read [Architecture](@ref) first. A modeler is a strategy (see Implementing a Strategy in CTBase.jl documentation) with two additional **callable contracts**.
+    Read [Architecture](@ref) first. A modeler is a strategy (see Implementing a Strategy in CTBase.jl documentation): it **carries validated backend options** and acts as a dispatch token — it does not build anything itself.
 
 ## The AbstractNLPModeler Contract
 
-A modeler must satisfy **three contracts**:
+A modeler must satisfy **two contracts**:
 
-1. **Strategy contract** — `id`, `metadata`, `options` (inherited from `AbstractStrategy`)
-2. **Model building callable** — `(modeler)(prob, initial_guess) → NLP model`
-3. **Solution building callable** — `(modeler)(prob, nlp_stats) → Solution`
+1. **Strategy contract** — `id`, `metadata`, `options`, `_default_parameter` (inherited from `AbstractStrategy`)
+2. **Modeler contract** — the generic functions `Optimization.build_model` / `Optimization.build_solution`, dispatched on the `(problem, modeler)` pair
 
 ```text
 AbstractStrategy
@@ -24,13 +23,17 @@ AbstractStrategy
 └─ options(inst)    → StrategyOptions
 
 AbstractNLPModeler <: AbstractStrategy
-├─ (modeler)(prob, x0)    → NLP model
-├─ (modeler)(prob, stats) → Solution
-├─► Modelers.ADNLP
-└─► Modelers.Exa
+├─ build_model(prob, x0, modeler)        → BuiltModel  (generic stub in CTSolvers)
+├─ build_solution(built, stats, modeler) → Solution    (generic stub in CTSolvers)
+├─► Modelers.ADNLP{P<:CPU}
+└─► Modelers.Exa{P<:Union{CPU,GPU}}
 ```
 
-Both callables have default implementations that throw `NotImplemented`.
+The modeler is **not callable** and does not know how to build an NLP model. The typed
+`build_model` / `build_solution` methods are implemented by the **package providing the
+problem** (e.g. CTDirect for `DiscretizedModel`), by multiple dispatch on the concrete
+`(problem, modeler)` pair. The generic stubs in CTSolvers (`src/Modelers/contract.jl`)
+throw `NotImplemented` with guidance when no method exists for a pair.
 
 ```@example modeler
 using CTSolvers
@@ -38,7 +41,7 @@ using CTBase: CTBase
 nothing # hide
 ```
 
-The `id` is available directly:
+The `id` is available directly, without any extension:
 
 ```@example modeler
 CTBase.Strategies.id(CTSolvers.Modelers.ADNLP)
@@ -50,211 +53,288 @@ CTBase.Strategies.id(CTSolvers.Modelers.Exa)
 
 ## Step-by-Step Implementation
 
-We walk through the Modelers.ADNLP implementation as a reference.
+We walk through the `Modelers.ADNLP` implementation (`src/Modelers/adnlp.jl`) as a reference.
 
-### Step 1 — Define the struct
+### Step 1 — Define the parameterized struct and its tag
+
+Modelers are **parameterized** by an execution parameter `P <: AbstractStrategyParameter`
+(see Strategy Parameters in CTBase.jl documentation). ADNLP only supports CPU:
 
 ```julia
-struct Modelers.ADNLP <: AbstractNLPModeler
+struct ADNLPTag <: CTBase.Core.AbstractTag end
+
+struct ADNLP{P<:CPU} <: AbstractNLPModeler
     options::CTBase.Strategies.StrategyOptions
 end
 ```
 
-### Step 2 — Implement `id`
+The tag type is used later to route the constructor to the extension (see Step 4).
 
-```@example modeler
-CTBase.Strategies.id(CTSolvers.Modelers.ADNLP)
-```
-
-### Step 3 — Define defaults and metadata
-
-The metadata defines all configurable options with types, defaults, and validators.
-It is defined in `ext/CTSolversADNLPModels.jl` and requires `ADNLPModels` to be loaded:
+### Step 2 — Implement `id`, `description`, and the default parameter
 
 ```julia
-# requires: using ADNLPModels
-CTBase.Strategies.metadata(CTSolvers.Modelers.ADNLP)
-# → StrategyMetadata with options: backend, show_time, ...
+CTBase.Strategies.id(::Type{<:Modelers.ADNLP}) = :adnlp
+
+CTBase.Strategies.description(::Type{<:Modelers.ADNLP}) =
+    "NLP modeler using ADNLPModels with automatic differentiation.\n" *
+    "See: https://jso.dev/ADNLPModels.jl"
+
+CTBase.Strategies._default_parameter(::Type{<:Modelers.ADNLP}) = CPU
 ```
 
-### Step 4 — Constructor and options accessor
+`_default_parameter` is part of the parameterized-strategy contract: it tells the
+unparameterized constructor `Modelers.ADNLP(...)` which parameter to use.
 
-The constructor validates options and stores them. It also requires the extension:
+### Step 3 — Declare `metadata` (stub in `src/`, real in `ext/`)
+
+The metadata defines all configurable options with types, defaults, and validators. Since
+the option definitions depend on the backend package, the method in `src/` is a stub that
+throws `ExtensionError`; the real implementation lives in `ext/CTSolversADNLPModels.jl`
+and requires `ADNLPModels` to be loaded:
+
+```julia
+# src/Modelers/adnlp.jl — stub
+function CTBase.Strategies.metadata(::Type{<:Modelers.ADNLP{P}}) where {P<:CPU}
+    throw(CTBase.Exceptions.ExtensionError(:ADNLPModels; ...))
+end
+
+# Fallback for the unparameterized type: delegate to the default parameter
+function CTBase.Strategies.metadata(::Type{Modelers.ADNLP})
+    return CTBase.Strategies.metadata(
+        Modelers.ADNLP{CTBase.Strategies._default_parameter(Modelers.ADNLP)}
+    )
+end
+```
+
+### Step 4 — Constructors via Tag Dispatch
+
+The constructor chain goes from the friendly keyword form down to a builder function
+dispatched on the **tag and parameter types** (not instances). The builder is a stub in
+`src/` and is overridden by the extension:
+
+```julia
+# Unparameterized constructor → resolve the default parameter
+function Modelers.ADNLP(; mode::Symbol=:strict, kwargs...)
+    P = CTBase.Strategies._default_parameter(Modelers.ADNLP)
+    return Modelers.ADNLP{P}(; mode=mode, kwargs...)
+end
+
+# Parameterized constructor → tag dispatch, tag and parameter passed as TYPES
+function Modelers.ADNLP{P}(; mode::Symbol=:strict, kwargs...) where {P<:CPU}
+    return build_adnlp_modeler(ADNLPTag, P; mode=mode, kwargs...)
+end
+
+# Stub — throws until ADNLPModels is loaded; the extension provides the
+# typed method build_adnlp_modeler(::Type{ADNLPTag}, ::Type{<:CPU}; ...)
+function build_adnlp_modeler(
+    ::Type{<:CTBase.Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter};
+    kwargs...,
+)
+    throw(CTBase.Exceptions.ExtensionError(:ADNLPModels; ...))
+end
+```
+
+Without the extension, constructing the modeler therefore raises `ExtensionError`:
+
+```@repl modeler
+try # hide
+CTSolvers.Modelers.ADNLP()
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
+```
+
+With `using ADNLPModels`, the extension's `build_adnlp_modeler` validates the options
+against the metadata and returns the configured instance:
 
 ```julia
 # requires: using ADNLPModels
 modeler = CTSolvers.Modelers.ADNLP(backend = :optimized)
 CTBase.Strategies.options(modeler)
-# → StrategyOptions with backend = :optimized
+# → StrategyOptions with backend = :optimized (and all defaults, with provenance)
 ```
 
-### Step 5 — Model building callable
+And that is all: the modeler is complete. It carries options — nothing else.
 
-This is the core of the modeler. It retrieves the appropriate **builder** from the problem and invokes it:
+## The build_model / build_solution Contract
 
-```julia
-function (modeler::Modelers.ADNLP)(
-    prob::AbstractOptimizationProblem,
-    initial_guess,
-)::ADNLPModels.ADNLPModel
-    # Get the builder registered for this problem type
-    builder = get_adnlp_model_builder(prob)
-
-    # Extract modeler options as a Dict
-    options = CTBase.Strategies.options_dict(modeler)
-
-    # Build the NLP model, passing all options to the builder
-    return builder(initial_guess; options...)
-end
-```
-
-The key interaction is with the **Builder pattern**: the modeler doesn't know how to build the
-model itself — it asks the problem for a builder, then calls it.
-See [Implementing an Optimization Problem](@ref) for how builders work.
-
-### Step 6 — Solution building callable
-
-Same pattern, but for converting NLP results back into a problem-specific solution:
+Model building is **not** the modeler's job. The `Optimization` module owns two generic
+functions whose `NotImplemented` stubs — the modeler contract — live in
+`src/Modelers/contract.jl`, typed on `AbstractNLPModeler`:
 
 ```julia
-function (modeler::Modelers.ADNLP)(
-    prob::AbstractOptimizationProblem,
-    nlp_solution::SolverCore.AbstractExecutionStats,
+function Optimization.build_model(
+    prob::Optimization.AbstractOptimizationProblem, initial_guess, modeler::AbstractNLPModeler
 )
-    builder = get_adnlp_solution_builder(prob)
-    return builder(nlp_solution)
+    throw(Exceptions.NotImplemented(
+        "Model building not implemented";
+        suggestion="Implement build_model for this (problem, modeler) pair in the package providing the problem",
+        ...
+    ))
 end
 ```
+
+The **package providing the problem** implements the typed methods by multiple dispatch
+on the concrete `(problem, modeler)` pair. For example, CTDirect implements the pair
+`(DiscretizedModel{<:Any,<:Collocation}, Modelers.ADNLP)` (simplified from
+`CTDirect/src/collocation.jl`):
+
+```julia
+# In CTDirect — the problem package builds the NLP, using the modeler's options
+function CTSolvers.build_model(
+    dm::CTSolvers.DiscretizedModel{<:Any,<:Collocation},
+    initial_guess::CTModels.AbstractInitialGuess,
+    modeler::CTSolvers.Modelers.ADNLP,
+)
+    docp = dm.cache.docp
+
+    # the modeler contributes its validated options
+    options = CTBase.Strategies.options_dict(modeler)
+    backend = pop!(options, :backend)
+
+    # ... build objective, constraints, initial guess from docp ...
+    nlp = ADNLPModels.ADNLPModel!(f, x0, ...; backend, options...)
+
+    # bundle problem + NLP + build-time cache (ADNLP needs none)
+    return CTSolvers.BuiltModel(dm, nlp, CTSolvers.NoCache())
+end
+
+function CTSolvers.build_solution(
+    built::CTSolvers.BuiltModel{<:CTSolvers.DiscretizedModel{<:Any,<:Collocation}},
+    nlp_solution::SolverCore.AbstractExecutionStats,
+    ::CTSolvers.Modelers.ADNLP,
+)
+    docp = built.problem.cache.docp
+    # ... build the OCP solution from the NLP solver output ...
+end
+```
+
+`build_model` returns an [`CTSolvers.Optimization.BuiltModel`](@ref) — an immutable
+bundle `(problem, nlp, cache)` — and `build_solution` dispatches on that bundle. See
+[Implementing an Optimization Problem](@ref) for the problem-side view of this contract.
 
 ## Modelers.Exa: A Second Example
 
-Modelers.Exa follows the same pattern with different options and a slightly different callable signature:
+`Modelers.Exa` follows exactly the same pattern, with two differences.
+
+**GPU support.** Exa accepts both execution parameters:
 
 ```julia
-struct Modelers.Exa <: AbstractNLPModeler
+struct Exa{P<:Union{CPU,GPU}} <: AbstractNLPModeler
     options::CTBase.Strategies.StrategyOptions
 end
 
 CTBase.Strategies.id(::Type{<:Modelers.Exa}) = :exa
+CTBase.Strategies._default_parameter(::Type{<:Modelers.Exa}) = CPU
 
-function CTBase.Strategies.metadata(::Type{<:Modelers.Exa})
-    return CTBase.Strategies.StrategyMetadata(
-        CTBase.Options.OptionDefinition(
-            name = :base_type,
-            type = DataType,
-            default = Float64,
-            description = "Base floating-point type used by ExaModels",
-            validator = validate_exa_base_type,
-        ),
-        CTBase.Options.OptionDefinition(
-            name = :backend,
-            type = Union{Nothing, KernelAbstractions.Backend},
-            default = nothing,
-            description = "Execution backend for ExaModels (CPU, GPU, etc.)",
-        ),
-    )
+function Modelers.Exa{P}(; mode::Symbol=:strict, kwargs...) where {P<:AbstractStrategyParameter}
+    return build_exa_modeler(ExaTag, P; mode=mode, kwargs...)
 end
 ```
 
-The model building callable extracts `base_type` as a positional argument:
+`Modelers.Exa{GPU}()` selects GPU-specific option defaults through the parameterized
+`metadata(Modelers.Exa{GPU})` (requires the CUDA-related extensions).
+
+**Build-time cache.** In CTDirect, building an `ExaModel` also produces a *getter*
+needed later to extract the solution. It travels in the `cache` field of the
+`BuiltModel` — immutable, no closure, no mutation:
 
 ```julia
-function (modeler::Modelers.Exa)(
-    prob::AbstractOptimizationProblem,
-    initial_guess,
-)::ExaModels.ExaModel
-    builder = get_exa_model_builder(prob)
-    options = CTBase.Strategies.options_dict(modeler)
+# In CTDirect
+function CTSolvers.build_model(
+    dm::CTSolvers.DiscretizedModel{<:Any,<:Collocation},
+    initial_guess::CTModels.AbstractInitialGuess,
+    modeler::CTSolvers.Modelers.Exa,
+)
+    # ... build the ExaModel and its getter ...
+    nlp, exa_getter = build_exa(; grid_size, backend, scheme, init, base_type)
 
-    # ExaModels requires BaseType as first positional argument
-    BaseType = options[:base_type]
-    delete!(options, :base_type)
+    # carry the getter in an immutable build-time cache
+    return CTSolvers.BuiltModel(dm, nlp, ExaBuildCache(exa_getter))
+end
 
-    return builder(BaseType, initial_guess; options...)
+function CTSolvers.build_solution(
+    built::CTSolvers.BuiltModel{<:CTSolvers.DiscretizedModel{<:Any,<:Collocation},<:Any,<:ExaBuildCache},
+    nlp_solution::SolverCore.AbstractExecutionStats,
+    ::CTSolvers.Modelers.Exa,
+)
+    exa_getter = built.cache.exa_getter   # read back from the bundle
+    # ... build the OCP solution using the getter ...
 end
 ```
 
-!!! note "Different builder signatures"
-    `ADNLPModelBuilder` takes `(initial_guess; kwargs...)` while `ExaModelBuilder` takes
-    `(BaseType, initial_guess; kwargs...)`. Each modeler adapts the call to its builder's expected signature.
+!!! note "Who owns what"
+    `ExaBuildCache` is defined in CTDirect, not CTSolvers — CTSolvers only requires
+    `cache <: CTBase.Core.AbstractCache`. Backends that need no auxiliary data use
+    [`CTSolvers.Optimization.NoCache`](@ref).
 
-## Integration with build_model / build_solution
+## Integration with the Pipeline
 
-The `Optimization` module owns two generic functions, `build_model` and `build_solution`.
-Their canonical `NotImplemented` contract stubs — the modeler contract — live in the `Modelers`
-module, typed on `AbstractNLPModeler`; concrete methods are provided by the package supplying
-the problem (e.g. CTDirect), dispatched on the concrete `(problem, modeler)` pair.
-`build_model` returns an `Optimization.BuiltModel` (the NLP plus an immutable build-time cache),
-and `build_solution` dispatches on that bundle.
-
-The high-level `CommonSolve.solve` pipeline:
+The high-level `CommonSolve.solve` pipeline (`src/Solvers/orchestration.jl`) composes the
+two contracts without knowing anything about backends:
 
 ```text
 User
  │
- ▼  solve(problem, x0, modeler, solver)
+ ▼  solve(docp, x0, modeler, solver)          ← orchestration.jl
 CommonSolve.solve
  │
- ├─► build_model(problem, x0, modeler)
- │       │
- │       ├─► modeler(problem, x0)
- │       │       ├─► get_adnlp_model_builder(problem)  →  ADNLPModelBuilder
- │       │       └─► builder(x0; show_time, backend, ...)  →  ADNLPModel
- │       └─► BuiltModel(nlp, cache)
+ ├─► build_model(docp, x0, modeler)           →  BuiltModel
+ │       (CTDirect provides the typed method for the (problem, modeler) pair)
  │
- ├─► solve(nlp, solver)  →  ExecutionStats
+ ├─► CommonSolve.solve(built.nlp, solver)     →  ExecutionStats
+ │       (backend extension provides the typed method, e.g. CTSolversIpopt)
  │
- └─► build_solution(built_model, stats, modeler)
-         └─► modeler(problem, stats)
-                 ├─► get_adnlp_solution_builder(problem) → ADNLPSolutionBuilder
-                 └─► builder(stats)  →  OCP Solution
+ └─► build_solution(built, stats, modeler)    →  OCP Solution
+         (CTDirect provides the typed method for the (built, modeler) pair)
 ```
 
 ## Validation
 
-Verify the three contract methods explicitly:
+Verify the strategy contract explicitly:
 
 ```julia
-# id is always available
+# id and description are always available
 CTBase.Strategies.id(CTSolvers.Modelers.ADNLP)    # => :adnlp
-CTBase.Strategies.id(CTSolvers.Modelers.Exa)       # => :exa
+CTBase.Strategies.id(CTSolvers.Modelers.Exa)      # => :exa
 
-# metadata is available without extension
+# metadata and construction require the backend extension
+# requires: using ADNLPModels
 CTBase.Strategies.metadata(CTSolvers.Modelers.ADNLP) isa CTBase.Strategies.StrategyMetadata  # => true
-CTBase.Strategies.metadata(CTSolvers.Modelers.Exa)   isa CTBase.Strategies.StrategyMetadata  # => true
-
-# options requires a constructed instance
 modeler = CTSolvers.Modelers.ADNLP()
 CTBase.Strategies.options(modeler) isa CTBase.Strategies.StrategyOptions  # => true
 ```
 
-For the callables, test with a fake or real problem:
+For the modeler contract, test the dispatch with a fake problem (fake types at the
+top level of the test module, never inside test functions):
 
 ```julia
-# Create a fake problem with builders
-prob = FakeOptimizationProblem(adnlp_builder, adnlp_solution_builder)
+struct FakeProblem <: CTSolvers.Optimization.AbstractOptimizationProblem end
 
-# Test model building
-modeler = CTSolvers.Modelers.ADNLP(backend = :optimized)
-nlp = modeler(prob, x0)
-@test nlp isa ADNLPModels.ADNLPModel
+function CTSolvers.Optimization.build_model(
+    prob::FakeProblem, initial_guess, modeler::CTSolvers.Modelers.ADNLP
+)
+    nlp = build_fake_nlp(initial_guess; CTBase.Strategies.options_dict(modeler)...)
+    return CTSolvers.Optimization.BuiltModel(prob, nlp, CTSolvers.Optimization.NoCache())
+end
 
-# Test solution building
-stats = solve(nlp, solver)
-solution = modeler(prob, stats)
-@test solution isa ExpectedSolutionType
+built = CTSolvers.Optimization.build_model(FakeProblem(), x0, modeler)
+@test built isa CTSolvers.Optimization.BuiltModel
+@test built.cache isa CTSolvers.Optimization.NoCache
 ```
+
+Without a typed method, the stub fails loudly with `NotImplemented` and names the exact
+method to implement.
 
 ## Summary: Adding a New Modeler
 
 To add a new modeler (e.g., `MyModeler` for a new NLP backend):
 
-1. Define `MyModeler <: AbstractNLPModeler` with `options::CTBase.Strategies.StrategyOptions`
-2. Implement `CTBase.Strategies.id(::Type{<:MyModeler}) = :my_backend`
-3. Implement `CTBase.Strategies.metadata(::Type{<:MyModeler})` with option definitions
-4. Write constructor: `MyModeler(; mode, kwargs...)`
-5. Implement `CTBase.Strategies.options(m::MyModeler) = m.options`
-6. Implement model building callable: `(modeler::MyModeler)(prob, x0) → NLP`
-7. Implement solution building callable: `(modeler::MyModeler)(prob, stats) → Solution`
-8. Add corresponding builder types in `Optimization` if needed (`MyModelBuilder`, `MySolutionBuilder`)
-9. Add contract methods in `Optimization`: `get_my_model_builder`, `get_my_solution_builder`
+1. Define the tag: `struct MyModelerTag <: CTBase.Core.AbstractTag end`
+2. Define the parameterized struct: `MyModeler{P<:CPU} <: AbstractNLPModeler` with `options::CTBase.Strategies.StrategyOptions`
+3. Implement `CTBase.Strategies.id(::Type{<:MyModeler}) = :my_backend` and `CTBase.Strategies.description`
+4. Implement `CTBase.Strategies._default_parameter(::Type{<:MyModeler}) = CPU`
+5. Declare the `metadata` stub in `src/` (throws `ExtensionError`); implement the real option definitions in the backend extension
+6. Write the constructor chain: `MyModeler(; ...)` → `MyModeler{P}(; ...)` → `build_my_modeler(MyModelerTag, P; ...)`, with the builder stub in `src/` and the real builder in the extension
+7. Implement `CTBase.Strategies.options(m::MyModeler) = m.options`
+8. **Do not** implement any model building on the modeler — the packages providing problem types opt in by defining `Optimization.build_model(prob, init, ::MyModeler)` and `Optimization.build_solution(built, stats, ::MyModeler)` for their own problems

--- a/docs/src/guides/implementing_a_modeler.md
+++ b/docs/src/guides/implementing_a_modeler.md
@@ -17,24 +17,17 @@ A modeler must satisfy **three contracts**:
 2. **Model building callable** — `(modeler)(prob, initial_guess) → NLP model`
 3. **Solution building callable** — `(modeler)(prob, nlp_stats) → Solution`
 
-```mermaid
-classDiagram
-    class AbstractStrategy {
-        <<abstract>>
-        id(::Type)::Symbol
-        metadata(::Type)::StrategyMetadata
-        options(instance)::StrategyOptions
-    }
+```text
+AbstractStrategy
+├─ id(::Type)       → Symbol
+├─ metadata(::Type) → StrategyMetadata
+└─ options(inst)    → StrategyOptions
 
-    class AbstractNLPModeler {
-        <<abstract>>
-        (modeler)(prob, x0) → NLP
-        (modeler)(prob, stats) → Solution
-    }
-
-    AbstractStrategy <|-- AbstractNLPModeler
-    AbstractNLPModeler <|-- Modelers.ADNLP
-    AbstractNLPModeler <|-- Modelers.Exa
+AbstractNLPModeler <: AbstractStrategy
+├─ (modeler)(prob, x0)    → NLP model
+├─ (modeler)(prob, stats) → Solution
+├─► Modelers.ADNLP
+└─► Modelers.Exa
 ```
 
 Both callables have default implementations that throw `NotImplemented`.
@@ -113,7 +106,9 @@ function (modeler::Modelers.ADNLP)(
 end
 ```
 
-The key interaction is with the **Builder pattern**: the modeler doesn't know how to build the model itself — it asks the problem for a builder, then calls it. See [Implementing an Optimization Problem](@ref) for how builders work.
+The key interaction is with the **Builder pattern**: the modeler doesn't know how to build the
+model itself — it asks the problem for a builder, then calls it.
+See [Implementing an Optimization Problem](@ref) for how builders work.
 
 ### Step 6 — Solution building callable
 
@@ -178,53 +173,39 @@ end
 ```
 
 !!! note "Different builder signatures"
-    `ADNLPModelBuilder` takes `(initial_guess; kwargs...)` while `ExaModelBuilder` takes `(BaseType, initial_guess; kwargs...)`. Each modeler adapts the call to its builder's expected signature.
+    `ADNLPModelBuilder` takes `(initial_guess; kwargs...)` while `ExaModelBuilder` takes
+    `(BaseType, initial_guess; kwargs...)`. Each modeler adapts the call to its builder's expected signature.
 
 ## Integration with build_model / build_solution
 
-The `Optimization` module *owns* two generic functions, `build_model` and
-`build_solution`. Their canonical `NotImplemented` contract stubs — the modeler
-contract — live in the `Modelers` module, typed on `AbstractNLPModeler`; concrete
-methods are provided by the package supplying the problem (e.g. CTDirect),
-dispatched on the concrete `(problem, modeler)` pair. `build_model` returns an
-`Optimization.BuiltModel` (the NLP plus an immutable build-time cache), and
-`build_solution` dispatches on that bundle:
+The `Optimization` module owns two generic functions, `build_model` and `build_solution`.
+Their canonical `NotImplemented` contract stubs — the modeler contract — live in the `Modelers`
+module, typed on `AbstractNLPModeler`; concrete methods are provided by the package supplying
+the problem (e.g. CTDirect), dispatched on the concrete `(problem, modeler)` pair.
+`build_model` returns an `Optimization.BuiltModel` (the NLP plus an immutable build-time cache),
+and `build_solution` dispatches on that bundle.
 
-```julia
-# In src/Modelers/contract.jl
+The high-level `CommonSolve.solve` pipeline:
 
-function Optimization.build_model(
-    prob::Optimization.AbstractOptimizationProblem, initial_guess, modeler::AbstractNLPModeler
-)
-    throw(Exceptions.NotImplemented(...))   # implemented per (problem, modeler) downstream
-end
-
-function Optimization.build_solution(
-    built::Optimization.BuiltModel, model_solution, modeler::AbstractNLPModeler
-)
-    throw(Exceptions.NotImplemented(...))
-end
-```
-
-These are used by the high-level `CommonSolve.solve`:
-
-```mermaid
-sequenceDiagram
-    participant User
-    participant Solve as CommonSolve.solve
-    participant BuildModel as build_model
-    participant Modeler as Modelers.ADNLP
-    participant Problem as AbstractOptimizationProblem
-    participant Builder as ADNLPModelBuilder
-
-    User->>Solve: solve(problem, x0, modeler, solver)
-    Solve->>BuildModel: build_model(problem, x0, modeler)
-    BuildModel->>Modeler: modeler(problem, x0)
-    Modeler->>Problem: get_adnlp_model_builder(problem)
-    Problem-->>Modeler: ADNLPModelBuilder
-    Modeler->>Builder: builder(x0; show_time, backend, ...)
-    Builder-->>Modeler: ADNLPModel
-    Modeler-->>Solve: ADNLPModel
+```text
+User
+ │
+ ▼  solve(problem, x0, modeler, solver)
+CommonSolve.solve
+ │
+ ├─► build_model(problem, x0, modeler)
+ │       │
+ │       ├─► modeler(problem, x0)
+ │       │       ├─► get_adnlp_model_builder(problem)  →  ADNLPModelBuilder
+ │       │       └─► builder(x0; show_time, backend, ...)  →  ADNLPModel
+ │       └─► BuiltModel(nlp, cache)
+ │
+ ├─► solve(nlp, solver)  →  ExecutionStats
+ │
+ └─► build_solution(built_model, stats, modeler)
+         └─► modeler(problem, stats)
+                 ├─► get_adnlp_solution_builder(problem) → ADNLPSolutionBuilder
+                 └─► builder(stats)  →  OCP Solution
 ```
 
 ## Validation
@@ -233,16 +214,16 @@ Verify the three contract methods explicitly:
 
 ```julia
 # id is always available
-CTBase.Strategies.id(Modelers.ADNLP)    # => :adnlp
-CTBase.Strategies.id(Modelers.Exa)      # => :exa
+CTBase.Strategies.id(CTSolvers.Modelers.ADNLP)    # => :adnlp
+CTBase.Strategies.id(CTSolvers.Modelers.Exa)       # => :exa
 
 # metadata is available without extension
-CTBase.Strategies.metadata(Modelers.ADNLP) isa CTBase.Strategies.StrategyMetadata  # => true
-CTBase.Strategies.metadata(Modelers.Exa)   isa CTBase.Strategies.StrategyMetadata  # => true
+CTBase.Strategies.metadata(CTSolvers.Modelers.ADNLP) isa CTBase.Strategies.StrategyMetadata  # => true
+CTBase.Strategies.metadata(CTSolvers.Modelers.Exa)   isa CTBase.Strategies.StrategyMetadata  # => true
 
 # options requires a constructed instance
-modeler = Modelers.ADNLP()
-CTBase.Strategies.options(modeler) isa CTBase.Strategies.StrategyOptions            # => true
+modeler = CTSolvers.Modelers.ADNLP()
+CTBase.Strategies.options(modeler) isa CTBase.Strategies.StrategyOptions  # => true
 ```
 
 For the callables, test with a fake or real problem:
@@ -252,7 +233,7 @@ For the callables, test with a fake or real problem:
 prob = FakeOptimizationProblem(adnlp_builder, adnlp_solution_builder)
 
 # Test model building
-modeler = Modelers.ADNLP(backend = :optimized)
+modeler = CTSolvers.Modelers.ADNLP(backend = :optimized)
 nlp = modeler(prob, x0)
 @test nlp isa ADNLPModels.ADNLPModel
 

--- a/docs/src/guides/implementing_a_modeler.md
+++ b/docs/src/guides/implementing_a_modeler.md
@@ -68,22 +68,24 @@ CTBase.Strategies.id(CTSolvers.Modelers.ADNLP)
 
 ### Step 3 — Define defaults and metadata
 
-The metadata defines all configurable options with types, defaults, and validators:
+The metadata defines all configurable options with types, defaults, and validators.
+It is defined in `ext/CTSolversADNLPModels.jl` and requires `ADNLPModels` to be loaded:
 
-```@example modeler
+```julia
+# requires: using ADNLPModels
 CTBase.Strategies.metadata(CTSolvers.Modelers.ADNLP)
+# → StrategyMetadata with options: backend, show_time, ...
 ```
 
 ### Step 4 — Constructor and options accessor
 
-The constructor validates options and stores them:
+The constructor validates options and stores them. It also requires the extension:
 
-```@example modeler
+```julia
+# requires: using ADNLPModels
 modeler = CTSolvers.Modelers.ADNLP(backend = :optimized)
-```
-
-```@example modeler
 CTBase.Strategies.options(modeler)
+# → StrategyOptions with backend = :optimized
 ```
 
 ### Step 5 — Model building callable

--- a/docs/src/guides/implementing_a_solver.md
+++ b/docs/src/guides/implementing_a_solver.md
@@ -17,25 +17,19 @@ A solver must satisfy **three contracts**:
 2. **Callable contract** — `(solver)(nlp; display) → ExecutionStats`
 3. **Tag Dispatch** — separates type definition from backend implementation
 
-```mermaid
-classDiagram
-    class AbstractStrategy {
-        <<abstract>>
-        id(::Type)::Symbol
-        metadata(::Type)::StrategyMetadata
-        options(instance)::StrategyOptions
-    }
+```text
+AbstractStrategy
+├─ id(::Type)       → Symbol
+├─ metadata(::Type) → StrategyMetadata
+└─ options(inst)    → StrategyOptions
 
-    class AbstractNLPSolver {
-        <<abstract>>
-        (solver)(nlp; display) → Stats
-    }
-
-    AbstractStrategy <|-- AbstractNLPSolver
-    AbstractNLPSolver <|-- Solvers.Ipopt
-    AbstractNLPSolver <|-- Solvers.MadNLP
-    AbstractNLPSolver <|-- Solvers.MadNCL
-    AbstractNLPSolver <|-- Solvers.Knitro
+AbstractNLPSolver <: AbstractStrategy
+└─ (solver)(nlp; display) → ExecutionStats
+   ├─► Solvers.Ipopt
+   ├─► Solvers.MadNLP
+   ├─► Solvers.MadNCL
+   ├─► Solvers.Knitro
+   └─► Solvers.Uno
 ```
 
 The default callable throws `NotImplemented` with guidance.
@@ -59,7 +53,7 @@ CTSolvers.Solvers.Ipopt()
 A **tag type** is a lightweight struct used for dispatch. It routes the constructor call to the right extension:
 
 ```julia
-# In src/Solvers/ipopt_solver.jl
+# In src/Solvers/ipopt.jl
 struct IpoptTag <: AbstractTag end
 ```
 
@@ -112,30 +106,24 @@ CTSolvers.Solvers.MadNLP()
 
 ## The Tag Dispatch Pattern
 
-```mermaid
-flowchart LR
-    subgraph src["src/Solvers/ipopt_solver.jl"]
-        Type["Solvers.Ipopt <: AbstractNLPSolver"]
-        Tag["IpoptTag <: AbstractTag"]
-        Ctor["Solvers.Ipopt(; kwargs...)\n→ build_ipopt_solver(IpoptTag(); kwargs...)"]
-        Stub["build_ipopt_solver(::AbstractTag)\n→ ExtensionError"]
-    end
+```text
+src/Solvers/ipopt.jl                    ext/CTSolversIpopt.jl
+────────────────────────────────────    ──────────────────────────────────────
+Solvers.Ipopt <: AbstractNLPSolver      metadata(::Type{<:Solvers.Ipopt})
+IpoptTag      <: AbstractTag              → StrategyMetadata(option defs...)
 
-    subgraph ext["ext/CTSolversIpopt.jl"]
-        Meta["metadata(::Type{<:Solvers.Ipopt})\n→ StrategyMetadata(...)"]
-        Build["build_ipopt_solver(::IpoptTag)\n→ Solvers.Ipopt(opts)"]
-        Call["(solver::Solvers.Ipopt)(nlp)\n→ ipopt(nlp; opts...)"]
-    end
+Solvers.Ipopt(; kwargs...)              build_ipopt_solver(::IpoptTag; kwargs...)
+  → build_ipopt_solver(IpoptTag(); …)     → Solvers.Ipopt(validated_opts)
 
-    Ctor -->|"tag dispatch"| Build
-    Stub -.->|"overridden by"| Build
+build_ipopt_solver(::AbstractTag; …)    (solver::Solvers.Ipopt)(nlp; display)
+  → ExtensionError(:NLPModelsIpopt)       → ipopt(nlp; opts...)
 ```
 
 The split is:
 
 | Location | Contains |
 |----------|----------|
-| `src/Solvers/ipopt_solver.jl` | Struct, `id`, tag, constructor stub, `ExtensionError` fallback |
+| `src/Solvers/ipopt.jl` | Struct, `id`, tag, constructor stub, `ExtensionError` fallback |
 | `ext/CTSolversIpopt.jl` | `metadata` (option definitions), `build_ipopt_solver` (real constructor), callable `(solver)(nlp)` |
 
 This keeps CTSolvers lightweight — `NLPModelsIpopt` is only loaded when the user does `using NLPModelsIpopt`.
@@ -144,7 +132,7 @@ This keeps CTSolvers lightweight — `NLPModelsIpopt` is only loaded when the us
 
 ### File structure
 
-```
+```text
 ext/
 └── CTSolversIpopt.jl    # Single-file extension module
 ```
@@ -230,26 +218,18 @@ end # module CTSolversIpopt
 
 CTSolvers provides a unified `CommonSolve.solve` interface at three levels:
 
-```mermaid
-flowchart TB
-    subgraph High["High-Level"]
-        H["solve(problem, x0, modeler, solver)"]
-    end
+```text
+High-level:  solve(problem, x0, modeler, solver)
+                │
+                ├─► build_model(problem, x0, modeler) → NLP
+                │
+                ├─► solve(nlp, solver) → ExecutionStats     ← Mid-level
+                │       └─► solver(nlp; display)
+                │
+                └─► build_solution(problem, stats, modeler) → OCP Solution
 
-    subgraph Mid["Mid-Level"]
-        M["solve(nlp, solver)"]
-    end
-
-    subgraph Low["Low-Level"]
-        L["solve(any, solver)"]
-    end
-
-    H -->|"build_model → NLP"| M
-    M -->|"solver(nlp)"| Callable["solver(nlp; display)"]
-    L -->|"solver(any)"| Callable
-    H -->|"build_solution → OCP Solution"| Result["OCP Solution"]
-    M --> Stats["ExecutionStats"]
-    L --> Any["Result"]
+Low-level:   solve(any, solver)
+                └─► solver(any; display)
 ```
 
 ### High-level: full pipeline
@@ -270,7 +250,7 @@ solution = solve(problem, x0, modeler, solver)
 using ADNLPModels
 
 nlp = ADNLPModel(x -> sum(x.^2), zeros(10))
-solver = Solvers.Ipopt(max_iter = 1000)
+solver = CTSolvers.Solvers.Ipopt(max_iter = 1000)
 stats = solve(nlp, solver; display = false)
 ```
 

--- a/docs/src/guides/implementing_a_solver.md
+++ b/docs/src/guides/implementing_a_solver.md
@@ -7,15 +7,19 @@ CurrentModule = CTSolvers
 This guide explains how to implement an optimization solver in CTSolvers. Solvers are strategies that wrap NLP backend libraries (Ipopt, MadNLP, Knitro, etc.) behind a unified interface. We use **Solvers.Ipopt** as the reference example throughout.
 
 !!! tip "Prerequisites"
-    Read [Architecture](@ref) first. A solver is a strategy (see Implementing a Strategy in CTBase.jl documentation) with two additional requirements: a **callable interface** and a **Tag Dispatch** extension.
+    Read [Architecture](@ref) first. A solver is a strategy (see Implementing a Strategy in CTBase.jl documentation) with two additional requirements: a **solve contract** and a **Tag Dispatch** extension.
 
 ## The AbstractNLPSolver Contract
 
 A solver must satisfy **three contracts**:
 
-1. **Strategy contract** — `id`, `metadata`, `options` (inherited from `AbstractStrategy`)
-2. **Callable contract** — `(solver)(nlp; display) → ExecutionStats`
+1. **Strategy contract** — `id`, `metadata`, `options`, `_default_parameter` (inherited from `AbstractStrategy`)
+2. **Solve contract** — `CommonSolve.solve(nlp, solver; display) → ExecutionStats`
 3. **Tag Dispatch** — separates type definition from backend implementation
+
+Solvers are **parameterized** by an execution parameter `P <: AbstractStrategyParameter`
+(see Strategy Parameters in CTBase.jl documentation). `Solvers.Ipopt{P<:CPU}` is CPU-only;
+`Solvers.MadNLP` and `Solvers.MadNCL` accept `Union{CPU,GPU}`.
 
 ```text
 AbstractStrategy
@@ -24,27 +28,15 @@ AbstractStrategy
 └─ options(inst)    → StrategyOptions
 
 AbstractNLPSolver <: AbstractStrategy
-└─ (solver)(nlp; display) → ExecutionStats
-   ├─► Solvers.Ipopt
-   ├─► Solvers.MadNLP
-   ├─► Solvers.MadNCL
+└─ CommonSolve.solve(nlp, solver; display) → ExecutionStats
+   ├─► Solvers.Ipopt{P<:CPU}
+   ├─► Solvers.MadNLP{P<:Union{CPU,GPU}}
+   ├─► Solvers.MadNCL{P<:Union{CPU,GPU}}
    ├─► Solvers.Knitro
    └─► Solvers.Uno
 ```
 
-The default callable throws `NotImplemented` with guidance.
-
-```@example solver
-using CTSolvers
-using CTBase: CTBase
-nothing # hide
-```
-
-Without the extension loaded, constructing a solver throws `ExtensionError`:
-
-```@repl solver
-CTSolvers.Solvers.Ipopt()
-```
+The generic stub throws `NotImplemented` until a backend extension provides the typed method. Without the extension loaded, constructing a solver throws `ExtensionError`.
 
 ## Implementing the Solver Type
 
@@ -57,35 +49,56 @@ A **tag type** is a lightweight struct used for dispatch. It routes the construc
 struct IpoptTag <: AbstractTag end
 ```
 
-### Step 2 — Define the struct
+### Step 2 — Define the parameterized struct
 
-Like any strategy, the solver has a single `options` field:
+Like any strategy, the solver has a single `options` field. It is parameterized by its
+execution parameter — Ipopt supports CPU only:
 
 ```julia
-struct Solvers.Ipopt <: AbstractNLPSolver
+# In module Solvers (src/Solvers/ipopt.jl)
+struct Ipopt{P<:CPU} <: AbstractNLPSolver
     options::CTBase.Strategies.StrategyOptions
 end
 ```
 
-### Step 3 — Implement `id`
+### Step 3 — Implement `id` and the default parameter
 
-The `id` is available even without the extension:
+The `id` is available even without the extension. `_default_parameter` tells the
+unparameterized constructor which parameter to use:
 
 ```@example solver
+using CTSolvers
+using CTBase
 CTBase.Strategies.id(CTSolvers.Solvers.Ipopt)
 ```
 
-### Step 4 — Constructor with Tag Dispatch
+```julia
+CTBase.Strategies._default_parameter(::Type{<:Solvers.Ipopt}) = CPU
+```
 
-The constructor delegates to a `build_*` function that dispatches on the tag. The stub in `src/` throws an `ExtensionError` if the extension is not loaded:
+### Step 4 — Constructors with Tag Dispatch
+
+The unparameterized constructor resolves the default parameter, then delegates to the
+parameterized one, which calls a `build_*` function dispatching on the **tag and parameter
+types** (passed as types, not instances). The stub in `src/` throws an `ExtensionError`
+until the extension is loaded:
 
 ```julia
+# Unparameterized → resolve the default parameter
 function Solvers.Ipopt(; mode::Symbol = :strict, kwargs...)
-    return build_ipopt_solver(IpoptTag(); mode = mode, kwargs...)
+    P = CTBase.Strategies._default_parameter(Solvers.Ipopt)
+    return Solvers.Ipopt{P}(; mode = mode, kwargs...)
+end
+
+# Parameterized → tag dispatch, IpoptTag and P passed as TYPES
+function Solvers.Ipopt{P}(; mode::Symbol = :strict, kwargs...) where {P<:CPU}
+    return build_ipopt_solver(IpoptTag, P; mode = mode, kwargs...)
 end
 
 # Stub — real implementation in ext/CTSolversIpopt.jl
-function build_ipopt_solver(::AbstractTag; kwargs...)
+function build_ipopt_solver(
+    ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
+)
     throw(Exceptions.ExtensionError(
         :NLPModelsIpopt;
         message = "to create Solvers.Ipopt, access options, and solve problems",
@@ -98,35 +111,78 @@ end
 Live demonstration of the `ExtensionError` for all solvers:
 
 ```@repl solver
+try # hide
 CTSolvers.Solvers.MadNLP()
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 !!! note "Why Tag Dispatch?"
-    The `metadata` (option definitions) and the callable (backend call) both live in the extension. The tag type allows the constructor in `src/` to dispatch to the extension without a direct dependency on the backend package.
+    The `metadata` (option definitions) and the solve method (backend call) both live in the extension. The tag type allows the constructor in `src/` to dispatch to the extension without a direct dependency on the backend package.
 
 ## The Tag Dispatch Pattern
 
-```text
-src/Solvers/ipopt.jl                    ext/CTSolversIpopt.jl
-────────────────────────────────────    ──────────────────────────────────────
-Solvers.Ipopt <: AbstractNLPSolver      metadata(::Type{<:Solvers.Ipopt})
-IpoptTag      <: AbstractTag              → StrategyMetadata(option defs...)
+**`src/Solvers/ipopt.jl`** — type definition and stubs, always loaded with CTSolvers:
 
-Solvers.Ipopt(; kwargs...)              build_ipopt_solver(::IpoptTag; kwargs...)
-  → build_ipopt_solver(IpoptTag(); …)     → Solvers.Ipopt(validated_opts)
+```julia
+struct IpoptTag <: Core.AbstractTag end
 
-build_ipopt_solver(::AbstractTag; …)    (solver::Solvers.Ipopt)(nlp; display)
-  → ExtensionError(:NLPModelsIpopt)       → ipopt(nlp; opts...)
+struct Ipopt{P<:CPU} <: AbstractNLPSolver
+    options::CTBase.Strategies.StrategyOptions
+end
+
+CTBase.Strategies.id(::Type{<:Solvers.Ipopt}) = :ipopt
+CTBase.Strategies._default_parameter(::Type{<:Solvers.Ipopt}) = CPU
+
+# Constructors — resolve the parameter, then dispatch via tag (types, not instances)
+Solvers.Ipopt(; mode = :strict, kwargs...) =
+    Solvers.Ipopt{CTBase.Strategies._default_parameter(Solvers.Ipopt)}(; mode, kwargs...)
+
+Solvers.Ipopt{P}(; mode = :strict, kwargs...) where {P<:CPU} =
+    build_ipopt_solver(IpoptTag, P; mode, kwargs...)
+
+# Stub — throws until NLPModelsIpopt is loaded
+build_ipopt_solver(::Type{<:Core.AbstractTag}, ::Type{<:AbstractStrategyParameter}; kwargs...) =
+    throw(Exceptions.ExtensionError(:NLPModelsIpopt))
 ```
 
-The split is:
+**`ext/CTSolversIpopt.jl`** — real implementations, loaded only with `using NLPModelsIpopt`:
 
-| Location | Contains |
-|----------|----------|
-| `src/Solvers/ipopt.jl` | Struct, `id`, tag, constructor stub, `ExtensionError` fallback |
-| `ext/CTSolversIpopt.jl` | `metadata` (option definitions), `build_ipopt_solver` (real constructor), callable `(solver)(nlp)` |
+```julia
+# Option definitions (parameterized on P)
+CTBase.Strategies.metadata(::Type{Solvers.Ipopt{P}}) where {P<:CPU} = StrategyMetadata(...)
+
+# Real constructor — validates options for the parameterized type and builds the struct
+build_ipopt_solver(::Type{Solvers.IpoptTag}, parameter::Type{<:AbstractStrategyParameter}; mode, kwargs...) =
+    Solvers.Ipopt{parameter}(CTBase.Strategies.build_strategy_options(Solvers.Ipopt{parameter}; mode, kwargs...))
+
+# Solve method — dispatches on NLP type and solver type
+CommonSolve.solve(nlp::NLPModels.AbstractNLPModel, solver::Solvers.Ipopt; display = true) =
+    solve_with_ipopt(nlp; options_dict(solver)...)
+```
 
 This keeps CTSolvers lightweight — `NLPModelsIpopt` is only loaded when the user does `using NLPModelsIpopt`.
+
+### Parameterization `{P}`
+
+The execution parameter `P` flows through the whole chain — constructor, `build_*`, and
+`metadata` — so a single implementation covers every supported backend. A GPU-capable
+solver simply widens the bound and provides GPU-specific defaults through the
+parameterized metadata:
+
+```julia
+struct MadNLP{P<:Union{CPU,GPU}} <: AbstractNLPSolver
+    options::CTBase.Strategies.StrategyOptions
+end
+
+# GPU-specific option defaults selected by the parameter
+CTBase.Strategies.metadata(::Type{Solvers.MadNLP{GPU}}) = StrategyMetadata(...)  # CUDA defaults
+
+Solvers.MadNLP{GPU}(max_iter = 1000)   # requires the CUDA-related extensions
+```
+
+See the Strategy Parameters guide in CTBase.jl documentation for the full parameter contract.
 
 ## Creating the Extension
 
@@ -151,7 +207,7 @@ CTSolversIpopt = "NLPModelsIpopt"
 
 The extension module provides three things:
 
-**1. Metadata** — option definitions with types, defaults, validators:
+**1. Metadata** — option definitions with types, defaults, validators (parameterized on `P`):
 
 ```julia
 module CTSolversIpopt
@@ -160,7 +216,7 @@ using CTSolvers, CTSolvers.Solvers, CTBase.Strategies, CTBase.Options
 using CTBase.Exceptions
 using NLPModelsIpopt, NLPModels, SolverCore
 
-function CTBase.Strategies.metadata(::Type{<:Solvers.Ipopt})
+function CTBase.Strategies.metadata(::Type{Solvers.Ipopt{P}}) where {P<:CPU}
     return CTBase.Strategies.StrategyMetadata(
         CTBase.Options.OptionDefinition(
             name = :tol,
@@ -182,20 +238,26 @@ function CTBase.Strategies.metadata(::Type{<:Solvers.Ipopt})
 end
 ```
 
-**2. Constructor** — builds validated options and returns the solver:
+**2. Constructor** — builds validated options for the parameterized type and returns the solver:
 
 ```julia
-function Solvers.build_ipopt_solver(::Solvers.IpoptTag; mode::Symbol = :strict, kwargs...)
-    opts = CTBase.Strategies.build_strategy_options(Solvers.Ipopt; mode = mode, kwargs...)
-    return Solvers.Ipopt(opts)
+function Solvers.build_ipopt_solver(
+    ::Type{Solvers.IpoptTag},
+    parameter::Type{<:AbstractStrategyParameter};
+    mode::Symbol = :strict,
+    kwargs...,
+)
+    opts = CTBase.Strategies.build_strategy_options(Solvers.Ipopt{parameter}; mode = mode, kwargs...)
+    return Solvers.Ipopt{parameter}(opts)
 end
 ```
 
-**3. Callable** — solves the NLP problem using the backend:
+**3. Solve method** — implements `CommonSolve.solve` dispatching on the NLP type and solver type:
 
 ```julia
-function (solver::Solvers.Ipopt)(
-    nlp::NLPModels.AbstractNLPModel;
+function CommonSolve.solve(
+    nlp::NLPModels.AbstractNLPModel,
+    solver::Solvers.Ipopt;
     display::Bool = true,
 )::SolverCore.GenericExecutionStats
     options = CTBase.Strategies.options_dict(solver)
@@ -204,8 +266,8 @@ function (solver::Solvers.Ipopt)(
 end
 
 function solve_with_ipopt(nlp::NLPModels.AbstractNLPModel; kwargs...)
-    solver = NLPModelsIpopt.Solvers.Ipopt(nlp)
-    return NLPModelsIpopt.solve!(solver, nlp; kwargs...)
+    ipopt_solver = NLPModelsIpopt.IpoptSolver(nlp)
+    return NLPModelsIpopt.solve!(ipopt_solver, nlp; kwargs...)
 end
 
 end # module CTSolversIpopt
@@ -216,20 +278,19 @@ end # module CTSolversIpopt
 
 ## CommonSolve Integration
 
-CTSolvers provides a unified `CommonSolve.solve` interface at three levels:
+CTSolvers provides a unified `CommonSolve.solve` interface at two levels:
 
 ```text
-High-level:  solve(problem, x0, modeler, solver)
+High-level:  solve(problem, x0, modeler, solver)          ← orchestration.jl
                 │
-                ├─► build_model(problem, x0, modeler) → NLP
+                ├─► build_model(problem, x0, modeler)     → BuiltModel
                 │
-                ├─► solve(nlp, solver) → ExecutionStats     ← Mid-level
-                │       └─► solver(nlp; display)
+                ├─► CommonSolve.solve(built.nlp, solver)  → ExecutionStats
                 │
-                └─► build_solution(problem, stats, modeler) → OCP Solution
+                └─► build_solution(built, stats, modeler) → OCP Solution
 
-Low-level:   solve(any, solver)
-                └─► solver(any; display)
+Mid-level:   CommonSolve.solve(nlp, solver; display)      ← backend extension
+                → ExecutionStats
 ```
 
 ### High-level: full pipeline
@@ -239,26 +300,19 @@ using CommonSolve
 
 solution = solve(problem, x0, modeler, solver)
 # Internally:
-#   1. nlp = build_model(problem, x0, modeler)
-#   2. stats = solve(nlp, solver)
-#   3. solution = build_solution(problem, stats, modeler)
+#   1. built = build_model(problem, x0, modeler)
+#   2. stats = CommonSolve.solve(built.nlp, solver)
+#   3. solution = build_solution(built, stats, modeler)
 ```
 
 ### Mid-level: NLP → Stats
 
 ```julia
-using ADNLPModels
+using ADNLPModels, NLPModelsIpopt
 
 nlp = ADNLPModel(x -> sum(x.^2), zeros(10))
 solver = CTSolvers.Solvers.Ipopt(max_iter = 1000)
-stats = solve(nlp, solver; display = false)
-```
-
-### Low-level: flexible dispatch
-
-```julia
-stats = solve(any_compatible_object, solver; display = false)
-# Calls solver(any_compatible_object; display = false)
+stats = CommonSolve.solve(nlp, solver; display = false)
 ```
 
 ## Summary: Adding a New Solver
@@ -267,17 +321,17 @@ To add a new solver (e.g., `MySolver` backed by `MyBackend`):
 
 ### In `src/Solvers/`
 
-1. Define `MyTag <: AbstractTag`
-2. Define `MySolver <: AbstractNLPSolver` with `options::CTBase.Strategies.StrategyOptions`
-3. Implement `CTBase.Strategies.id(::Type{<:MySolver}) = :my_solver`
-4. Write constructor: `MySolver(; mode, kwargs...) = build_my_solver(MyTag(); mode, kwargs...)`
-5. Write stub: `build_my_solver(::AbstractTag; kwargs...) = throw(ExtensionError(...))`
+1. Define `MyTag <: Core.AbstractTag`
+2. Define the parameterized struct `MySolver{P<:CPU} <: AbstractNLPSolver` with `options::CTBase.Strategies.StrategyOptions` (widen the bound to `Union{CPU,GPU}` for GPU-capable backends)
+3. Implement `CTBase.Strategies.id(::Type{<:MySolver}) = :my_solver` and `CTBase.Strategies._default_parameter(::Type{<:MySolver}) = CPU`
+4. Write the constructor chain: `MySolver(; ...)` → `MySolver{P}(; ...)` → `build_my_solver(MyTag, P; mode, kwargs...)`
+5. Write stub: `build_my_solver(::Type{<:Core.AbstractTag}, ::Type{<:AbstractStrategyParameter}; kwargs...) = throw(ExtensionError(...))`
 
 ### In `ext/CTSolversMyBackend.jl`
 
-6. Implement `CTBase.Strategies.metadata(::Type{<:MySolver})` with all option definitions
-7. Implement `Solvers.build_my_solver(::Solvers.MyTag; kwargs...)` — real constructor
-8. Implement `(solver::Solvers.MySolver)(nlp; display)` — callable that invokes the backend
+6. Implement `CTBase.Strategies.metadata(::Type{MySolver{P}}) where {P<:CPU}` with all option definitions
+7. Implement `Solvers.build_my_solver(::Type{Solvers.MyTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...)` — real constructor
+8. Implement `CommonSolve.solve(nlp, solver::MySolver; display)` — solve method invoking the backend
 
 ### In `Project.toml`
 
@@ -286,6 +340,5 @@ To add a new solver (e.g., `MySolver` backed by `MyBackend`):
 ### Tests
 
 10. **Contract test**: `CTBase.Strategies.id(MySolver)`, `CTBase.Strategies.metadata(MySolver)`, and `CTBase.Strategies.options(MySolver())` (requires extension loaded)
-11. **Callable test**: `solver(nlp; display = false)` returns `AbstractExecutionStats`
-12. **CommonSolve test**: `solve(nlp, solver)` works at mid-level
-13. **Extension error test**: without `using MyBackend`, `MySolver()` throws `ExtensionError`
+11. **Solve test**: `CommonSolve.solve(nlp, solver; display = false)` returns `AbstractExecutionStats`
+12. **Extension error test**: without `using MyBackend`, `MySolver()` throws `ExtensionError`

--- a/docs/src/guides/implementing_an_integrator.md
+++ b/docs/src/guides/implementing_an_integrator.md
@@ -17,27 +17,21 @@ An integrator must satisfy **three contracts**:
 2. **Solve contract** — `CommonSolve.solve(prob, integrator; options, unsafe) → AbstractIntegrationResult`
 3. **Tag Dispatch** — separates type definition from backend implementation
 
-```mermaid
-classDiagram
-    class AbstractStrategy {
-        <<abstract>>
-        id(::Type)::Symbol
-        metadata(::Type)::StrategyMetadata
-        options(instance)::StrategyOptions
-    }
+```text
+AbstractStrategy
+├─ id(::Type)       → Symbol
+├─ metadata(::Type) → StrategyMetadata
+└─ options(inst)    → StrategyOptions
 
-    class AbstractIntegrator {
-        <<abstract>>
-        solve(prob, integ; options, unsafe) → AbstractIntegrationResult
-        merge(segments) → AbstractIntegrationResult
-    }
-
-    AbstractStrategy <|-- AbstractIntegrator
-    AbstractIntegrator <|-- Integrators.AbstractSciMLIntegrator
-    Integrators.AbstractSciMLIntegrator <|-- Integrators.SciML
+AbstractIntegrator <: AbstractStrategy
+└─ solve(prob, integ; options, unsafe) → AbstractIntegrationResult
+   └─► AbstractSciMLIntegrator
+           └─► Integrators.SciML
 ```
 
-Unlike the NLP solver, there is **no callable** — the solve contract is expressed directly as `CommonSolve.solve` methods, problem-first, exactly like the mid-level `solve(nlp, solver)` of the NLP side. The generic stub throws `NotImplemented` with guidance.
+Unlike the NLP solver, there is **no callable** — the solve contract is expressed directly as
+`CommonSolve.solve` methods, problem-first, exactly like the mid-level `solve(nlp, solver)` of
+the NLP side. The generic stub throws `NotImplemented` with guidance.
 
 ```@example integrator
 using CTSolvers
@@ -53,7 +47,9 @@ CTSolvers.Integrators.SciML()
 
 ## The Integration Result
 
-An integrator does not return a raw ODE solution; it returns a subtype of [`Integrators.AbstractIntegrationResult`](@ref) that exposes three semantic accessors, decoupling consumers from the backend solution type:
+An integrator does not return a raw ODE solution; it returns a subtype of
+[`Integrators.AbstractIntegrationResult`](@ref) that exposes three semantic accessors,
+decoupling consumers from the backend solution type:
 
 - `final_state(r)` — the final state vector
 - `times(r)` — the vector of time points
@@ -74,7 +70,8 @@ struct SciMLTag <: Core.AbstractTag end
 
 ### Step 2 — Define the struct
 
-The integrator stores the validated `options` plus two pre-computed option dictionaries — one for *point* (final-state) integration and one for *trajectory* integration:
+The integrator stores the validated `options` plus two pre-computed option dictionaries —
+one for *point* (final-state) integration and one for *trajectory* integration:
 
 ```julia
 struct SciML{O,OP,OT} <: AbstractSciMLIntegrator
@@ -84,7 +81,9 @@ struct SciML{O,OP,OT} <: AbstractSciMLIntegrator
 end
 ```
 
-The two dictionaries are exposed through the [`options_point`](@ref) / [`options_trajectory`](@ref) accessors. Consumers (e.g. CTFlows) decide which one to pass to `solve` based on what they need; CTSolvers does not own that decision.
+The two dictionaries are exposed through the [`options_point`](@ref) / [`options_trajectory`](@ref)
+accessors. Consumers (e.g. CTFlows) decide which one to pass to `solve` based on what they need;
+CTSolvers does not own that decision.
 
 ### Step 3 — Implement `id`
 
@@ -119,25 +118,20 @@ end
 
 ## The Tag Dispatch Pattern
 
-```mermaid
-flowchart LR
-    subgraph src["src/Integrators/"]
-        Type["SciML <: AbstractSciMLIntegrator"]
-        Tag["SciMLTag <: Core.AbstractTag"]
-        Ctor["SciML(; kwargs...)\n→ build_sciml_integrator(SciMLTag; kwargs...)"]
-        Stub["build_sciml_integrator(::Type{<:AbstractTag})\n→ ExtensionError"]
-        SolveStub["solve(prob, ::AbstractIntegrator)\n→ NotImplemented"]
-    end
+```text
+src/Integrators/sciml.jl                ext/CTSolversSciMLIntegrator.jl
+────────────────────────────────────    ─────────────────────────────────────────
+SciML <: AbstractSciMLIntegrator        metadata(::Type{SciML})
+SciMLTag <: Core.AbstractTag              → StrategyMetadata(option defs...)
 
-    subgraph ext["ext/CTSolversSciMLIntegrator.jl"]
-        Meta["metadata(::Type{SciML})\n→ StrategyMetadata(...)"]
-        Build["build_sciml_integrator(::Type{SciMLTag})\n→ SciML(opts, ...)"]
-        Solve["solve(prob::AbstractODEProblem, ::SciML)\n→ SciMLIntegrationResult"]
-    end
+SciML(; kwargs...)                      build_sciml_integrator(::Type{SciMLTag}; …)
+  → build_sciml_integrator(SciMLTag; …)   → SciML(opts, options_point, options_traj)
 
-    Ctor -->|"tag dispatch"| Build
-    Stub -.->|"overridden by"| Build
-    SolveStub -.->|"overridden by"| Solve
+build_sciml_integrator(::AbstractTag)   solve(prob::AbstractODEProblem, ::SciML)
+  → ExtensionError(:OrdinaryDiffEqTsit5)  → SciMLIntegrationResult
+
+solve(prob, ::AbstractIntegrator)       SciMLIntegrationResult (with accessors)
+  → NotImplemented
 ```
 
 The split is:
@@ -154,7 +148,7 @@ This keeps CTSolvers lightweight — `SciMLBase`/`DiffEqBase` are only loaded wh
 
 ### File structure
 
-```
+```text
 ext/
 ├── CTSolversSciMLIntegrator.jl     # metadata + builder + solve + result + merge
 ├── CTSolversForwardDiff.jl         # deepvalue / real_norm for ForwardDiff.Dual
@@ -233,16 +227,19 @@ using CTSolvers
 using OrdinaryDiffEqTsit5     # activates CTSolversSciMLIntegrator + default Tsit5
 using CommonSolve
 
-integ = Integrators.SciML(alg = Tsit5())
+integ = CTSolvers.Integrators.SciML(alg = Tsit5())
 prob  = ODEProblem((u, p, t) -> -u, [1.0], (0.0, 1.0))
 
-r = solve(prob, integ)          # → SciMLIntegrationResult
-Integrators.final_state(r)      # ≈ [exp(-1)]
-Integrators.evaluate_at(r, 0.5) # ≈ [exp(-0.5)]
+r = solve(prob, integ)                  # → SciMLIntegrationResult
+CTSolvers.Integrators.final_state(r)    # ≈ [exp(-1)]
+CTSolvers.Integrators.evaluate_at(r, 0.5)  # ≈ [exp(-0.5)]
 ```
 
 !!! note "Where the domain glue lives"
-    Turning a control system/configuration into an `ODEProblem` (`build_problem`) and choosing point vs trajectory options (`build_options`) is **not** part of CTSolvers — it belongs to the consuming package (e.g. CTFlows). CTSolvers only integrates a ready-made `ODEProblem` and exposes the `options_point`/`options_trajectory` accessors.
+    Turning a control system/configuration into an `ODEProblem` (`build_problem`) and choosing
+    point vs trajectory options (`build_options`) is **not** part of CTSolvers — it belongs to
+    the consuming package (e.g. CTFlows). CTSolvers only integrates a ready-made `ODEProblem`
+    and exposes the `options_point`/`options_trajectory` accessors.
 
 ## Summary: Adding a New Integrator
 

--- a/docs/src/guides/implementing_an_integrator.md
+++ b/docs/src/guides/implementing_an_integrator.md
@@ -42,7 +42,11 @@ nothing # hide
 Without the extension loaded, constructing an integrator throws `ExtensionError`:
 
 ```@repl integrator
+try # hide
 CTSolvers.Integrators.SciML()
+catch e # hide
+showerror(IOContext(stdout, :color => false), e) # hide
+end # hide
 ```
 
 ## The Integration Result

--- a/docs/src/guides/implementing_an_optimization_problem.md
+++ b/docs/src/guides/implementing_an_optimization_problem.md
@@ -28,7 +28,7 @@ nothing # hide
 
 ## BuiltModel and NoCache
 
-`build_model` does not return a raw NLP model. It returns a [`Optimization.BuiltModel`](@ref) — an immutable bundle that carries everything `build_solution` needs:
+`build_model` does not return a raw NLP model. It returns a [`CTSolvers.Optimization.BuiltModel`](@ref) — an immutable bundle that carries everything `build_solution` needs:
 
 ```text
 BuiltModel{TP <: AbstractOptimizationProblem, TN, TC <: AbstractCache}
@@ -37,7 +37,7 @@ BuiltModel{TP <: AbstractOptimizationProblem, TN, TC <: AbstractCache}
 └─ cache::TC     — immutable build-time auxiliary
 ```
 
-[`Optimization.NoCache`](@ref) is the default `cache` for backends that produce no auxiliary data:
+[`CTSolvers.Optimization.NoCache`](@ref) is the default `cache` for backends that produce no auxiliary data:
 
 ```@example optprob
 CTSolvers.Optimization.NoCache()
@@ -66,36 +66,46 @@ The accessor `ocp_model(docp)` returns the original OCP.
 
 ### Step 2 — Construct via `discretize` (in CTDirect)
 
-`DiscretizedModel` is not constructed by calling the struct directly. The `discretize`
-function in `CTDirect.jl` creates it after preprocessing the OCP:
+`DiscretizedModel` is not constructed by calling the struct directly. CTSolvers owns a
+generic `CTSolvers.discretize` stub (`src/DOCP/contract.jl`) that throws `NotImplemented`;
+the package providing the discretizer implements the typed method. In CTDirect
+(`src/collocation.jl`) it preprocesses the OCP into a `DOCP` and wraps it in a cache:
 
 ```julia
-# In CTDirect.jl (external package)
-function discretize(ocp, discretizer::Collocation)
-    cache = DOCPCache(ocp, discretizer)   # problem-specific preprocessing
-    return CTSolvers.DOCP.DiscretizedModel(ocp, discretizer, cache)
+# In CTDirect — typed method for the Collocation discretizer
+function CTSolvers.discretize(ocp::AbstractModel, discretizer::Collocation)
+    docp = get_docp(discretizer, ocp)                        # problem-specific preprocessing
+    return CTSolvers.DiscretizedModel(ocp, discretizer, DOCPCache(docp))
 end
 ```
+
+`DOCPCache` is a `CTBase.Core.AbstractCache` subtype defined in CTDirect — CTSolvers only
+requires the `cache` field to be `<: CTBase.Core.AbstractCache`.
 
 ### Step 3 — Implement build_model / build_solution (in CTDirect)
 
 CTSolvers owns the generic stubs; CTDirect owns the concrete methods via multiple dispatch:
 
 ```julia
-# In CTDirect.jl — concrete methods for (DiscretizedModel, ADNLP)
-import CTSolvers.Optimization: build_model, build_solution, BuiltModel, NoCache
-
-function build_model(docp::DiscretizedModel, initial_guess, ::CTSolvers.Modelers.ADNLP)
-    nlp = build_adnlp_model(docp, initial_guess)   # ADNLPModel built from cache
-    return BuiltModel(docp, nlp, NoCache())
+# In CTDirect — concrete methods for (DiscretizedModel + Collocation, ADNLP)
+function CTSolvers.build_model(
+    dm::CTSolvers.DiscretizedModel{<:Any,<:Collocation},
+    initial_guess::CTModels.AbstractInitialGuess,
+    modeler::CTSolvers.Modelers.ADNLP,
+)
+    docp = dm.cache.docp
+    options = Strategies.options_dict(modeler)         # the modeler's validated options
+    nlp = build_adnlp_model(docp, initial_guess; options...)  # ADNLPModel
+    return CTSolvers.BuiltModel(dm, nlp, CTSolvers.NoCache())  # ADNLP needs no aux cache
 end
 
-function build_solution(
-    built::BuiltModel{<:DiscretizedModel},
-    stats,
+function CTSolvers.build_solution(
+    built::CTSolvers.BuiltModel{<:CTSolvers.DiscretizedModel{<:Any,<:Collocation}},
+    nlp_solution::SolverCore.AbstractExecutionStats,
     ::CTSolvers.Modelers.ADNLP,
 )
-    return extract_ocp_solution(built.problem, stats)   # OCPSolution
+    docp = built.problem.cache.docp
+    return build_OCP_solution(docp, nlp_solution)      # OCP solution
 end
 ```
 

--- a/docs/src/guides/implementing_an_optimization_problem.md
+++ b/docs/src/guides/implementing_an_optimization_problem.md
@@ -40,37 +40,18 @@ You only need to implement the getters for the backends you support. If your pro
 
 ## The Builder Pattern
 
-Builders are **callable objects** that encapsulate the logic for constructing NLP models or solutions. They are defined in the `Optimization` module.
+Builders are **callable objects** that encapsulate the logic for constructing NLP models or solutions. They are defined in the `Optimization` module:
 
-```mermaid
-classDiagram
-    class AbstractBuilder {
-        <<abstract>>
-    }
-
-    class AbstractModelBuilder {
-        <<abstract>>
-        (builder)(x0; kwargs...) → NLP
-    }
-
-    class AbstractSolutionBuilder {
-        <<abstract>>
-        (builder)(stats) → Solution
-    }
-
-    class AbstractOCPSolutionBuilder {
-        <<abstract>>
-        (builder)(stats) → OCPSolution
-    }
-
-    AbstractBuilder <|-- AbstractModelBuilder
-    AbstractBuilder <|-- AbstractSolutionBuilder
-    AbstractSolutionBuilder <|-- AbstractOCPSolutionBuilder
-
-    AbstractModelBuilder <|-- ADNLPModelBuilder
-    AbstractModelBuilder <|-- ExaModelBuilder
-    AbstractOCPSolutionBuilder <|-- ADNLPSolutionBuilder
-    AbstractOCPSolutionBuilder <|-- ExaSolutionBuilder
+```text
+AbstractBuilder
+├─► AbstractModelBuilder
+│       ├─ (builder)(x0; kwargs...) → NLP
+│       ├─► ADNLPModelBuilder
+│       └─► ExaModelBuilder
+└─► AbstractSolutionBuilder
+        └─► AbstractOCPSolutionBuilder
+                ├─► ADNLPSolutionBuilder
+                └─► ExaSolutionBuilder
 ```
 
 ### ADNLPModelBuilder
@@ -116,7 +97,9 @@ sol_builder(:converged)  # call the builder
 ```
 
 !!! note "Why callable objects?"
-    Builders capture problem-specific data (closures) while presenting a uniform interface to modelers. The modeler doesn't need to know what data the builder needs — it just calls it with the standard arguments.
+    Builders capture problem-specific data (closures) while presenting a uniform interface to
+    modelers. The modeler doesn't need to know what data the builder needs — it just calls it
+    with the standard arguments.
 
 ## Implementing DiscretizedModel
 
@@ -148,10 +131,10 @@ Each getter simply returns the corresponding field:
 import CTSolvers.Optimization: get_adnlp_model_builder, get_exa_model_builder
 import CTSolvers.Optimization: get_adnlp_solution_builder, get_exa_solution_builder
 
-get_adnlp_model_builder(prob::DiscretizedModel) = prob.adnlp_model_builder
-get_exa_model_builder(prob::DiscretizedModel) = prob.exa_model_builder
+get_adnlp_model_builder(prob::DiscretizedModel)    = prob.adnlp_model_builder
+get_exa_model_builder(prob::DiscretizedModel)      = prob.exa_model_builder
 get_adnlp_solution_builder(prob::DiscretizedModel) = prob.adnlp_solution_builder
-get_exa_solution_builder(prob::DiscretizedModel) = prob.exa_solution_builder
+get_exa_solution_builder(prob::DiscretizedModel)   = prob.exa_solution_builder
 ```
 
 ### Step 3 — Construct with builders
@@ -179,34 +162,21 @@ end
 
 The complete data flow from user call to solution:
 
-```mermaid
-sequenceDiagram
-    participant User
-    participant Solve as CommonSolve.solve
-    participant Modeler as Modelers.ADNLP
-    participant Problem as DOCP
-    participant ModelBuilder as ADNLPModelBuilder
-    participant Solver as Solvers.Ipopt
-    participant SolBuilder as ADNLPSolutionBuilder
-
-    User->>Solve: solve(docp, x0, modeler, solver)
-    Solve->>Modeler: build_model(docp, x0, modeler)
-    Modeler->>Problem: get_adnlp_model_builder(docp)
-    Problem-->>Modeler: ADNLPModelBuilder
-    Modeler->>ModelBuilder: builder(x0; backend=:optimized, ...)
-    ModelBuilder-->>Modeler: ADNLPModel
-    Modeler-->>Solve: nlp
-
-    Solve->>Solver: solve(nlp, solver)
-    Solver-->>Solve: stats
-
-    Solve->>Modeler: build_solution(docp, stats, modeler)
-    Modeler->>Problem: get_adnlp_solution_builder(docp)
-    Problem-->>Modeler: ADNLPSolutionBuilder
-    Modeler->>SolBuilder: builder(stats)
-    SolBuilder-->>Modeler: OCPSolution
-    Modeler-->>Solve: solution
-    Solve-->>User: solution
+```text
+User
+ │
+ ▼  solve(docp, x0, modeler, solver)
+CommonSolve.solve
+ │
+ ├─► build_model(docp, x0, modeler)
+ │       ├─► get_adnlp_model_builder(docp) → ADNLPModelBuilder
+ │       └─► builder(x0; backend=:optimized, ...) → ADNLPModel
+ │
+ ├─► solve(nlp, solver) → ExecutionStats
+ │
+ └─► build_solution(docp, stats, modeler)
+         ├─► get_adnlp_solution_builder(docp) → ADNLPSolutionBuilder
+         └─► builder(stats) → OCPSolution
 ```
 
 The key insight is that the **problem provides the builders** and the **modeler orchestrates the calls**. This separation allows:

--- a/docs/src/guides/implementing_an_optimization_problem.md
+++ b/docs/src/guides/implementing_an_optimization_problem.md
@@ -4,23 +4,21 @@
 CurrentModule = CTSolvers
 ```
 
-This guide explains how to implement an optimization problem in CTSolvers. An optimization problem is a concrete type that carries all the data needed to build NLP models and extract solutions. We use **DiscretizedModel** (DOCP) as the reference example.
+This guide explains how to implement an optimization problem in CTSolvers. An optimization problem is a concrete subtype of `AbstractOptimizationProblem` that pairs problem data with a discretizer and a backend-opaque cache. We use **DiscretizedModel** (DOCP) as the reference implementation.
 
 !!! tip "Prerequisites"
-    Read [Architecture](@ref) and [Implementing a Modeler](@ref) first. The optimization problem provides the **builders** that modelers call.
+    Read [Architecture](@ref) and [Implementing a Modeler](@ref) first. The optimization problem is the data holder; the modeler and the package providing the problem (e.g. CTDirect) implement the NLP building logic.
 
 ## The AbstractOptimizationProblem Contract
 
-Every concrete optimization problem must implement **four builder getters** — one model builder and one solution builder per NLP backend:
+`AbstractOptimizationProblem` is a marker abstract type with **no required methods of its own**. The contract is expressed through two generic functions that must be implemented by **multiple dispatch** in the package providing the concrete problem:
 
-| Method | Returns | Used by |
-|--------|---------|---------|
-| `get_adnlp_model_builder(prob)` | `AbstractModelBuilder` | `Modelers.ADNLP` |
-| `get_exa_model_builder(prob)` | `AbstractModelBuilder` | `Modelers.Exa` |
-| `get_adnlp_solution_builder(prob)` | `AbstractSolutionBuilder` | `Modelers.ADNLP` |
-| `get_exa_solution_builder(prob)` | `AbstractSolutionBuilder` | `Modelers.Exa` |
+| Method | Signature | Returns | Implemented in |
+|--------|-----------|---------|----------------|
+| `build_model` | `(prob::MyProblem, init, modeler::ADNLP)` | `BuiltModel` | package providing `MyProblem` |
+| `build_solution` | `(built::BuiltModel{<:MyProblem}, stats, modeler::ADNLP)` | domain solution | package providing `MyProblem` |
 
-All four have default implementations that throw `NotImplemented`:
+The generic stubs in CTSolvers throw `NotImplemented` with guidance. Defining a subtype without these methods is valid — the error only fires when the pipeline is actually invoked:
 
 ```@example optprob
 using CTSolvers
@@ -28,133 +26,76 @@ struct EmptyProblem <: CTSolvers.Optimization.AbstractOptimizationProblem end
 nothing # hide
 ```
 
-```@repl optprob
-CTSolvers.Optimization.get_adnlp_model_builder(EmptyProblem())
-```
+## BuiltModel and NoCache
 
-```@repl optprob
-CTSolvers.Optimization.get_exa_solution_builder(EmptyProblem())
-```
-
-You only need to implement the getters for the backends you support. If your problem only supports ADNLPModels, leave the ExaModels getters unimplemented — they will throw a clear error if called.
-
-## The Builder Pattern
-
-Builders are **callable objects** that encapsulate the logic for constructing NLP models or solutions. They are defined in the `Optimization` module:
+`build_model` does not return a raw NLP model. It returns a [`Optimization.BuiltModel`](@ref) — an immutable bundle that carries everything `build_solution` needs:
 
 ```text
-AbstractBuilder
-├─► AbstractModelBuilder
-│       ├─ (builder)(x0; kwargs...) → NLP
-│       ├─► ADNLPModelBuilder
-│       └─► ExaModelBuilder
-└─► AbstractSolutionBuilder
-        └─► AbstractOCPSolutionBuilder
-                ├─► ADNLPSolutionBuilder
-                └─► ExaSolutionBuilder
+BuiltModel{TP <: AbstractOptimizationProblem, TN, TC <: AbstractCache}
+├─ problem::TP   — the original problem (gives access to ocp, discretizer, cache)
+├─ nlp::TN       — the backend NLP model (ADNLPModel, ExaModel, …)
+└─ cache::TC     — immutable build-time auxiliary
 ```
 
-### ADNLPModelBuilder
-
-Wraps a function that builds an `ADNLPModel` from an initial guess:
+[`Optimization.NoCache`](@ref) is the default `cache` for backends that produce no auxiliary data:
 
 ```@example optprob
-using CTSolvers.Optimization: ADNLPModelBuilder
-
-builder = ADNLPModelBuilder(x0 -> "NLP from x0=$x0")
+CTSolvers.Optimization.NoCache()
 ```
-
-```@example optprob
-builder([1.0, 2.0])  # call the builder
-```
-
-### ExaModelBuilder
-
-Wraps a function that builds an `ExaModel` from a base type and initial guess:
-
-```@example optprob
-using CTSolvers.Optimization: ExaModelBuilder
-
-exa_builder = ExaModelBuilder((T, x0) -> "ExaModel{$T} from x0=$x0")
-```
-
-```@example optprob
-exa_builder(Float64, [1.0, 2.0])  # call the builder
-```
-
-### Solution Builders
-
-Same pattern for solution builders:
-
-```@example optprob
-using CTSolvers.Optimization: ADNLPSolutionBuilder
-
-sol_builder = ADNLPSolutionBuilder(stats -> "Solution from stats=$stats")
-```
-
-```@example optprob
-sol_builder(:converged)  # call the builder
-```
-
-!!! note "Why callable objects?"
-    Builders capture problem-specific data (closures) while presenting a uniform interface to
-    modelers. The modeler doesn't need to know what data the builder needs — it just calls it
-    with the standard arguments.
 
 ## Implementing DiscretizedModel
 
-### Step 1 — Define the struct
+`DiscretizedModel` is the canonical `AbstractOptimizationProblem` implementation in CTSolvers.
+It pairs an OCP with the discretizer that produced it and a backend-opaque cache:
 
-The DOCP stores the original OCP plus one builder per backend:
+### Step 1 — Define the struct
 
 ```julia
 struct DiscretizedModel{
-    TO <: AbstractModel,
-    TAMB <: AbstractModelBuilder,
-    TEMB <: AbstractModelBuilder,
-    TASB <: AbstractSolutionBuilder,
-    TESB <: AbstractSolutionBuilder,
+    TO <: CTModels.AbstractModel,
+    TD <: AbstractDiscretizer,
+    TC <: CTBase.Core.AbstractCache,
 } <: AbstractOptimizationProblem
-    optimal_control_problem::TO
-    adnlp_model_builder::TAMB
-    exa_model_builder::TEMB
-    adnlp_solution_builder::TASB
-    exa_solution_builder::TESB
+    ocp::TO          # original OCP
+    discretizer::TD  # e.g. Collocation
+    cache::TC        # opaque to CTSolvers; populated by the discretizing package
 end
 ```
 
-### Step 2 — Implement the contract
+The accessor `ocp_model(docp)` returns the original OCP.
 
-Each getter simply returns the corresponding field:
+### Step 2 — Construct via `discretize` (in CTDirect)
 
-```julia
-import CTSolvers.Optimization: get_adnlp_model_builder, get_exa_model_builder
-import CTSolvers.Optimization: get_adnlp_solution_builder, get_exa_solution_builder
-
-get_adnlp_model_builder(prob::DiscretizedModel)    = prob.adnlp_model_builder
-get_exa_model_builder(prob::DiscretizedModel)      = prob.exa_model_builder
-get_adnlp_solution_builder(prob::DiscretizedModel) = prob.adnlp_solution_builder
-get_exa_solution_builder(prob::DiscretizedModel)   = prob.exa_solution_builder
-```
-
-### Step 3 — Construct with builders
-
-The DOCP is typically constructed by a discretization strategy (e.g., Collocation) that creates the builders from the OCP:
+`DiscretizedModel` is not constructed by calling the struct directly. The `discretize`
+function in `CTDirect.jl` creates it after preprocessing the OCP:
 
 ```julia
 # In CTDirect.jl (external package)
 function discretize(ocp, discretizer::Collocation)
-    # Build the closures that know how to create NLP models from this OCP
-    adnlp_builder = ADNLPModelBuilder(x0 -> build_adnlp(ocp, discretizer, x0))
-    exa_builder = ExaModelBuilder((T, x0) -> build_exa(ocp, discretizer, T, x0))
+    cache = DOCPCache(ocp, discretizer)   # problem-specific preprocessing
+    return CTSolvers.DOCP.DiscretizedModel(ocp, discretizer, cache)
+end
+```
 
-    # Build the closures that know how to extract solutions
-    adnlp_sol_builder = ADNLPSolutionBuilder(stats -> extract_solution(ocp, discretizer, stats))
-    exa_sol_builder = ExaSolutionBuilder(stats -> extract_solution(ocp, discretizer, stats))
+### Step 3 — Implement build_model / build_solution (in CTDirect)
 
-    return DiscretizedModel(
-        ocp, adnlp_builder, exa_builder, adnlp_sol_builder, exa_sol_builder,
-    )
+CTSolvers owns the generic stubs; CTDirect owns the concrete methods via multiple dispatch:
+
+```julia
+# In CTDirect.jl — concrete methods for (DiscretizedModel, ADNLP)
+import CTSolvers.Optimization: build_model, build_solution, BuiltModel, NoCache
+
+function build_model(docp::DiscretizedModel, initial_guess, ::CTSolvers.Modelers.ADNLP)
+    nlp = build_adnlp_model(docp, initial_guess)   # ADNLPModel built from cache
+    return BuiltModel(docp, nlp, NoCache())
+end
+
+function build_solution(
+    built::BuiltModel{<:DiscretizedModel},
+    stats,
+    ::CTSolvers.Modelers.ADNLP,
+)
+    return extract_ocp_solution(built.problem, stats)   # OCPSolution
 end
 ```
 
@@ -169,33 +110,28 @@ User
 CommonSolve.solve
  │
  ├─► build_model(docp, x0, modeler)
- │       ├─► get_adnlp_model_builder(docp) → ADNLPModelBuilder
- │       └─► builder(x0; backend=:optimized, ...) → ADNLPModel
+ │       │
+ │       ├─► (CTDirect) build_adnlp_model(docp, x0)  →  ADNLPModel
+ │       └─► BuiltModel(docp, nlp, NoCache())
  │
  ├─► solve(nlp, solver) → ExecutionStats
  │
- └─► build_solution(docp, stats, modeler)
-         ├─► get_adnlp_solution_builder(docp) → ADNLPSolutionBuilder
-         └─► builder(stats) → OCPSolution
+ └─► build_solution(built, stats, modeler)
+         └─► (CTDirect) extract_ocp_solution(docp, stats)  →  OCPSolution
 ```
 
-The key insight is that the **problem provides the builders** and the **modeler orchestrates the calls**. This separation allows:
+Separation of responsibilities:
 
-- Different problem types to provide different builders
-- The same modeler to work with any problem that implements the contract
-- Builders to capture problem-specific data without exposing it to the modeler
+- **CTSolvers** declares `build_model`/`build_solution` and owns the `NotImplemented` stubs
+- **CTDirect** provides the concrete methods dispatched on `(DiscretizedModel, ADNLP/Exa)`
+- **CTSolvers** orchestrates the pipeline in `CommonSolve.solve` without knowing NLP internals
 
 ## Summary: Adding a New Optimization Problem
 
-To add a new optimization problem type:
+To add a new optimization problem type that plugs into the CTSolvers pipeline:
 
-1. Define `MyProblem <: AbstractOptimizationProblem` with fields for your problem data and builders
-2. Implement `get_adnlp_model_builder(prob::MyProblem)` — return an `ADNLPModelBuilder`
-3. Implement `get_adnlp_solution_builder(prob::MyProblem)` — return an `ADNLPSolutionBuilder`
-4. Optionally implement `get_exa_model_builder` and `get_exa_solution_builder` for ExaModels support
-5. Create a construction function that builds the builders from your problem data
-
-The builders should be callable objects that:
-
-- **Model builders**: take `(initial_guess; kwargs...)` and return an NLP model
-- **Solution builders**: take `(nlp_stats)` and return a problem-specific solution
+1. Define `MyProblem <: AbstractOptimizationProblem` with your data fields
+2. Implement `CTSolvers.Optimization.build_model(prob::MyProblem, init, modeler::ADNLP)` returning a `BuiltModel`
+3. Implement `CTSolvers.Optimization.build_solution(built::BuiltModel{<:MyProblem}, stats, modeler::ADNLP)` returning your domain solution
+4. Optionally add methods for other modelers (`Exa`, future backends) following the same dispatch pattern
+5. If `build_model` produces auxiliary data needed by `build_solution`, store it in a custom `<: CTBase.Core.AbstractCache` subtype rather than `NoCache`

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -31,9 +31,6 @@
 
 | Module | Responsibility |
 |--------|---------------|
-| `CTBase.Options` | Option definition, extraction, validation, provenance tracking |
-| `CTBase.Strategies` | Abstract strategy contract, metadata, options, registry |
-| `CTBase.Orchestration` | Option routing, disambiguation, method tuple handling |
 | `Optimization` | Abstract problem types (`AbstractOptimizationProblem`, `BuiltModel`, `NoCache`), `build_model`/`build_solution` generic functions |
 | `Modelers` | `Modelers.ADNLP`, `Modelers.Exa` — NLP backend adapters |
 | `DOCP` | `DiscretizedModel` — concrete problem type, pairs OCP with its discretizer (from [CTDirect.jl](https://github.com/control-toolbox/CTDirect.jl)) |
@@ -47,7 +44,7 @@
 - **Developer Guides** — step-by-step tutorials for implementing each component type:
   - [Implementing a Solver](@ref) — tag dispatch, extension pattern, CommonSolve integration
   - [Implementing an Integrator](@ref) — SciML wrapper, integration result types
-  - [Implementing a Modeler](@ref) — callable contracts, `build_model`/`build_solution` dispatch
+  - [Implementing a Modeler](@ref) — strategy options, `build_model`/`build_solution` dispatch
   - [Implementing an Optimization Problem](@ref) — `AbstractOptimizationProblem` contract, `DiscretizedModel`
   - [Error Messages Reference](@ref) — all exception types with examples and fixes
 - **API Reference** — auto-generated documentation for all public and private symbols.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,19 +1,6 @@
 # CTSolvers.jl
 
-```@meta
-CurrentModule = CTSolvers
-```
-
-The `CTSolvers.jl` package is part of the [control-toolbox ecosystem](https://github.com/control-toolbox).
-It provides the **solution layer** for optimal control problems:
-
-- **CTBase.Options** — flexible configuration with provenance tracking and validation
-- **CTBase.Strategies** — two-level contract pattern for configurable components
-- **CTBase.Orchestration** — automatic option routing across multi-strategy pipelines
-- **Optimization** — abstract problem types and callable builder pattern
-- **Modelers** — NLP backend adapters (ADNLPModels, ExaModels)
-- **DOCP** — discretized optimal control problem types
-- **Solvers** — NLP solver integration (Ipopt, MadNLP, Knitro) via tag dispatch
+`CTSolvers.jl` is the **resolution layer** of the [control-toolbox](https://github.com/control-toolbox) ecosystem. It transforms optimal control problems (defined in [CTModels.jl](https://github.com/control-toolbox/CTModels.jl)) into NLP models, solves them, and converts the results back into optimal control solutions.
 
 !!! info "CTSolvers vs CTModels"
     **CTSolvers** focuses on **solving** optimal control problems (discretization, NLP backends, optimization strategies).
@@ -31,54 +18,34 @@ It provides the **solution layer** for optimal control problems:
 
     ```julia
     using CTSolvers
-    CTBase.Options.extract_options(kwargs, defs)   # ✓ Qualified
-    CTBase.Strategies.id(Solvers.Ipopt)              # ✓ Qualified
+    CTBase.Strategies.id(CTSolvers.Solvers.Ipopt)   # ✓ Qualified
+    CTSolvers.Optimization.build_model(prob, x0, m)  # ✓ Qualified
     ```
 
-## Modules
+## Module overview
 
-| Module | Purpose |
-|--------|---------|
+| Module | Responsibility |
+|--------|---------------|
 | `CTBase.Options` | Option definition, extraction, validation, provenance tracking |
 | `CTBase.Strategies` | Abstract strategy contract, metadata, options, registry |
 | `CTBase.Orchestration` | Option routing, disambiguation, method tuple handling |
 | `Optimization` | Abstract problem types, builder pattern, build/solve API |
-| `Modelers` | Modelers.ADNLP, Modelers.Exa — NLP backend adapters |
-| `DOCP` | DiscretizedModel — concrete problem type |
-| `Solvers` | Solvers.Ipopt, Solvers.MadNLP, Solvers.MadNCL, Solvers.Knitro — NLP solver wrappers |
+| `Modelers` | `Modelers.ADNLP`, `Modelers.Exa` — NLP backend adapters |
+| `DOCP` | `DiscretizedModel` — concrete problem type bridging CTModels and CTSolvers |
+| `Solvers` | `Solvers.Ipopt`, `Solvers.MadNLP`, `Solvers.MadNCL`, `Solvers.Knitro`, `Solvers.Uno` — NLP solver wrappers |
+| `Integrators` | `Integrators.SciML` — ODE integrator wrapper |
 
-## Documentation
+## How this documentation is organized
 
-### Developer Guides
+- **Getting Started** — installation and a quick-start walkthrough.
+- **Architecture** — module overview, type hierarchies, data flow, and design patterns.
+- **Developer Guides** — step-by-step tutorials for implementing each component type:
+  - [Implementing a Solver](@ref) — tag dispatch, extension pattern, CommonSolve integration
+  - [Implementing an Integrator](@ref) — SciML wrapper, integration result types
+  - [Implementing a Modeler](@ref) — callable contracts, builder interaction
+  - [Implementing an Optimization Problem](@ref) — builder pattern, DOCP example
+  - [Error Messages Reference](@ref) — all exception types with examples and fixes
+- **API Reference** — auto-generated documentation for all public and private symbols.
 
-- [Architecture](@ref) — module overview, type hierarchy, data flow
-- [Implementing a Solver](@ref) — tag dispatch, extension pattern, CommonSolve integration
-- [Implementing a Modeler](@ref) — callable contracts, builder interaction
-- [Implementing an Optimization Problem](@ref) — builder pattern, DOCP example
-- [Error Messages Reference](@ref) — all exception types with examples and fixes
-
-!!! note "Generic infrastructure guides"
-    The guides for Options, Strategies, Orchestration, and Strategy Parameters have moved to
-    [CTBase.jl documentation](https://github.com/control-toolbox/CTBase.jl) where these
-    modules now live.
-
-### API Reference
-
-Auto-generated documentation for all public and private symbols, organized by module.
-
-## Quick Start
-
-```julia
-using CTSolvers
-using NLPModelsIpopt  # loads the Ipopt extension
-
-# Create a solver with validated options
-solver = CTSolvers.Solvers.Ipopt(max_iter = 1000, tol = 1e-8)
-
-# Create a modeler
-modeler = CTSolvers.Modelers.ADNLP(backend = :optimized)
-
-# Solve (high-level API)
-using CommonSolve
-solution = solve(problem, initial_guess, modeler, solver; display = false)
-```
+!!! tip "Ask DeepWiki"
+    [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/control-toolbox/CTSolvers.jl) offers an interactive, AI-generated overview of this codebase. Answers may be inaccurate — use this reference documentation as the source of truth.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,11 +1,16 @@
 # CTSolvers.jl
 
-`CTSolvers.jl` is the **resolution layer** of the [control-toolbox](https://github.com/control-toolbox) ecosystem. It transforms optimal control problems (defined in [CTModels.jl](https://github.com/control-toolbox/CTModels.jl)) into NLP models, solves them, and converts the results back into optimal control solutions.
+`CTSolvers.jl` is the **resolution layer** of the [control-toolbox](https://github.com/control-toolbox) ecosystem. It provides the infrastructure — solvers, modelers, integrators, and abstract problem types — used by upstream packages to solve optimal control problems.
 
-!!! info "CTSolvers vs CTModels"
-    **CTSolvers** focuses on **solving** optimal control problems (discretization, NLP backends, optimization strategies).
-    For **defining** these problems and representing their solutions,
-    see [CTModels.jl](https://github.com/control-toolbox/CTModels.jl).
+!!! info "CTSolvers and its consumers"
+    **CTSolvers** provides the *resolution infrastructure*; it does not call it directly.
+    Two packages build on top of it:
+
+    - [CTDirect.jl](https://github.com/control-toolbox/CTDirect.jl) — **direct methods**:
+      discretizes continuous-time OCPs (defined in [CTModels.jl](https://github.com/control-toolbox/CTModels.jl))
+      into finite-dimensional NLPs, then uses CTSolvers' `Solvers` and `Modelers` to solve them.
+    - [CTFlows.jl](https://github.com/control-toolbox/CTFlows.jl) — **flows for indirect methods**:
+      builds Hamiltonian flows from ODE systems and integrates them with CTSolvers' `Integrators`.
 
 !!! note
     The root package is [OptimalControl.jl](https://github.com/control-toolbox/OptimalControl.jl) which aims
@@ -29,9 +34,9 @@
 | `CTBase.Options` | Option definition, extraction, validation, provenance tracking |
 | `CTBase.Strategies` | Abstract strategy contract, metadata, options, registry |
 | `CTBase.Orchestration` | Option routing, disambiguation, method tuple handling |
-| `Optimization` | Abstract problem types, builder pattern, build/solve API |
+| `Optimization` | Abstract problem types (`AbstractOptimizationProblem`, `BuiltModel`, `NoCache`), `build_model`/`build_solution` generic functions |
 | `Modelers` | `Modelers.ADNLP`, `Modelers.Exa` — NLP backend adapters |
-| `DOCP` | `DiscretizedModel` — concrete problem type bridging CTModels and CTSolvers |
+| `DOCP` | `DiscretizedModel` — concrete problem type, pairs OCP with its discretizer (from [CTDirect.jl](https://github.com/control-toolbox/CTDirect.jl)) |
 | `Solvers` | `Solvers.Ipopt`, `Solvers.MadNLP`, `Solvers.MadNCL`, `Solvers.Knitro`, `Solvers.Uno` — NLP solver wrappers |
 | `Integrators` | `Integrators.SciML` — ODE integrator wrapper |
 
@@ -42,8 +47,8 @@
 - **Developer Guides** — step-by-step tutorials for implementing each component type:
   - [Implementing a Solver](@ref) — tag dispatch, extension pattern, CommonSolve integration
   - [Implementing an Integrator](@ref) — SciML wrapper, integration result types
-  - [Implementing a Modeler](@ref) — callable contracts, builder interaction
-  - [Implementing an Optimization Problem](@ref) — builder pattern, DOCP example
+  - [Implementing a Modeler](@ref) — callable contracts, `build_model`/`build_solution` dispatch
+  - [Implementing an Optimization Problem](@ref) — `AbstractOptimizationProblem` contract, `DiscretizedModel`
   - [Error Messages Reference](@ref) — all exception types with examples and fixes
 - **API Reference** — auto-generated documentation for all public and private symbols.
 

--- a/src/Integrators/abstract_integrator.jl
+++ b/src/Integrators/abstract_integrator.jl
@@ -21,11 +21,13 @@ Methods defined on **instances** that provide the actual configuration:
 
 Concrete integrators implement, typically in a backend extension:
 - `CommonSolve.solve(prob, integrator::S; options, unsafe)`: integrate the (external) ODE
-  problem `prob` with the resolved `options`, returning an [`AbstractIntegrationResult`](@ref).
-- [`merge`](@ref): concatenate a sequence of integration results (multi-phase trajectories).
+  problem `prob` with the resolved `options`, returning an
+  [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref).
+- [`CTSolvers.Integrators.merge`](@ref): concatenate a sequence of integration results
+  (multi-phase trajectories).
 
 The cached per-call option dictionaries are exposed through the
-[`options_point`](@ref) / [`options_trajectory`](@ref) accessors.
+[`CTSolvers.Integrators.options_point`](@ref) / [`CTSolvers.Integrators.options_trajectory`](@ref) accessors.
 
 See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref).
 """

--- a/src/Integrators/contract.jl
+++ b/src/Integrators/contract.jl
@@ -34,7 +34,7 @@ in the `CTSolversSciMLIntegrator` extension. This generic stub throws `NotImplem
 - `unsafe::Bool`: If `true`, bypass retcode checking (default: `false`).
 
 # Returns
-- An [`AbstractIntegrationResult`](@ref).
+- An [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref).
 
 # Throws
 - [`CTBase.Exceptions.NotImplemented`](@extref): until a backend extension provides the
@@ -66,7 +66,7 @@ implement this method for their specific result types, typically in a backend ex
   `T <: AbstractIntegrationResult`.
 
 # Returns
-- A single [`AbstractIntegrationResult`](@ref) representing the merged trajectory.
+- A single [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref) representing the merged trajectory.
 
 # Throws
 - [`CTBase.Exceptions.NotImplemented`](@extref): until a backend extension provides the

--- a/src/Modelers/contract.jl
+++ b/src/Modelers/contract.jl
@@ -10,13 +10,13 @@
 """
 $(TYPEDSIGNATURES)
 
-Build a [`Optimization.BuiltModel`](@ref) from an optimization problem using the
-specified modeler.
+Build a [`CTSolvers.Optimization.BuiltModel`](@ref) from an optimization problem using
+the specified modeler.
 
 This is the modeler contract: the modeler converts the problem into a backend NLP
-model. The returned [`Optimization.BuiltModel`](@ref) carries the backend NLP model
-together with any immutable build-time auxiliary needed later by
-[`Optimization.build_solution`](@ref).
+model. The returned [`CTSolvers.Optimization.BuiltModel`](@ref) carries the backend NLP
+model together with any immutable build-time auxiliary needed later by
+[`CTSolvers.Optimization.build_solution`](@ref).
 
 # Contract
 Must be implemented in the package providing the concrete problem, dispatching on the
@@ -30,13 +30,13 @@ generic stub throws [`CTBase.Exceptions.NotImplemented`](@extref).
 - `modeler::AbstractNLPModeler`: The modeler strategy (e.g. `ADNLP`, `Exa`).
 
 # Returns
-- A [`Optimization.BuiltModel`](@ref) bundling the backend NLP model and its build-time cache.
+- A [`CTSolvers.Optimization.BuiltModel`](@ref) bundling the backend NLP model and its build-time cache.
 
 # Throws
 - [`CTBase.Exceptions.NotImplemented`](@extref): when no method exists for this
   `(problem, modeler)` pair.
 
-See also: `Optimization.build_solution`, `Optimization.BuiltModel`.
+See also: [`CTSolvers.Optimization.build_solution`](@ref), [`CTSolvers.Optimization.BuiltModel`](@ref).
 """
 function Optimization.build_model(
     prob::Optimization.AbstractOptimizationProblem, initial_guess, modeler::AbstractNLPModeler
@@ -58,8 +58,9 @@ Build a problem-level solution from NLP execution statistics using the specified
 modeler.
 
 This is the modeler contract: it reconstructs the solution from the
-[`Optimization.BuiltModel`](@ref) returned by [`Optimization.build_model`](@ref)
-(which carries the problem and the immutable build-time cache) and the solver output.
+[`CTSolvers.Optimization.BuiltModel`](@ref) returned by
+[`CTSolvers.Optimization.build_model`](@ref) (which carries the problem and the
+immutable build-time cache) and the solver output.
 
 # Contract
 Must be implemented in the package providing the concrete problem, dispatching on the
@@ -79,7 +80,7 @@ in CTDirect. This generic stub throws [`CTBase.Exceptions.NotImplemented`](@extr
 - [`CTBase.Exceptions.NotImplemented`](@extref): when no method exists for this
   `(problem, modeler)` pair.
 
-See also: `Optimization.build_model`, `Optimization.BuiltModel`.
+See also: [`CTSolvers.Optimization.build_model`](@ref), [`CTSolvers.Optimization.BuiltModel`](@ref).
 """
 function Optimization.build_solution(
     built::Optimization.BuiltModel, model_solution, modeler::AbstractNLPModeler

--- a/src/Optimization/building.jl
+++ b/src/Optimization/building.jl
@@ -1,14 +1,56 @@
 # Generic build functions (declarations)
 #
 # `Optimization` owns and re-exports the generic functions `build_model` and
-# `build_solution`. They are *declared* here (empty generics) so the binding exists
-# and the export is valid; their canonical `NotImplemented` contract stubs — the
-# modeler contract, with full docstrings — live in `Modelers/contract.jl`, and
-# concrete methods live in the package providing the problem (e.g. CTDirect).
-#
-# This file is intentionally excluded from the API reference: it carries no
-# documentable content; `build_model` / `build_solution` are documented via their
-# contract methods on the Modelers page.
+# `build_solution`. They are *declared* here so the binding exists and the export is
+# valid. The canonical `NotImplemented` contract stubs — with method-level docstrings —
+# live in `Modelers/contract.jl`; concrete methods live in the package providing the
+# problem (e.g. CTDirect).
 
+"""
+Build a backend NLP model from an optimization problem and an initial guess.
+
+Generic function for the model-building contract. Concrete methods must be provided
+by the package supplying the optimization problem (e.g. CTDirect for
+[`CTSolvers.DOCP.DiscretizedModel`](@ref)), dispatching on the concrete
+`(problem, modeler)` pair.
+
+# Arguments
+- `prob::CTSolvers.Optimization.AbstractOptimizationProblem`: The optimization problem.
+- `initial_guess`: Initial guess passed to the NLP backend.
+- `modeler::CTSolvers.Modelers.AbstractNLPModeler`: The modeler strategy (e.g. `ADNLP`, `Exa`).
+
+# Returns
+- [`CTSolvers.Optimization.BuiltModel`](@ref): immutable bundle of the problem, the
+  backend NLP model, and an optional build-time cache.
+
+# Throws
+- [`CTBase.Exceptions.NotImplemented`](@extref): when no concrete method exists for
+  this `(problem, modeler)` pair.
+
+See also: [`CTSolvers.Optimization.build_solution`](@ref), [`CTSolvers.Optimization.BuiltModel`](@ref).
+"""
 function build_model end
+
+"""
+Build a problem-level solution from NLP solver statistics.
+
+Generic function for the solution-building contract. Concrete methods must be provided
+by the package supplying the optimization problem, dispatching on the concrete
+`(built, modeler)` pair.
+
+# Arguments
+- `built::CTSolvers.Optimization.BuiltModel`: The bundle returned by
+  [`CTSolvers.Optimization.build_model`](@ref).
+- `model_solution`: NLP solver output (execution statistics from SolverCore).
+- `modeler::CTSolvers.Modelers.AbstractNLPModeler`: The modeler strategy used to build.
+
+# Returns
+- A solution object appropriate for the problem type.
+
+# Throws
+- [`CTBase.Exceptions.NotImplemented`](@extref): when no concrete method exists for
+  this `(built, modeler)` pair.
+
+See also: [`CTSolvers.Optimization.build_model`](@ref), [`CTSolvers.Optimization.BuiltModel`](@ref).
+"""
 function build_solution end

--- a/src/Optimization/built_model.jl
+++ b/src/Optimization/built_model.jl
@@ -13,17 +13,17 @@ $(TYPEDEF)
 
 Empty cache for backends whose `build_model` produces no auxiliary data.
 
-Used as the `cache` field of a [`BuiltModel`](@ref) when nothing besides the NLP
-needs to be carried to `build_solution` (e.g. the ADNLP backend). Reusable by any
-backend, including the future ODE side.
+Used as the `cache` field of a [`CTSolvers.Optimization.BuiltModel`](@ref) when
+nothing besides the NLP needs to be carried to `build_solution` (e.g. the ADNLP
+backend). Reusable by any backend, including the future ODE side.
 """
 struct NoCache <: Core.AbstractCache end
 
 """
 $(TYPEDEF)
 
-Immutable bundle produced by [`build_model`](@ref) and consumed by
-[`build_solution`](@ref).
+Immutable bundle produced by [`CTSolvers.Optimization.build_model`](@ref) and consumed
+by [`CTSolvers.Optimization.build_solution`](@ref).
 
 It pairs the optimization problem with the backend NLP model and an optional,
 immutable build-time cache. This replaces the previous pattern of mutating a
@@ -36,14 +36,15 @@ NLP (e.g. an ExaModels getter) is stored here once, never mutated.
 - `nlp::TN`: The backend NLP model. Left untyped because its package (e.g.
   `NLPModels`) is a weak dependency.
 - `cache::TC`: Immutable build-time auxiliary (`<: CTBase.Core.AbstractCache`),
-  populated by `build_model`. [`NoCache`](@ref) when the backend needs none.
+  populated by `build_model`. [`CTSolvers.Optimization.NoCache`](@ref) when the
+  backend needs none.
 
 # Type parameters
 - `TP <: AbstractOptimizationProblem`
 - `TN`
 - `TC <: CTBase.Core.AbstractCache`
 
-See also: [`build_model`](@ref), [`build_solution`](@ref), [`NoCache`](@ref).
+See also: [`CTSolvers.Optimization.build_model`](@ref), [`CTSolvers.Optimization.build_solution`](@ref), [`CTSolvers.Optimization.NoCache`](@ref).
 """
 struct BuiltModel{TP<:AbstractOptimizationProblem,TN,TC<:Core.AbstractCache}
     problem::TP


### PR DESCRIPTION
## Summary

- **Migration VitePress** : remplace `Documenter.HTML` par `DocumenterVitepress.MarkdownVitepress`, ajoute `DocumenterInterLinks` (CTBase + CTModels), `sidebar_drawer`, guard `bases_file` pour le déploiement
- **Refonte `api_reference.jl`** : patron canonique CTModels — `modules_config` array, une page publique par module, une seule page Internals pour tous les symboles privés + toutes les extensions (au lieu de 12 pages extension séparées)
- **Nouvelle page `getting-started.md`** : installation, mental model, quick start, options, next steps
- **Suppression de tous les diagrammes Mermaid** (17 blocs) : remplacés par des schémas ASCII `text` dans `architecture.md` et les quatre guides, sans dépendance npm
- **Infrastructure VitePress** : `package.json`, `.vitepress/config.mts`, `mathjax-plugin.ts`, `julia-repl-transformer.ts`, `theme/`, `components/` (4 fichiers Vue) — copiés depuis CTModels
- **`index.md`** mise à jour comme landing page VitePress propre
- **`docs/Project.toml`** : retire `DocumenterMermaid`, ajoute `DocumenterVitepress`, `DocumenterInterLinks`, `LiveServer`

## Test plan

- [ ] `julia --project=docs docs/make.jl` s'exécute sans erreur
- [ ] `cd docs && npm install && npm run docs:build` réussit
- [ ] `npx serve docs/build/1 --listen 5173` : navigation correcte, 5 pages API publiques + Internals, aucun diagramme Mermaid cassé
- [ ] Les blocs `@repl` affichent les erreurs colorées correctement (via `julia-repl-transformer.ts`)
- [ ] Les liens InterLinks vers CTBase et CTModels résolvent correctement

🤖 Generated with [Claude Code](https://claude.ai/claude-code)