### PR TITLE
Release v0.4.26-beta: widen compat for CTBase and CTModels

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -5,6 +5,22 @@ and provides migration guides for users upgrading between versions.
 
 ---
 
+## v0.4.26-beta (2026-07-09)
+
+**No breaking changes.**
+
+This release widens compat for CTBase and CTModels.
+
+### Summary - v0.4.26-beta
+
+- Widen compat: `CTBase = "0.26, 0.27"`, `CTModels = "0.14, 0.15"`
+
+### Migration - v0.4.26-beta
+
+**No action required.** All existing code continues to work without changes.
+
+---
+
 ## v0.4.23-beta (2026-06-27)
 
 **Breaking change:** `build_model` returns an immutable `BuiltModel` bundle (not a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.26-beta] - 2026-07-09
+
+### Changed
+
+- **Compat bumps** — `CTBase = "0.26, 0.27"`, `CTModels = "0.14, 0.15"` in `Project.toml` and
+  `docs/Project.toml`.
+
+---
+
 ## [0.4.25-beta] - 2026-06-30
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTSolvers"
 uuid = "d3e8d392-8e4b-4d9b-8e92-d7d4e3650ef6"
-version = "0.4.25-beta"
+version = "0.4.26-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]
@@ -49,8 +49,8 @@ CTSolversZygote = "Zygote"
 ADNLPModels = "0.8"
 Aqua = "0.8"
 BenchmarkTools = "1"
-CTBase = "0.26"
-CTModels = "0.14"
+CTBase = "0.26, 0.27"
+CTModels = "0.14, 0.15"
 CUDA = "5, 6"
 CommonSolve = "0.2"
 DiffEqBase = "6, 7"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -8,7 +8,7 @@ MarkdownAST = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
 NLPModelsIpopt = "f4238b75-b362-5c4c-b852-0801c9a21d71"
 
 [compat]
-CTBase = "0.26"
+CTBase = "0.26, 0.27"
 Documenter = "1"
 DocumenterInterLinks = "1"
 DocumenterVitepress = "0.3"


### PR DESCRIPTION
## Summary

This release widens compat for CTBase and CTModels to support newer versions.

## Changes

- **Compat bumps** — `CTBase = "0.26, 0.27"`, `CTModels = "0.14, 0.15"` in `Project.toml` and `docs/Project.toml`.

## Breaking Changes

None. This is a compat-only release with no breaking changes.