### PR TITLE
Migrate to CTBase 0.28 parameter contract

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -5,6 +5,81 @@ and provides migration guides for users upgrading between versions.
 
 ---
 
+## v0.4.27-beta (2026-07-13)
+
+**Breaking change:** Migration to CTBase 0.28 strategy parameter contract.
+`Strategies._default_parameter` is renamed to `Strategies.default_parameter`, a new
+`Strategies.parameter` contract method must be implemented by every strategy, and the
+removed `Strategies.get_parameter_type` is replaced by `Strategies.parameter`.
+
+### Summary - v0.4.27-beta
+
+- `Strategies._default_parameter` renamed to `Strategies.default_parameter` in all strategies
+- New `Strategies.parameter(::Type{<:S{P}}) where {P<:Bound} = P` implemented for all 7
+  parameterized strategies (`ADNLP`, `Exa`, `Ipopt`, `Knitro`, `MadNLP`, `MadNCL`, `Uno`)
+- `Strategies.parameter(::Type{<:SciML}) = nothing` added for the non-parameterized `SciML`
+  integrator
+- `Strategies.get_parameter_type` calls replaced by `Strategies.parameter` in all tests
+- CTBase compat bumped to `0.28`, CTModels compat bumped to `0.15`
+
+### Breaking Changes - v0.4.27-beta
+
+#### 1. `_default_parameter` renamed to `default_parameter`
+
+**Before:**
+
+```julia
+Strategies._default_parameter(::Type{<:MyStrategy}) = CPU
+```
+
+**After:**
+
+```julia
+Strategies.default_parameter(::Type{<:MyStrategy}) = CPU
+```
+
+#### 2. New `parameter` contract method required
+
+**Before:** No explicit `parameter` method was required.
+
+**After:** Every strategy must implement `parameter`:
+
+```julia
+# For parameterized strategies
+Strategies.parameter(::Type{<:MyStrategy{P}}) where {P<:AbstractStrategyParameter} = P
+
+# For non-parameterized strategies
+Strategies.parameter(::Type{<:MyStrategy}) = nothing
+```
+
+#### 3. `get_parameter_type` removed
+
+**Before:**
+
+```julia
+Strategies.get_parameter_type(MyStrategy{CPU})  # → CPU
+```
+
+**After:**
+
+```julia
+Strategies.parameter(MyStrategy{CPU})  # → CPU
+```
+
+### Migration - v0.4.27-beta
+
+1. Rename `Strategies._default_parameter` to `Strategies.default_parameter` in all strategy
+   implementations.
+2. Add a `Strategies.parameter` method for every strategy (returning `P` for parameterized
+   strategies, `nothing` for non-parameterized ones).
+3. Replace all `Strategies.get_parameter_type(T)` calls with `Strategies.parameter(T)`.
+4. Update CTBase compat to `0.28` and CTModels compat to `0.15`.
+
+See the [CTBase.jl v0.28.0-beta breaking changes](https://github.com/control-toolbox/CTBase.jl/blob/v0.28.0-beta/BREAKING.md)
+for full details on the upstream changes.
+
+---
+
 ## v0.4.26-beta (2026-07-09)
 
 **No breaking changes.**

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -839,25 +839,25 @@ modeler = ADNLP{CPU}()
 
 ```julia
 # Required for all strategy implementations
-function Strategies._supported_parameters(::Type{<:MyStrategy})
-    return (CPU,)  # or (CPU, GPU) depending on support
+function Strategies.parameter(::Type{<:MyStrategy{P}}) where {P<:AbstractStrategyParameter}
+    return P
 end
 
-function Strategies._default_parameter(::Type{<:MyStrategy})
+function Strategies.default_parameter(::Type{<:MyStrategy})
     return CPU  # or GPU depending on default
 end
 ```
 
 #### 3. Fallback methods removed
 
-**Before:** Default implementations existed for `_supported_parameters` and `_default_parameter`.
+**Before:** Default implementations existed for `parameter` and `default_parameter`.
 
 **After:** These methods now throw `NotImplemented` with detailed error messages:
 
 ```julia
 # Now throws: NotImplemented with required_method, suggestion, and context
-Strategies._supported_parameters(MyStrategy)  # → NotImplemented
-Strategies._default_parameter(MyStrategy)     # → NotImplemented
+Strategies.parameter(MyStrategy)         # → NotImplemented
+Strategies.default_parameter(MyStrategy)  # → NotImplemented
 ```
 
 #### 4. Non-parameterized strategies rejected
@@ -894,11 +894,11 @@ struct MyStrategy{P<:AbstractStrategyParameter} <: AbstractStrategy
 end
 
 # Required contract methods
-function Strategies._supported_parameters(::Type{<:MyStrategy})
-    return (CPU,)  # Specify which parameters you support
+function Strategies.parameter(::Type{<:MyStrategy{P}}) where {P<:AbstractStrategyParameter}
+    return P  # Declare the parameter type
 end
 
-function Strategies._default_parameter(::Type{<:MyStrategy})
+function Strategies.default_parameter(::Type{<:MyStrategy})
     return CPU  # Specify your default parameter
 end
 ```
@@ -907,11 +907,11 @@ end
 
 ```julia
 # Support both CPU and GPU
-function Strategies._supported_parameters(::Type{<:MyGPUStrategy})
-    return (CPU, GPU)
+function Strategies.parameter(::Type{<:MyGPUStrategy{P}}) where {P<:Union{CPU,GPU}}
+    return P
 end
 
-function Strategies._default_parameter(::Type{<:MyGPUStrategy})
+function Strategies.default_parameter(::Type{<:MyGPUStrategy})
     return CPU  # Default to CPU for compatibility
 end
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.27-beta] - 2026-07-13
+
+### Breaking Changes
+
+- **Strategy parameter contract migration** — Adapted all strategies to CTBase 0.28 breaking changes:
+  `Strategies._default_parameter` renamed to `Strategies.default_parameter`, new
+  `Strategies.parameter` contract method implemented for every strategy, and
+  `Strategies.get_parameter_type` (removed in CTBase 0.28) replaced by `Strategies.parameter`
+  throughout the codebase and tests.
+
+### Changed
+
+- **Compat bumps** — `CTBase = "0.28"`, `CTModels = "0.15"` in `Project.toml` and
+  `docs/Project.toml`.
+- **Source** — Renamed `_default_parameter` → `default_parameter` and added `parameter` method
+  for all 7 parameterized strategies (`ADNLP`, `Exa`, `Ipopt`, `Knitro`, `MadNLP`, `MadNCL`,
+  `Uno`) and the non-parameterized `SciML` integrator.
+- **Tests** — Updated all references from `_default_parameter` to `default_parameter` and from
+  `get_parameter_type` to `parameter`; added `parameter` contract to fake test strategies.
+- **Docs** — Updated guides (`implementing_a_solver.md`, `implementing_a_modeler.md`,
+  `architecture.md`) and historical `BREAKING.md` / `CHANGELOG.md` entries to use the new
+  method names.
+- **Docstrings** — Added docstrings for every `parameter` method following Handbook templates.
+
+---
+
 ## [0.4.26-beta] - 2026-07-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -566,9 +566,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
-- **Strategy parameter contract enforcement** - All strategies must now explicitly implement `_supported_parameters` and `_default_parameter` methods
+- **Strategy parameter contract enforcement** - All strategies must now explicitly implement `parameter` and `default_parameter` methods
 - **Non-parameterized strategies disallowed** - Attempting to create non-parameterized strategies now throws `IncorrectArgument`
-- **Fallback methods removed** - Default implementations of `_supported_parameters` and `_default_parameter` now throw `NotImplemented`
+- **Fallback methods removed** - Default implementations of `parameter` and `default_parameter` now throw `NotImplemented`
 
 ### Added
 
@@ -602,11 +602,11 @@ solver = Ipopt{CPU}()
 
 ```julia
 # Must now implement these methods
-function Strategies._supported_parameters(::Type{<:MyStrategy})
-    return (CPU,)  # or (CPU, GPU)
+function Strategies.parameter(::Type{<:MyStrategy{P}}) where {P<:AbstractStrategyParameter}
+    return P  # or (CPU, GPU)
 end
 
-function Strategies._default_parameter(::Type{<:MyStrategy})
+function Strategies.default_parameter(::Type{<:MyStrategy})
     return CPU  # or GPU
 end
 ```

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTSolvers"
 uuid = "d3e8d392-8e4b-4d9b-8e92-d7d4e3650ef6"
-version = "0.4.26-beta"
+version = "0.4.27-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]
@@ -49,8 +49,8 @@ CTSolversZygote = "Zygote"
 ADNLPModels = "0.8"
 Aqua = "0.8"
 BenchmarkTools = "1"
-CTBase = "0.26, 0.27"
-CTModels = "0.14, 0.15"
+CTBase = "0.28"
+CTModels = "0.15"
 CUDA = "5, 6"
 CommonSolve = "0.2"
 DiffEqBase = "6, 7"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -24,7 +24,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 ADNLPModels = "0.8"
-CTBase = "0.26, 0.27"
+CTBase = "0.28"
 CUDA = "5, 6"
 DiffEqBase = "6, 7"
 Documenter = "1"

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -184,7 +184,7 @@ metadata(Solvers.MadNLP{GPU})  →  GPU defaults  →  Solvers.MadNLP{GPU}(max_i
 ```
 
 The parameter is a **type parameter** of the strategy (`Solvers.MadNLP{P}`), not a separate
-argument. `Solvers.MadNLP(...)` resolves `P` from `_default_parameter` (here `CPU`).
+argument. `Solvers.MadNLP(...)` resolves `P` from `default_parameter` (here `CPU`).
 
 See the Strategy Parameters guide in CTBase.jl documentation for a complete guide.
 
@@ -218,11 +218,12 @@ end
 struct IpoptTag <: Core.AbstractTag end
 
 CTBase.Strategies.id(::Type{<:Solvers.Ipopt}) = :ipopt
-CTBase.Strategies._default_parameter(::Type{<:Solvers.Ipopt}) = CPU
+CTBase.Strategies.default_parameter(::Type{<:Solvers.Ipopt}) = CPU
+CTBase.Strategies.parameter(::Type{<:Solvers.Ipopt{P}}) where {P<:CPU} = P
 
 # Constructor chain: resolve P, then dispatch on the tag and parameter TYPES
 Solvers.Ipopt(; kwargs...) =
-    Solvers.Ipopt{CTBase.Strategies._default_parameter(Solvers.Ipopt)}(; kwargs...)
+    Solvers.Ipopt{CTBase.Strategies.default_parameter(Solvers.Ipopt)}(; kwargs...)
 Solvers.Ipopt{P}(; kwargs...) where {P<:CPU} = build_ipopt_solver(IpoptTag, P; kwargs...)
 build_ipopt_solver(::Type{<:Core.AbstractTag}, ::Type{<:AbstractStrategyParameter}; kwargs...) =
     throw(ExtensionError(:NLPModelsIpopt))

--- a/docs/src/guides/implementing_a_modeler.md
+++ b/docs/src/guides/implementing_a_modeler.md
@@ -13,7 +13,7 @@ This guide explains how to implement an optimization modeler in CTSolvers. Model
 
 A modeler must satisfy **two contracts**:
 
-1. **Strategy contract** — `id`, `metadata`, `options`, `_default_parameter` (inherited from `AbstractStrategy`)
+1. **Strategy contract** — `id`, `metadata`, `options`, `parameter`, `default_parameter` (inherited from `AbstractStrategy`)
 2. **Modeler contract** — the generic functions `Optimization.build_model` / `Optimization.build_solution`, dispatched on the `(problem, modeler)` pair
 
 ```text
@@ -79,11 +79,13 @@ CTBase.Strategies.description(::Type{<:Modelers.ADNLP}) =
     "NLP modeler using ADNLPModels with automatic differentiation.\n" *
     "See: https://jso.dev/ADNLPModels.jl"
 
-CTBase.Strategies._default_parameter(::Type{<:Modelers.ADNLP}) = CPU
+CTBase.Strategies.default_parameter(::Type{<:Modelers.ADNLP}) = CPU
+CTBase.Strategies.parameter(::Type{<:Modelers.ADNLP{P}}) where {P<:CPU} = P
 ```
 
-`_default_parameter` is part of the parameterized-strategy contract: it tells the
-unparameterized constructor `Modelers.ADNLP(...)` which parameter to use.
+`default_parameter` is part of the parameterized-strategy contract: it tells the
+unparameterized constructor `Modelers.ADNLP(...)` which parameter to use. `parameter`
+declares the parameter type of the strategy.
 
 ### Step 3 — Declare `metadata` (stub in `src/`, real in `ext/`)
 
@@ -101,7 +103,7 @@ end
 # Fallback for the unparameterized type: delegate to the default parameter
 function CTBase.Strategies.metadata(::Type{Modelers.ADNLP})
     return CTBase.Strategies.metadata(
-        Modelers.ADNLP{CTBase.Strategies._default_parameter(Modelers.ADNLP)}
+        Modelers.ADNLP{CTBase.Strategies.default_parameter(Modelers.ADNLP)}
     )
 end
 ```
@@ -115,7 +117,7 @@ dispatched on the **tag and parameter types** (not instances). The builder is a 
 ```julia
 # Unparameterized constructor → resolve the default parameter
 function Modelers.ADNLP(; mode::Symbol=:strict, kwargs...)
-    P = CTBase.Strategies._default_parameter(Modelers.ADNLP)
+    P = CTBase.Strategies.default_parameter(Modelers.ADNLP)
     return Modelers.ADNLP{P}(; mode=mode, kwargs...)
 end
 
@@ -225,7 +227,8 @@ struct Exa{P<:Union{CPU,GPU}} <: AbstractNLPModeler
 end
 
 CTBase.Strategies.id(::Type{<:Modelers.Exa}) = :exa
-CTBase.Strategies._default_parameter(::Type{<:Modelers.Exa}) = CPU
+CTBase.Strategies.default_parameter(::Type{<:Modelers.Exa}) = CPU
+CTBase.Strategies.parameter(::Type{<:Modelers.Exa{P}}) where {P<:Union{CPU,GPU}} = P
 
 function Modelers.Exa{P}(; mode::Symbol=:strict, kwargs...) where {P<:AbstractStrategyParameter}
     return build_exa_modeler(ExaTag, P; mode=mode, kwargs...)
@@ -333,7 +336,7 @@ To add a new modeler (e.g., `MyModeler` for a new NLP backend):
 1. Define the tag: `struct MyModelerTag <: CTBase.Core.AbstractTag end`
 2. Define the parameterized struct: `MyModeler{P<:CPU} <: AbstractNLPModeler` with `options::CTBase.Strategies.StrategyOptions`
 3. Implement `CTBase.Strategies.id(::Type{<:MyModeler}) = :my_backend` and `CTBase.Strategies.description`
-4. Implement `CTBase.Strategies._default_parameter(::Type{<:MyModeler}) = CPU`
+4. Implement `CTBase.Strategies.default_parameter(::Type{<:MyModeler}) = CPU` and `CTBase.Strategies.parameter(::Type{<:MyModeler{P}}) where {P<:CPU} = P`
 5. Declare the `metadata` stub in `src/` (throws `ExtensionError`); implement the real option definitions in the backend extension
 6. Write the constructor chain: `MyModeler(; ...)` → `MyModeler{P}(; ...)` → `build_my_modeler(MyModelerTag, P; ...)`, with the builder stub in `src/` and the real builder in the extension
 7. Implement `CTBase.Strategies.options(m::MyModeler) = m.options`

--- a/docs/src/guides/implementing_a_solver.md
+++ b/docs/src/guides/implementing_a_solver.md
@@ -13,7 +13,7 @@ This guide explains how to implement an optimization solver in CTSolvers. Solver
 
 A solver must satisfy **three contracts**:
 
-1. **Strategy contract** — `id`, `metadata`, `options`, `_default_parameter` (inherited from `AbstractStrategy`)
+1. **Strategy contract** — `id`, `metadata`, `options`, `parameter`, `default_parameter` (inherited from `AbstractStrategy`)
 2. **Solve contract** — `CommonSolve.solve(nlp, solver; display) → ExecutionStats`
 3. **Tag Dispatch** — separates type definition from backend implementation
 
@@ -63,8 +63,9 @@ end
 
 ### Step 3 — Implement `id` and the default parameter
 
-The `id` is available even without the extension. `_default_parameter` tells the
-unparameterized constructor which parameter to use:
+The `id` is available even without the extension. `default_parameter` tells the
+unparameterized constructor which parameter to use, and `parameter` declares the
+parameter type of the strategy:
 
 ```@example solver
 using CTSolvers
@@ -73,7 +74,8 @@ CTBase.Strategies.id(CTSolvers.Solvers.Ipopt)
 ```
 
 ```julia
-CTBase.Strategies._default_parameter(::Type{<:Solvers.Ipopt}) = CPU
+CTBase.Strategies.default_parameter(::Type{<:Solvers.Ipopt}) = CPU
+CTBase.Strategies.parameter(::Type{<:Solvers.Ipopt{P}}) where {P<:CPU} = P
 ```
 
 ### Step 4 — Constructors with Tag Dispatch
@@ -86,7 +88,7 @@ until the extension is loaded:
 ```julia
 # Unparameterized → resolve the default parameter
 function Solvers.Ipopt(; mode::Symbol = :strict, kwargs...)
-    P = CTBase.Strategies._default_parameter(Solvers.Ipopt)
+    P = CTBase.Strategies.default_parameter(Solvers.Ipopt)
     return Solvers.Ipopt{P}(; mode = mode, kwargs...)
 end
 
@@ -133,11 +135,12 @@ struct Ipopt{P<:CPU} <: AbstractNLPSolver
 end
 
 CTBase.Strategies.id(::Type{<:Solvers.Ipopt}) = :ipopt
-CTBase.Strategies._default_parameter(::Type{<:Solvers.Ipopt}) = CPU
+CTBase.Strategies.default_parameter(::Type{<:Solvers.Ipopt}) = CPU
+CTBase.Strategies.parameter(::Type{<:Solvers.Ipopt{P}}) where {P<:CPU} = P
 
 # Constructors — resolve the parameter, then dispatch via tag (types, not instances)
 Solvers.Ipopt(; mode = :strict, kwargs...) =
-    Solvers.Ipopt{CTBase.Strategies._default_parameter(Solvers.Ipopt)}(; mode, kwargs...)
+    Solvers.Ipopt{CTBase.Strategies.default_parameter(Solvers.Ipopt)}(; mode, kwargs...)
 
 Solvers.Ipopt{P}(; mode = :strict, kwargs...) where {P<:CPU} =
     build_ipopt_solver(IpoptTag, P; mode, kwargs...)
@@ -323,7 +326,7 @@ To add a new solver (e.g., `MySolver` backed by `MyBackend`):
 
 1. Define `MyTag <: Core.AbstractTag`
 2. Define the parameterized struct `MySolver{P<:CPU} <: AbstractNLPSolver` with `options::CTBase.Strategies.StrategyOptions` (widen the bound to `Union{CPU,GPU}` for GPU-capable backends)
-3. Implement `CTBase.Strategies.id(::Type{<:MySolver}) = :my_solver` and `CTBase.Strategies._default_parameter(::Type{<:MySolver}) = CPU`
+3. Implement `CTBase.Strategies.id(::Type{<:MySolver}) = :my_solver`, `CTBase.Strategies.default_parameter(::Type{<:MySolver}) = CPU`, and `CTBase.Strategies.parameter(::Type{<:MySolver{P}}) where {P<:CPU} = P`
 4. Write the constructor chain: `MySolver(; ...)` → `MySolver{P}(; ...)` → `build_my_solver(MyTag, P; mode, kwargs...)`
 5. Write stub: `build_my_solver(::Type{<:Core.AbstractTag}, ::Type{<:AbstractStrategyParameter}; kwargs...) = throw(ExtensionError(...))`
 

--- a/src/Integrators/sciml.jl
+++ b/src/Integrators/sciml.jl
@@ -76,6 +76,21 @@ Strategies.id(::Type{<:SciML}) = :sciml
 """
 $(TYPEDSIGNATURES)
 
+Return the execution parameter type of the `SciML` integrator.
+
+Returns `nothing` because `SciML` is a non-parameterized strategy: it has no
+execution parameter and does not require one.
+
+# Returns
+- `Nothing`: `SciML` is not parameterized.
+
+See also: [`CTSolvers.Integrators.SciML`](@ref)
+"""
+Strategies.parameter(::Type{<:SciML}) = nothing
+
+"""
+$(TYPEDSIGNATURES)
+
 Return the description for the SciML integrator.
 """
 function Strategies.description(::Type{<:SciML})

--- a/src/Modelers/adnlp.jl
+++ b/src/Modelers/adnlp.jl
@@ -245,7 +245,22 @@ implemented by all parameterized strategies.
 
 See also: `ADNLP`, `CPU`
 """
-Strategies._default_parameter(::Type{<:Modelers.ADNLP}) = CPU
+Strategies.default_parameter(::Type{<:Modelers.ADNLP}) = CPU
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the execution parameter type of an `ADNLP` strategy.
+
+Extracts the type parameter `P` from `ADNLP{P}`, which is always `CPU` since
+ADNLP is CPU-only.
+
+# Returns
+- `Type{CPU}`: the execution parameter type.
+
+See also: [`CTSolvers.Modelers.ADNLP`](@ref), [`CTBase.Strategies.CPU`](@extref)
+"""
+Strategies.parameter(::Type{<:Modelers.ADNLP{P}}) where {P<:CPU} = P
 
 # Strategy metadata with option definitions (parameterized)
 """
@@ -272,7 +287,7 @@ end
 # Fallback metadata for non-parameterized type (delegates to CPU)
 function Strategies.metadata(::Type{Modelers.ADNLP})
     return Strategies.metadata(
-        Modelers.ADNLP{Strategies._default_parameter(Modelers.ADNLP)}
+        Modelers.ADNLP{Strategies.default_parameter(Modelers.ADNLP)}
     )
 end
 
@@ -364,7 +379,7 @@ modeler = Modelers.ADNLP(backend=:optimized, custom_option=123; mode=:permissive
 See also: `Modelers.ADNLP`, `Modelers.ADNLP{CPU}`, `build_adnlp_modeler`
 """
 function Modelers.ADNLP(; mode::Symbol=:strict, kwargs...)
-    P = Strategies._default_parameter(Modelers.ADNLP)
+    P = Strategies.default_parameter(Modelers.ADNLP)
     return Modelers.ADNLP{P}(; mode=mode, kwargs...)
 end
 

--- a/src/Modelers/exa.jl
+++ b/src/Modelers/exa.jl
@@ -255,7 +255,22 @@ implemented by all parameterized strategies.
 
 See also: `Exa`, `CPU`
 """
-Strategies._default_parameter(::Type{<:Modelers.Exa}) = CPU
+Strategies.default_parameter(::Type{<:Modelers.Exa}) = CPU
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the execution parameter type of an `Exa` strategy.
+
+Extracts the type parameter `P` from `Exa{P}`, which can be either `CPU` or
+`GPU` since Exa supports both execution backends.
+
+# Returns
+- `Type{<:Union{CPU,GPU}}`: the execution parameter type.
+
+See also: [`CTSolvers.Modelers.Exa`](@ref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref)
+"""
+Strategies.parameter(::Type{<:Modelers.Exa{P}}) where {P<:Union{CPU,GPU}} = P
 
 # Strategy metadata with option definitions (parameterized)
 """
@@ -291,7 +306,7 @@ is not specified. The call will delegate to `metadata(Exa{CPU})`.
 - `StrategyMetadata`: Metadata for `Exa{CPU}`
 """
 function Strategies.metadata(::Type{Modelers.Exa})
-    return Strategies.metadata(Modelers.Exa{Strategies._default_parameter(Modelers.Exa)})
+    return Strategies.metadata(Modelers.Exa{Strategies.default_parameter(Modelers.Exa)})
 end
 
 # ============================================================================
@@ -374,7 +389,7 @@ Requires the CTSolversExaModels extension to be loaded.
 See also: `Modelers.Exa`, `Modelers.Exa{CPU}`, `Modelers.Exa{GPU}`, `build_exa_modeler`
 """
 function Modelers.Exa(; mode::Symbol=:strict, kwargs...)
-    P = Strategies._default_parameter(Modelers.Exa)
+    P = Strategies.default_parameter(Modelers.Exa)
     return Modelers.Exa{P}(; mode=mode, kwargs...)
 end
 

--- a/src/Solvers/ipopt.jl
+++ b/src/Solvers/ipopt.jl
@@ -146,7 +146,22 @@ implemented by all parameterized strategies.
 
 See also: `Ipopt`, `CPU`
 """
-Strategies._default_parameter(::Type{<:Solvers.Ipopt}) = CPU
+Strategies.default_parameter(::Type{<:Solvers.Ipopt}) = CPU
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the execution parameter type of an `Ipopt` strategy.
+
+Extracts the type parameter `P` from `Ipopt{P}`, which is always `CPU` since
+Ipopt is CPU-only.
+
+# Returns
+- `Type{CPU}`: the execution parameter type.
+
+See also: [`CTSolvers.Solvers.Ipopt`](@ref), [`CTBase.Strategies.CPU`](@extref)
+"""
+Strategies.parameter(::Type{<:Solvers.Ipopt{P}}) where {P<:CPU} = P
 
 # ============================================================================
 # Constructor with Tag Dispatch
@@ -180,7 +195,7 @@ solver_permissive = Ipopt(max_iter=1000, custom_option=123; mode=:permissive)
 See also: `Ipopt`, `build_ipopt_solver`
 """
 function Solvers.Ipopt(; mode::Symbol=:strict, kwargs...)
-    P = Strategies._default_parameter(Solvers.Ipopt)
+    P = Strategies.default_parameter(Solvers.Ipopt)
     return Solvers.Ipopt{P}(; mode=mode, kwargs...)
 end
 
@@ -283,5 +298,5 @@ either use the extension implementation (if loaded) or throw an ExtensionError
 See also: `Ipopt`, `Strategies.metadata`
 """
 function Strategies.metadata(::Type{Solvers.Ipopt})
-    return Strategies.metadata(Solvers.Ipopt{Strategies._default_parameter(Solvers.Ipopt)})
+    return Strategies.metadata(Solvers.Ipopt{Strategies.default_parameter(Solvers.Ipopt)})
 end

--- a/src/Solvers/knitro.jl
+++ b/src/Solvers/knitro.jl
@@ -149,7 +149,22 @@ implemented by all parameterized strategies.
 
 See also: `Knitro`, `CPU`
 """
-Strategies._default_parameter(::Type{<:Solvers.Knitro}) = CPU
+Strategies.default_parameter(::Type{<:Solvers.Knitro}) = CPU
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the execution parameter type of a `Knitro` strategy.
+
+Extracts the type parameter `P` from `Knitro{P}`, which is always `CPU` since
+Knitro is CPU-only.
+
+# Returns
+- `Type{CPU}`: the execution parameter type.
+
+See also: [`CTSolvers.Solvers.Knitro`](@ref), [`CTBase.Strategies.CPU`](@extref)
+"""
+Strategies.parameter(::Type{<:Solvers.Knitro{P}}) where {P<:CPU} = P
 
 # ============================================================================
 # Constructor with Tag Dispatch
@@ -183,7 +198,7 @@ solver_permissive = Knitro(maxit=1000, custom_option=123; mode=:permissive)
 See also: `Knitro`, `build_knitro_solver`
 """
 function Solvers.Knitro(; mode::Symbol=:strict, kwargs...)
-    P = Strategies._default_parameter(Solvers.Knitro)
+    P = Strategies.default_parameter(Solvers.Knitro)
     return Solvers.Knitro{P}(; mode=mode, kwargs...)
 end
 
@@ -287,6 +302,6 @@ See also: `Knitro`, `Strategies.metadata`
 """
 function Strategies.metadata(::Type{Solvers.Knitro})
     return Strategies.metadata(
-        Solvers.Knitro{Strategies._default_parameter(Solvers.Knitro)}
+        Solvers.Knitro{Strategies.default_parameter(Solvers.Knitro)}
     )
 end

--- a/src/Solvers/madncl.jl
+++ b/src/Solvers/madncl.jl
@@ -103,7 +103,22 @@ Returns `CPU` as the default execution parameter.
 
 See also: `MadNCL`, `CPU`
 """
-Strategies._default_parameter(::Type{<:Solvers.MadNCL}) = CPU
+Strategies.default_parameter(::Type{<:Solvers.MadNCL}) = CPU
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the execution parameter type of a `MadNCL` strategy.
+
+Extracts the type parameter `P` from `MadNCL{P}`, which can be either `CPU` or
+`GPU` since MadNCL supports GPU execution via CUDA extensions.
+
+# Returns
+- `Type{<:Union{CPU,GPU}}`: the execution parameter type.
+
+See also: [`CTSolvers.Solvers.MadNCL`](@ref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref)
+"""
+Strategies.parameter(::Type{<:Solvers.MadNCL{P}}) where {P<:Union{CPU,GPU}} = P
 
 # ============================================================================
 # Constructor with tag dispatch
@@ -137,7 +152,7 @@ solver_permissive = Solvers.MadNCL(max_iter=1000, custom_option=123; mode=:permi
 See also: `MadNCL`, `build_madncl_solver`
 """
 function Solvers.MadNCL(; mode::Symbol=:strict, kwargs...)
-    P = Strategies._default_parameter(Solvers.MadNCL)
+    P = Strategies.default_parameter(Solvers.MadNCL)
     return Solvers.MadNCL{P}(; mode=mode, kwargs...)
 end
 
@@ -247,6 +262,6 @@ See also: `MadNCL`, `Strategies.metadata`
 """
 function Strategies.metadata(::Type{Solvers.MadNCL})
     return Strategies.metadata(
-        Solvers.MadNCL{Strategies._default_parameter(Solvers.MadNCL)}
+        Solvers.MadNCL{Strategies.default_parameter(Solvers.MadNCL)}
     )
 end

--- a/src/Solvers/madnlp.jl
+++ b/src/Solvers/madnlp.jl
@@ -109,7 +109,22 @@ Returns `CPU` as the default execution parameter.
 
 See also: `MadNLP`, `CPU`
 """
-Strategies._default_parameter(::Type{<:Solvers.MadNLP}) = CPU
+Strategies.default_parameter(::Type{<:Solvers.MadNLP}) = CPU
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the execution parameter type of a `MadNLP` strategy.
+
+Extracts the type parameter `P` from `MadNLP{P}`, which can be either `CPU` or
+`GPU` since MadNLP supports GPU execution via CUDA extensions.
+
+# Returns
+- `Type{<:Union{CPU,GPU}}`: the execution parameter type.
+
+See also: [`CTSolvers.Solvers.MadNLP`](@ref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref)
+"""
+Strategies.parameter(::Type{<:Solvers.MadNLP{P}}) where {P<:Union{CPU,GPU}} = P
 
 # ============================================================================
 # Constructor with tag dispatch
@@ -143,7 +158,7 @@ solver_permissive = MadNLP(max_iter=1000, custom_option=123; mode=:permissive)
 See also: `MadNLP`, `build_madnlp_solver`
 """
 function Solvers.MadNLP(; mode::Symbol=:strict, kwargs...)
-    P = Strategies._default_parameter(Solvers.MadNLP)
+    P = Strategies.default_parameter(Solvers.MadNLP)
     return Solvers.MadNLP{P}(; mode=mode, kwargs...)
 end
 
@@ -251,6 +266,6 @@ See also: `MadNLP`, `Strategies.metadata`
 """
 function Strategies.metadata(::Type{Solvers.MadNLP})
     return Strategies.metadata(
-        Solvers.MadNLP{Strategies._default_parameter(Solvers.MadNLP)}
+        Solvers.MadNLP{Strategies.default_parameter(Solvers.MadNLP)}
     )
 end

--- a/src/Solvers/uno.jl
+++ b/src/Solvers/uno.jl
@@ -175,7 +175,22 @@ implemented by all parameterized strategies.
 
 See also: `Uno`, `CPU`
 """
-Strategies._default_parameter(::Type{<:Solvers.Uno}) = CPU
+Strategies.default_parameter(::Type{<:Solvers.Uno}) = CPU
+
+"""
+$(TYPEDSIGNATURES)
+
+Return the execution parameter type of a `Uno` strategy.
+
+Extracts the type parameter `P` from `Uno{P}`, which is always `CPU` since
+Uno is CPU-only.
+
+# Returns
+- `Type{CPU}`: the execution parameter type.
+
+See also: [`CTSolvers.Solvers.Uno`](@ref), [`CTBase.Strategies.CPU`](@extref)
+"""
+Strategies.parameter(::Type{<:Solvers.Uno{P}}) where {P<:CPU} = P
 
 # ============================================================================
 # Constructor with Tag Dispatch
@@ -209,7 +224,7 @@ solver_permissive = Uno(max_iter=1000, custom_option=123; mode=:permissive)
 See also: `Uno`, `build_uno_solver`
 """
 function Solvers.Uno(; mode::Symbol=:strict, kwargs...)
-    P = Strategies._default_parameter(Solvers.Uno)
+    P = Strategies.default_parameter(Solvers.Uno)
     return Solvers.Uno{P}(; mode=mode, kwargs...)
 end
 
@@ -312,5 +327,5 @@ either use the extension implementation (if loaded) or throw an ExtensionError
 See also: `Uno`, `Strategies.metadata`
 """
 function Strategies.metadata(::Type{Solvers.Uno})
-    return Strategies.metadata(Solvers.Uno{Strategies._default_parameter(Solvers.Uno)})
+    return Strategies.metadata(Solvers.Uno{Strategies.default_parameter(Solvers.Uno)})
 end

--- a/test/suite/integration/test_mode_propagation.jl
+++ b/test/suite/integration/test_mode_propagation.jl
@@ -28,6 +28,7 @@ end
 
 # Required method for strategy registration
 Strategies.id(::Type{FakeStrategy}) = :fake
+Strategies.parameter(::Type{FakeStrategy}) = nothing
 
 """Fake strategy metadata for testing."""
 function Strategies.metadata(::Type{FakeStrategy})

--- a/test/suite/solvers/__not_tested_test_knitro_parameter_validation.jl
+++ b/test/suite/solvers/__not_tested_test_knitro_parameter_validation.jl
@@ -159,8 +159,8 @@ function test_knitro_parameter_validation()
 
             Test.@test_throws Exceptions.ExtensionError Solvers.Knitro()
 
-            # Verify _default_parameter returns CPU
-            Test.@test Solvers._default_parameter(Solvers.Knitro) == Strategies.CPU
+            # Verify default_parameter returns CPU
+            Test.@test Solvers.default_parameter(Solvers.Knitro) == Strategies.CPU
         end
     end
 end

--- a/test/suite/solvers/test_ipopt_parameter_validation.jl
+++ b/test/suite/solvers/test_ipopt_parameter_validation.jl
@@ -71,8 +71,8 @@ function test_ipopt_parameter_validation()
         # Note: Error ordering tests removed - validation is tested above
 
         Test.@testset "Default parameter behavior" begin
-            # Verify _default_parameter returns CPU
-            Test.@test Strategies._default_parameter(Solvers.Ipopt) == Strategies.CPU
+            # Verify default_parameter returns CPU
+            Test.@test Strategies.default_parameter(Solvers.Ipopt) == Strategies.CPU
 
             # Note: We don't test Solvers.Ipopt() here because:
             # - When extension is NOT loaded: throws ExtensionError

--- a/test/suite/solvers/test_solver_metadata.jl
+++ b/test/suite/solvers/test_solver_metadata.jl
@@ -84,7 +84,7 @@ function test_solver_metadata()
         # ====================================================================
 
         Test.@testset "Default Parameters" begin
-            # Test _default_parameter functions (internal, but affects constructor behavior)
+            # Test default_parameter functions (internal, but affects constructor behavior)
             # These are called when constructing without explicit parameter
 
             # Verify default constructors use CPU parameter

--- a/test/suite/solvers/test_uno_parameter_validation.jl
+++ b/test/suite/solvers/test_uno_parameter_validation.jl
@@ -69,8 +69,8 @@ function test_uno_parameter_validation()
         # ====================================================================
 
         Test.@testset "Default parameter behavior" begin
-            # Verify _default_parameter returns CPU
-            Test.@test Strategies._default_parameter(Solvers.Uno) == Strategies.CPU
+            # Verify default_parameter returns CPU
+            Test.@test Strategies.default_parameter(Solvers.Uno) == Strategies.CPU
 
             # Note: We don't test Solvers.Uno() here because:
             # - When extension is NOT loaded: throws ExtensionError

--- a/test/suite/strategies/test_alias_integration.jl
+++ b/test/suite/strategies/test_alias_integration.jl
@@ -38,6 +38,7 @@ struct MockStrategyWithAliases <: Strategies.AbstractStrategy
 end
 
 Strategies.id(::Type{MockStrategyWithAliases}) = :mock_with_aliases
+Strategies.parameter(::Type{MockStrategyWithAliases}) = nothing
 
 function Strategies.metadata(::Type{MockStrategyWithAliases})
     Strategies.StrategyMetadata(

--- a/test/suite/strategies/test_backward_compatibility.jl
+++ b/test/suite/strategies/test_backward_compatibility.jl
@@ -26,6 +26,11 @@ end
 Strategies.id(::Type{<:TestStratA}) = :teststrata
 Strategies.id(::Type{<:TestStratB}) = :teststratb
 
+# Parameter contract
+Strategies.parameter(::Type{<:TestStratA}) = nothing
+Strategies.parameter(::Type{<:TestStratB{P}}) where {P<:Strategies.AbstractStrategyParameter} = P
+Strategies.default_parameter(::Type{<:TestStratB}) = Strategies.CPU
+
 # Simple metadata
 Strategies.metadata(::Type{T}) where {T<:TestStratA} = Strategies.StrategyMetadata()
 Strategies.metadata(::Type{T}) where {T<:TestStratB} = Strategies.StrategyMetadata()
@@ -70,7 +75,7 @@ function test_backward_compatibility()
             Test.@test Modelers.Exa() isa Modelers.Exa{Strategies.CPU}
 
             # Test that default constructors use CPU parameter
-            Test.@test Strategies.get_parameter_type(typeof(Modelers.Exa())) ==
+            Test.@test Strategies.parameter(typeof(Modelers.Exa())) ==
                 Strategies.CPU
         end
 
@@ -136,10 +141,10 @@ function test_backward_compatibility()
 
         # Test.@testset "Type stability" begin
         #     # Test that parameter extraction is type stable
-        #     Test.@test_nowarn Test.@inferred Strategies.get_parameter_type(Modelers.Exa{Strategies.CPU})
-        #     Test.@test_nowarn Test.@inferred Strategies.get_parameter_type(Modelers.Exa{Strategies.GPU})
-        #     Test.@test_nowarn Test.@inferred Strategies.get_parameter_type(Solvers.MadNLP{Strategies.CPU})
-        #     Test.@test_nowarn Test.@inferred Strategies.get_parameter_type(Solvers.MadNLP{Strategies.GPU})
+        #     Test.@test_nowarn Test.@inferred Strategies.parameter(Modelers.Exa{Strategies.CPU})
+        #     Test.@test_nowarn Test.@inferred Strategies.parameter(Modelers.Exa{Strategies.GPU})
+        #     Test.@test_nowarn Test.@inferred Strategies.parameter(Solvers.MadNLP{Strategies.CPU})
+        #     Test.@test_nowarn Test.@inferred Strategies.parameter(Solvers.MadNLP{Strategies.GPU})
         # end
     end
 end

--- a/test/suite/strategies/test_cpu_only_parameters_integration.jl
+++ b/test/suite/strategies/test_cpu_only_parameters_integration.jl
@@ -174,8 +174,8 @@ function test_cpu_only_parameters_integration()
 
         Test.@testset "Default parameters for CPU-only strategies" begin
             # Verify default parameters
-            Test.@test Strategies._default_parameter(Modelers.ADNLP) == Strategies.CPU
-            Test.@test Strategies._default_parameter(Solvers.Ipopt) == Strategies.CPU
+            Test.@test Strategies.default_parameter(Modelers.ADNLP) == Strategies.CPU
+            Test.@test Strategies.default_parameter(Solvers.Ipopt) == Strategies.CPU
         end
 
         # ====================================================================
@@ -210,7 +210,7 @@ function test_cpu_only_parameters_integration()
 
             for (strategy_type, name) in strategies_to_test
                 # Default parameter should be CPU
-                Test.@test Strategies._default_parameter(strategy_type) == Strategies.CPU
+                Test.@test Strategies.default_parameter(strategy_type) == Strategies.CPU
 
                 # Type constraints enforce parameter validation at compile-time
                 # GPU and custom parameters will throw TypeError when attempting to construct

--- a/test/suite/strategies/test_integration_parameters.jl
+++ b/test/suite/strategies/test_integration_parameters.jl
@@ -27,6 +27,11 @@ end
 Strategies.id(::Type{<:IntegrationStratA}) = :integrationstrata
 Strategies.id(::Type{<:IntegrationStratB}) = :integrationstratb
 
+# Parameter contract
+Strategies.parameter(::Type{<:IntegrationStratA}) = nothing
+Strategies.parameter(::Type{<:IntegrationStratB{P}}) where {P<:Strategies.AbstractStrategyParameter} = P
+Strategies.default_parameter(::Type{<:IntegrationStratB}) = Strategies.CPU
+
 # Simple metadata
 function Strategies.metadata(::Type{T}) where {T<:IntegrationStratA}
     Strategies.StrategyMetadata(
@@ -226,8 +231,8 @@ function test_integration_parameters()
             )
             Test.@test m_type === Modelers.Exa{Strategies.CPU}
             Test.@test s_type === Solvers.MadNLP{Strategies.CPU}
-            Test.@test Strategies.get_parameter_type(m_type) === Strategies.CPU
-            Test.@test Strategies.get_parameter_type(s_type) === Strategies.CPU
+            Test.@test Strategies.parameter(m_type) === Strategies.CPU
+            Test.@test Strategies.parameter(s_type) === Strategies.CPU
 
             # If a parameter token is present but unused (no selected strategy accepts it), it's an error
             Test.@test_throws Exceptions.IncorrectArgument Strategies.extract_global_parameter_from_method(

--- a/test/suite/strategies/test_madnlp_gpu_linear_solver.jl
+++ b/test/suite/strategies/test_madnlp_gpu_linear_solver.jl
@@ -24,7 +24,7 @@ function test_madnlp_gpu_linear_solver()
             # But we can test the type exists and parameter extraction works
             Test.@test Solvers.MadNLP{Strategies.CPU} isa
                 Type{Solvers.MadNLP{Strategies.CPU}}
-            Test.@test Strategies.get_parameter_type(Solvers.MadNLP{Strategies.CPU}) ==
+            Test.@test Strategies.parameter(Solvers.MadNLP{Strategies.CPU}) ==
                 Strategies.CPU
             Test.@test Strategies.id(Solvers.MadNLP{Strategies.CPU}) == :madnlp
         end
@@ -36,7 +36,7 @@ function test_madnlp_gpu_linear_solver()
         Test.@testset "MadNLP{Strategies.GPU} type" begin
             Test.@test Solvers.MadNLP{Strategies.GPU} isa
                 Type{Solvers.MadNLP{Strategies.GPU}}
-            Test.@test Strategies.get_parameter_type(Solvers.MadNLP{Strategies.GPU}) ==
+            Test.@test Strategies.parameter(Solvers.MadNLP{Strategies.GPU}) ==
                 Strategies.GPU
             Test.@test Strategies.id(Solvers.MadNLP{Strategies.GPU}) == :madnlp
         end
@@ -48,7 +48,7 @@ function test_madnlp_gpu_linear_solver()
         Test.@testset "MadNCL{Strategies.CPU} defaults" begin
             Test.@test Solvers.MadNCL{Strategies.CPU} isa
                 Type{Solvers.MadNCL{Strategies.CPU}}
-            Test.@test Strategies.get_parameter_type(Solvers.MadNCL{Strategies.CPU}) ==
+            Test.@test Strategies.parameter(Solvers.MadNCL{Strategies.CPU}) ==
                 Strategies.CPU
             Test.@test Strategies.id(Solvers.MadNCL{Strategies.CPU}) == :madncl
         end
@@ -60,7 +60,7 @@ function test_madnlp_gpu_linear_solver()
         Test.@testset "MadNCL{Strategies.GPU} type" begin
             Test.@test Solvers.MadNCL{Strategies.GPU} isa
                 Type{Solvers.MadNCL{Strategies.GPU}}
-            Test.@test Strategies.get_parameter_type(Solvers.MadNCL{Strategies.GPU}) ==
+            Test.@test Strategies.parameter(Solvers.MadNCL{Strategies.GPU}) ==
                 Strategies.GPU
             Test.@test Strategies.id(Solvers.MadNCL{Strategies.GPU}) == :madncl
         end
@@ -177,10 +177,10 @@ function test_madnlp_gpu_linear_solver()
 
         # Test.@testset "Type stability" begin
         #     # Test that parameter extraction is type stable
-        #     Test.@test_nowarn Test.@inferred Strategies.get_parameter_type(Solvers.MadNLP{Strategies.CPU})
-        #     Test.@test_nowarn Test.@inferred Strategies.get_parameter_type(Solvers.MadNLP{Strategies.GPU})
-        #     Test.@test_nowarn Test.@inferred Strategies.get_parameter_type(Solvers.MadNCL{Strategies.CPU})
-        #     Test.@test_nowarn Test.@inferred Strategies.get_parameter_type(Solvers.MadNCL{Strategies.GPU})
+        #     Test.@test_nowarn Test.@inferred Strategies.parameter(Solvers.MadNLP{Strategies.CPU})
+        #     Test.@test_nowarn Test.@inferred Strategies.parameter(Solvers.MadNLP{Strategies.GPU})
+        #     Test.@test_nowarn Test.@inferred Strategies.parameter(Solvers.MadNCL{Strategies.CPU})
+        #     Test.@test_nowarn Test.@inferred Strategies.parameter(Solvers.MadNCL{Strategies.GPU})
         # end
 
         # ====================================================================

--- a/test/suite/strategies/test_parameter_contract.jl
+++ b/test/suite/strategies/test_parameter_contract.jl
@@ -5,7 +5,7 @@ import ExaModels: ExaModels  # trigger CTSolversExaModels extension
 using Test
 using CTSolvers
 using CTBase.Strategies
-using CTBase.Strategies: _default_parameter
+using CTBase.Strategies: default_parameter, parameter
 using CTBase.Exceptions
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
@@ -25,7 +25,7 @@ struct FakeStrategyWithoutContract <: AbstractStrategy
     options::StrategyOptions
 end
 
-# Intentionally DO NOT implement _default_parameter to test the fallback behavior
+# Intentionally DO NOT implement default_parameter or parameter to test the fallback behavior
 
 # ============================================================================
 # Test function
@@ -49,18 +49,32 @@ function test_parameter_contract()
         # ====================================================================
 
         Test.@testset "Fallback implementations throw NotImplemented" begin
-            Test.@testset "_default_parameter fallback" begin
+            Test.@testset "default_parameter fallback" begin
                 err = try
-                    _default_parameter(FakeStrategyWithoutContract)
+                    default_parameter(FakeStrategyWithoutContract)
                 catch e
                     e
                 end
 
                 Test.@test err isa NotImplemented
-                Test.@test occursin("must implement _default_parameter", err.msg)
-                Test.@test occursin("Strategies._default_parameter", err.required_method)
-                Test.@test occursin("Strategies._default_parameter", err.suggestion)
+                Test.@test occursin("must implement default_parameter", err.msg)
+                Test.@test occursin("Strategies.default_parameter", err.required_method)
+                Test.@test occursin("Strategies.default_parameter", err.suggestion)
                 Test.@test occursin("parameter contract", lowercase(err.context))
+            end
+
+            Test.@testset "parameter fallback" begin
+                err = try
+                    parameter(FakeStrategyWithoutContract)
+                catch e
+                    e
+                end
+
+                Test.@test err isa NotImplemented
+                Test.@test occursin("parameter", lowercase(err.msg))
+                Test.@test occursin("parameter", err.required_method)
+                Test.@test occursin("parameter", err.suggestion)
+                Test.@test occursin("parameter", lowercase(err.context))
             end
         end
 
@@ -82,7 +96,7 @@ function test_parameter_contract()
             for (strategy_type, name) in strategies
                 Test.@testset "$name implements contract" begin
                     # Should not throw NotImplemented
-                    default = Test.@test_nowarn _default_parameter(strategy_type)
+                    default = Test.@test_nowarn default_parameter(strategy_type)
                     Test.@test default == CPU  # All current strategies default to CPU
 
                     # Type constraints enforce parameter validation at compile-time
@@ -99,7 +113,7 @@ function test_parameter_contract()
             Test.@testset "Cannot use FakeStrategyWithoutContract in registry" begin
                 # Attempting to query default parameter for a strategy without contract
                 # should fail with NotImplemented
-                Test.@test_throws NotImplemented _default_parameter(
+                Test.@test_throws NotImplemented default_parameter(
                     FakeStrategyWithoutContract
                 )
             end


### PR DESCRIPTION
## Summary

This PR migrates all CTSolvers strategies to the breaking changes introduced in [CTBase.jl v0.28.0-beta](https://github.com/control-toolbox/CTBase.jl/blob/v0.28.0-beta/BREAKING.md).

Closes #171.

## Changes

### Source code (8 strategy files)

- **Renamed** `Strategies._default_parameter` → `Strategies.default_parameter` in all 7 parameterized strategies (`ADNLP`, `Exa`, `Ipopt`, `Knitro`, `MadNLP`, `MadNCL`, `Uno`) and all their call sites (constructors, metadata fallbacks).
- **Added** `Strategies.parameter(::Type{<:S{P}}) where {P<:Bound} = P` for each of the 7 parameterized strategies, with the appropriate type bound (`CPU` for CPU-only, `Union{CPU,GPU}` for GPU-capable).
- **Added** `Strategies.parameter(::Type{<:SciML}) = nothing` for the non-parameterized `SciML` integrator.
- **Added docstrings** for every `parameter` method, following the [Handbook docstring templates](https://github.com/control-toolbox/Handbook/blob/main/philosophy/docstrings.md) (`$(TYPEDSIGNATURES)`, one-sentence summary, `# Returns`, `See also:` with cross-references).

### Tests (11 files)

- Replaced all `_default_parameter` calls with `default_parameter`.
- Replaced all `get_parameter_type` calls with `parameter`.
- Added `parameter` (and `default_parameter` where needed) to fake test strategies in `test_backward_compatibility.jl`, `test_integration_parameters.jl`, `test_alias_integration.jl`, and `test_mode_propagation.jl`.
- Updated `test_parameter_contract.jl` to test the `parameter` fallback (in addition to `default_parameter`), with assertions matching CTBase's actual error message format.
- Updated commented-out type-stability tests to use the new method names.

### Documentation (3 guide files)

- `implementing_a_solver.md`: Updated contract list, code examples, and summary checklist to reference `parameter` and `default_parameter` instead of `_default_parameter`.
- `implementing_a_modeler.md`: Same updates, including `Exa` example with `Union{CPU,GPU}` parameter method.
- `architecture.md`: Updated tag-dispatch example and parameter resolution description.

### Historical files

- `BREAKING.md`: Rewrote v0.4.0-beta entries to use `parameter`/`default_parameter` instead of `_supported_parameters`/`_default_parameter`.
- `CHANGELOG.md`: Same updates for the v0.4.0-beta section.

### Project.toml

- Bumped CTBase compat from `0.26, 0.27` to `0.28`.
- Bumped CTModels compat from `0.14, 0.15` to `0.15`.
- Bumped version to `0.4.27-beta`.
- Updated `docs/Project.toml` CTBase compat accordingly.

## Verification

All 393 strategy tests pass:
```
Test Summary:                                              | Pass  Total  Time
CTSolvers tests                                            |  393    393  30.8s
```