### PR TITLE
Fix test registries to use explicit parameters + add parameter=nothing for mock strategies

### DIFF
--- a/test/suite/integration/test_comprehensive_validation.jl
+++ b/test/suite/integration/test_comprehensive_validation.jl
@@ -197,9 +197,9 @@ function test_strategy_construction(
 
         Test.@testset "build_strategy_from_resolved()" begin
             method = if family == Modelers.AbstractNLPModeler
-                (:collocation, strategy_id, :ipopt)
+                (:collocation, strategy_id, :ipopt, :cpu)
             else
-                (:collocation, :adnlp, strategy_id)
+                (:collocation, :adnlp, strategy_id, :cpu)
             end
 
             families = (strategy=family,)
@@ -331,16 +331,19 @@ function test_comprehensive_validation()
 
         # Create registries for testing
         modeler_registry = Strategies.create_registry(
-            Modelers.AbstractNLPModeler => (Modelers.ADNLP, Modelers.Exa)
+            Modelers.AbstractNLPModeler => (
+                (Modelers.ADNLP, [Strategies.CPU]),
+                (Modelers.Exa, [Strategies.CPU, Strategies.GPU]),
+            )
         )
 
         # Create solver registry based on available extensions
         solver_types = []
-        IPOPT_AVAILABLE && push!(solver_types, Solvers.Ipopt)
-        MADNLP_AVAILABLE && push!(solver_types, Solvers.MadNLP)
-        MADNCL_AVAILABLE && push!(solver_types, Solvers.MadNCL)
-        UNO_AVAILABLE && push!(solver_types, Solvers.Uno)
-        # KNITRO_AVAILABLE && push!(solver_types, Solvers.Knitro)  # Never available - no license
+        IPOPT_AVAILABLE && push!(solver_types, (Solvers.Ipopt, [Strategies.CPU]))
+        MADNLP_AVAILABLE && push!(solver_types, (Solvers.MadNLP, [Strategies.CPU, Strategies.GPU]))
+        MADNCL_AVAILABLE && push!(solver_types, (Solvers.MadNCL, [Strategies.CPU, Strategies.GPU]))
+        UNO_AVAILABLE && push!(solver_types, (Solvers.Uno, [Strategies.CPU]))
+        # KNITRO_AVAILABLE && push!(solver_types, (Solvers.Knitro, [Strategies.CPU]))  # Never available - no license
 
         solver_registry = if isempty(solver_types)
             Strategies.create_registry(Solvers.AbstractNLPSolver => ())
@@ -711,7 +714,7 @@ function test_comprehensive_validation()
                 )
                 # Test.@test modeler2.options.mode == :permissive  # WRONG - mode should NOT be stored
 
-                method = (:collocation, :adnlp, :ipopt)
+                method = (:collocation, :adnlp, :ipopt, :cpu)
                 families = (modeler=Modelers.AbstractNLPModeler,)
                 resolved = Orchestration.resolve_method(method, families, registry)
                 modeler3 = Orchestration.build_strategy_from_resolved(
@@ -759,7 +762,10 @@ function test_comprehensive_validation()
                 local unknown_options = (test_consistency=42)
 
                 local registry = Strategies.create_registry(
-                    Modelers.AbstractNLPModeler => (Modelers.ADNLP, Modelers.Exa)
+                    Modelers.AbstractNLPModeler => (
+                        (Modelers.ADNLP, [Strategies.CPU]),
+                        (Modelers.Exa, [Strategies.CPU, Strategies.GPU]),
+                    )
                 )
 
                 # Create strategies with different methods - redirect stderr to hide warnings
@@ -780,7 +786,7 @@ function test_comprehensive_validation()
                         mode=:permissive,
                     )
 
-                    method = (:collocation, :adnlp, :ipopt)
+                    method = (:collocation, :adnlp, :ipopt, :cpu)
                     families = (modeler=Modelers.AbstractNLPModeler,)
                     resolved = Orchestration.resolve_method(method, families, registry)
                     modeler3 = Orchestration.build_strategy_from_resolved(

--- a/test/suite/integration/test_route_to_comprehensive.jl
+++ b/test/suite/integration/test_route_to_comprehensive.jl
@@ -92,6 +92,11 @@ Strategies.id(::Type{RouteADNLP}) = :adnlp
 Strategies.id(::Type{RouteIpopt}) = :ipopt
 Strategies.id(::Type{RouteMadNLP}) = :madnlp
 
+Strategies.parameter(::Type{<:RouteCollocation}) = nothing
+Strategies.parameter(::Type{<:RouteADNLP}) = nothing
+Strategies.parameter(::Type{<:RouteIpopt}) = nothing
+Strategies.parameter(::Type{<:RouteMadNLP}) = nothing
+
 # Add constructors for mock strategies
 function RouteCollocation(; mode=:strict, kwargs...)
     options = Strategies.build_strategy_options(RouteCollocation; mode=mode, kwargs...)
@@ -175,6 +180,7 @@ const MOCK_REGISTRY = Strategies.create_registry(
 # Test method and families
 const MOCK_METHOD = (:collocation, :adnlp, :ipopt)
 const MOCK_METHOD_MULTI = (:collocation, :adnlp, :ipopt)
+const REAL_METHOD = (:collocation, :adnlp, :ipopt, :cpu)
 
 const MOCK_FAMILIES = (
     discretizer=RouteTestDiscretizer, modeler=RouteTestModeler, solver=RouteTestSolver
@@ -500,7 +506,7 @@ function test_route_to_comprehensive()
             Test.@testset "Real Modelers.ADNLP" begin
                 real_registry = Strategies.create_registry(
                     RouteTestDiscretizer => (RouteCollocation,),
-                    Modelers.AbstractNLPModeler => (Modelers.ADNLP,),
+                    Modelers.AbstractNLPModeler => ((Modelers.ADNLP, [Strategies.CPU]),),
                     RouteTestSolver => (RouteIpopt,),
                 )
 
@@ -518,12 +524,12 @@ function test_route_to_comprehensive()
                 )
 
                 routed = Orchestration.route_all_options(
-                    MOCK_METHOD, real_families, ACTION_DEFS, kwargs, real_registry
+                    REAL_METHOD, real_families, ACTION_DEFS, kwargs, real_registry
                 )
 
                 # Build real modeler
                 resolved = Orchestration.resolve_method(
-                    MOCK_METHOD, real_families, real_registry
+                    REAL_METHOD, real_families, real_registry
                 )
                 real_modeler = Orchestration.build_strategy_from_resolved(
                     resolved,
@@ -543,7 +549,7 @@ function test_route_to_comprehensive()
                     real_registry = Strategies.create_registry(
                         RouteTestDiscretizer => (RouteCollocation,),
                         RouteTestModeler => (RouteADNLP,),
-                        Solvers.AbstractNLPSolver => (Solvers.Uno,),
+                        Solvers.AbstractNLPSolver => ((Solvers.Uno, [Strategies.CPU]),),
                     )
 
                     real_families = (
@@ -553,7 +559,7 @@ function test_route_to_comprehensive()
                     )
 
                     # Use :uno in method tuple, not :ipopt
-                    uno_method = (:collocation, :adnlp, :uno)
+                    uno_method = (:collocation, :adnlp, :uno, :cpu)
 
                     kwargs = (
                         grid_size=200,
@@ -594,7 +600,7 @@ function test_route_to_comprehensive()
                     real_registry = Strategies.create_registry(
                         RouteTestDiscretizer => (RouteCollocation,),
                         RouteTestModeler => (RouteADNLP,),
-                        Solvers.AbstractNLPSolver => (Solvers.Ipopt,),
+                        Solvers.AbstractNLPSolver => ((Solvers.Ipopt, [Strategies.CPU]),),
                     )
 
                     real_families = (
@@ -611,12 +617,12 @@ function test_route_to_comprehensive()
                     )
 
                     routed = Orchestration.route_all_options(
-                        MOCK_METHOD, real_families, ACTION_DEFS, kwargs, real_registry
+                        REAL_METHOD, real_families, ACTION_DEFS, kwargs, real_registry
                     )
 
                     # Build real solver
                     resolved = Orchestration.resolve_method(
-                        MOCK_METHOD, real_families, real_registry
+                        REAL_METHOD, real_families, real_registry
                     )
                     real_solver = Orchestration.build_strategy_from_resolved(
                         resolved,
@@ -626,7 +632,7 @@ function test_route_to_comprehensive()
                         routed.strategies.solver...,
                     )
 
-                    # Verify real solver has the routed options 
+                    # Verify real solver has the routed options
                     test_option_routing(real_solver, :tol, 1e-6)
                     test_option_routing(real_solver, :max_iter, 1000)
                 end
@@ -637,7 +643,7 @@ function test_route_to_comprehensive()
                     real_registry = Strategies.create_registry(
                         RouteTestDiscretizer => (RouteCollocation,),
                         RouteTestModeler => (RouteADNLP,),
-                        Solvers.AbstractNLPSolver => (Solvers.Ipopt,),
+                        Solvers.AbstractNLPSolver => ((Solvers.Ipopt, [Strategies.CPU]),),
                     )
 
                     real_families = (
@@ -655,12 +661,12 @@ function test_route_to_comprehensive()
                     )
 
                     routed = Orchestration.route_all_options(
-                        MOCK_METHOD, real_families, ACTION_DEFS, kwargs, real_registry
+                        REAL_METHOD, real_families, ACTION_DEFS, kwargs, real_registry
                     )
 
                     # Build real solver
                     resolved = Orchestration.resolve_method(
-                        MOCK_METHOD, real_families, real_registry
+                        REAL_METHOD, real_families, real_registry
                     )
                     real_solver = Orchestration.build_strategy_from_resolved(
                         resolved,

--- a/test/suite/integration/test_strict_permissive_integration.jl
+++ b/test/suite/integration/test_strict_permissive_integration.jl
@@ -51,6 +51,10 @@ Strategies.id(::Type{FakeSolver}) = :fake_solver
 Strategies.id(::Type{FakeModeler}) = :fake_modeler
 Strategies.id(::Type{FakeDiscretizer}) = :fake_discretizer
 
+Strategies.parameter(::Type{<:FakeSolver}) = nothing
+Strategies.parameter(::Type{<:FakeModeler}) = nothing
+Strategies.parameter(::Type{<:FakeDiscretizer}) = nothing
+
 # Metadata for FakeSolver
 function Strategies.metadata(::Type{FakeSolver})
     return Strategies.StrategyMetadata(


### PR DESCRIPTION
## Summary

CTBase PR #497 introduced the `parameter` contract for `AbstractStrategy`. Parameterized strategies (e.g. `Ipopt{P}`) must be registered with explicit parameter lists `(Ipopt, [CPU])` so the registry stores concrete `Ipopt{CPU}` — not the UnionAll `Ipopt`. The CTSolvers tests were registering parameterized strategies as bare UnionAlls, which triggered `NotImplemented` from the `parameter` contract. Additionally, non-parameterized mock strategies in tests lacked the required `parameter = nothing` method.

## Changes

- **`test_comprehensive_validation.jl`**: Fixed registries to use explicit parameter lists `(ADNLP, [CPU])`, `(Exa, [CPU, GPU])`, `(Ipopt, [CPU])`, etc. Added `:cpu` token to method tuples used with parameterized registries.
- **`test_route_to_comprehensive.jl`**: Added `parameter = nothing` for 4 mock strategies (`RouteCollocation`, `RouteADNLP`, `RouteIpopt`, `RouteMadNLP`). Fixed real strategy registries to use explicit parameters. Added `REAL_METHOD` constant with `:cpu` token for real strategy tests.
- **`test_strict_permissive_integration.jl`**: Added `parameter = nothing` for 3 mock strategies (`FakeSolver`, `FakeModeler`, `FakeDiscretizer`).

## Rationale

The old `get_parameter_type` silently returned `nothing` for UnionAll types via try/catch, masking incorrect registry entries. The new `parameter` contract correctly exposes this: parameterized strategies must be registered with explicit parameter lists, as `OptimalControl.jl` already does. No CTBase or CTSolvers source changes needed — the fix is entirely in test setup.

## Test Results

All 511 integration tests pass (0 failed, 0 errored).