### PR TITLE
Fix GPU CI: propagate modeler backend option to test-problem builders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ tmp/
 .vscode/
 .extras/
 .coverage/
+.claude/

--- a/test/problems/problems_definition.jl
+++ b/test/problems/problems_definition.jl
@@ -6,25 +6,30 @@
 
 import CTSolvers.Optimization
 import CTSolvers.Modelers
+import CTBase.Strategies
 
 struct OptimizationProblem{A,E} <: CTSolvers.AbstractOptimizationProblem
     build_adnlp_model::A
     build_exa_model::E
 end
 
-# Build the ADNLP model from the wrapped builder.
+# Build the ADNLP model from the wrapped builder, forwarding all modeler options.
 function Optimization.build_model(
-    prob::OptimizationProblem, initial_guess, ::Modelers.ADNLP
+    prob::OptimizationProblem, initial_guess, modeler::Modelers.ADNLP
 )
-    nlp = prob.build_adnlp_model(initial_guess)
+    options = Strategies.options_dict(modeler)
+    nlp = prob.build_adnlp_model(initial_guess; options...)
     return Optimization.BuiltModel(prob, nlp, Optimization.NoCache())
 end
 
-# Build the Exa model from the wrapped builder, using the modeler base type.
+# Build the Exa model from the wrapped builder, using the modeler base type and
+# forwarding all remaining options (e.g. backend).
 function Optimization.build_model(
     prob::OptimizationProblem, initial_guess, modeler::Modelers.Exa
 )
-    nlp = prob.build_exa_model(modeler[:base_type], initial_guess)
+    options = Strategies.options_dict(modeler)
+    base_type = pop!(options, :base_type)
+    nlp = prob.build_exa_model(base_type, initial_guess; options...)
     return Optimization.BuiltModel(prob, nlp, Optimization.NoCache())
 end
 

--- a/test/suite/extensions/test_madnlp_extension.jl
+++ b/test/suite/extensions/test_madnlp_extension.jl
@@ -286,8 +286,8 @@ function test_madnlp_extension()
 
         Test.@testset "GPU Tests" begin
             if is_cuda_on() && MadNLPGPU.CUDSSSolver isa Type
-                gpu_modeler = Modelers.Exa(backend=CUDA.CUDABackend())
-                gpu_solver = Solvers.MadNLP(
+                gpu_modeler = Modelers.Exa{Strategies.GPU}()
+                gpu_solver = Solvers.MadNLP{Strategies.GPU}(
                     max_iter=1000,
                     tol=1e-6,
                     print_level=MadNLP.ERROR,

--- a/test/suite/optimization/test_problem_definition.jl
+++ b/test/suite/optimization/test_problem_definition.jl
@@ -1,0 +1,95 @@
+module TestProblemDefinition
+
+using Test: Test
+import CTSolvers.Optimization
+import CTSolvers.Modelers
+import CTBase.Strategies
+using CUDA: CUDA
+
+include(joinpath(@__DIR__, "..", "..", "problems", "TestProblems.jl"))
+import .TestProblems
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+"""
+    test_problem_definition()
+
+🧪 Contract test for `test/problems/problems_definition.jl`'s `Optimization.build_model`
+methods: every modeler option (in particular `:backend`) must reach the wrapped
+`build_adnlp_model`/`build_exa_model` closure, not just `:base_type`.
+
+Uses fake builder closures that record their kwargs instead of building a real NLP
+model, so the forwarding contract is checked on CPU-only CI — no functional CUDA
+required — unlike the end-to-end GPU solves in `test_madnlp_extension.jl` /
+`test_madncl_extension.jl`, which are skipped unless real GPU hardware is present.
+This is the regression test for the bug where `Modelers.Exa{GPU}`'s `:backend`
+option was silently dropped, so GPU-strategy tests kept building CPU-resident
+models without any test noticing on CPU-only CI.
+"""
+function test_problem_definition()
+    Test.@testset "Problem definition — modeler option forwarding" verbose=VERBOSE showtiming=SHOWTIMING begin
+
+        # ====================================================================
+        # CONTRACT TESTS - Exa modeler
+        # ====================================================================
+
+        Test.@testset "Exa modeler forwards backend (GPU)" begin
+            received = Ref{Any}(nothing)
+            build_exa = (base_type, initial_guess; kwargs...) -> begin
+                received[] = (base_type, NamedTuple(kwargs))
+                return initial_guess
+            end
+            prob = TestProblems.OptimizationProblem(nothing, build_exa)
+
+            modeler = Modelers.Exa{Strategies.GPU}()
+            Optimization.build_model(prob, [1.0], modeler)
+
+            base_type, kwargs = received[]
+            Test.@test base_type == Float64
+            Test.@test haskey(kwargs, :backend)
+            Test.@test kwargs[:backend] === modeler[:backend]
+            Test.@test modeler[:backend] isa CUDA.CUDABackend
+        end
+
+        Test.@testset "Exa modeler forwards backend (CPU)" begin
+            received = Ref{Any}(nothing)
+            build_exa = (base_type, initial_guess; kwargs...) -> begin
+                received[] = (base_type, NamedTuple(kwargs))
+                return initial_guess
+            end
+            prob = TestProblems.OptimizationProblem(nothing, build_exa)
+
+            modeler = Modelers.Exa{Strategies.CPU}()
+            Optimization.build_model(prob, [1.0], modeler)
+
+            base_type, kwargs = received[]
+            Test.@test base_type == Float64
+            Test.@test kwargs[:backend] === nothing
+        end
+
+        # ====================================================================
+        # CONTRACT TESTS - ADNLP modeler
+        # ====================================================================
+
+        Test.@testset "ADNLP modeler forwards its options" begin
+            received = Ref{Any}(nothing)
+            build_adnlp = (initial_guess; kwargs...) -> begin
+                received[] = NamedTuple(kwargs)
+                return initial_guess
+            end
+            prob = TestProblems.OptimizationProblem(build_adnlp, nothing)
+
+            modeler = Modelers.ADNLP()
+            Optimization.build_model(prob, [1.0], modeler)
+
+            kwargs = received[]
+            Test.@test haskey(kwargs, :backend)
+            Test.@test kwargs[:backend] === modeler[:backend]
+        end
+    end
+end
+
+end # module
+
+test_problem_definition() = TestProblemDefinition.test_problem_definition()


### PR DESCRIPTION
## Summary

The self-hosted GPU runner (`kkt`) is now functional in CI, and it surfaces 13 test
errors across `test_madncl_extension.jl` and `test_madnlp_extension.jl`'s GPU
testsets — testsets that were always silently skipped before (`is_cuda_on() ==
false`), so this was the first time they actually ran:

```
MethodError: no method matching MadNLPGPU.CUDSSSolver(::SparseMatrixCSC{Float64, Int32}; opt::MadNLPGPU.CudssSolverOptions)
```

**Root cause**: `OptimizationProblem`'s `Optimization.build_model` methods in
`test/problems/problems_definition.jl` only forwarded `modeler[:base_type]` (Exa) or
nothing at all (ADNLP) to the wrapped `build_*_model` closures, silently dropping
every other modeler option — including `:backend`. So a `GPU`-strategy `Exa`
modeler still built a CPU-resident `ExaModels.ExaModel`, which then crashed when
handed to the GPU-only `MadNLPGPU.CUDSSSolver`.

Confirmed this is a regression (not a pre-existing test bug) against tag `v0.4.17`:
back then `Modelers.Exa`/`Modelers.ADNLP` were callable functors that forwarded
**all** options via `Strategies.options_dict(modeler)`. Commit `5d01d1d`
("test: update suite to the dispatch-based DOCP contract") replaced that pattern
with today's `Optimization.build_model` dispatch but dropped the general option
forwarding in the process.

Also checked CTDirect.jl's `refactor/docp-dispatch` branch for the same
regression in the real DOCP path: it already forwards options correctly
(`Strategies.options_dict(modeler)` / `modeler[:backend]`), so this fix is
confined to CTSolvers' own test harness — no CTDirect change needed.

## Changes

- `test/problems/problems_definition.jl`: `build_model` for `Modelers.ADNLP` /
  `Modelers.Exa` now forwards the full `Strategies.options_dict(modeler)` to the
  builder closure instead of dropping options.
- `test/suite/extensions/test_madnlp_extension.jl`: the one remaining GPU testset
  using parameter-less (CPU-defaulting) `Modelers.Exa(...)` /
  `Solvers.MadNLP(...)` constructors now uses explicit `{Strategies.GPU}`,
  matching every other GPU testset in the suite.
- `test/suite/optimization/test_problem_definition.jl` (new): contract-level
  regression test that catches this bug class on CPU-only CI, without needing
  real GPU hardware — it intercepts the builder closure's kwargs with fakes
  instead of building a real NLP model. Verified it fails against the pre-fix
  code and passes against the fix.

No `src/` or `ext/` changes — the strategy/backend metadata and defaulting logic
were already correct; only the test harness failed to use them.

## Test plan

- [x] Full CPU test suite green locally (2587/2587 passed), including the new
      regression test.
- [x] New regression test manually verified to fail against the pre-fix code and
      pass against the fix.
- [ ] GPU CI job (`test-gpu-kkt`, gated by the `run ci gpu` label) — this is the
      real verification of the `CUDSSSolver`/GPU-array path; no CUDA hardware
      available locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)