### PR TITLE
Rename internal build_* stubs to _build_* for Handbook convention

### DIFF
--- a/.github/workflows/Breakage.yml
+++ b/.github/workflows/Breakage.yml
@@ -5,7 +5,7 @@ name: Breakage
 # no access to secrets
 on:
   pull_request:
-    types: [labeled, synchronize, opened, reopened]
+    types: [labeled, synchronize, reopened]
 
 jobs:
   call:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ on:
       - main
     tags: '*'
   pull_request:
-    types: [labeled, synchronize, opened, reopened]
+    types: [labeled, synchronize, reopened]
     
 jobs:
   # Job pour les runners GitHub hosted (ubuntu, windows, macos)

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -6,7 +6,7 @@ on:
       - main
     tags: '*'
   pull_request:
-    types: [labeled, synchronize, opened, reopened]
+    types: [labeled, synchronize, reopened]
   
 jobs:
   call:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.32-beta] - 2026-07-22
+
+### Changed
+
+- **Internal builder stubs renamed with `_` prefix** — all `build_*_solver`,
+  `build_*_modeler`, and `build_sciml_integrator` functions are renamed to
+  `_build_*_solver`, `_build_*_modeler`, and `_build_sciml_integrator`
+  respectively, following the Handbook convention for unexported internal
+  functions. `build_sciml_integrator` is also removed from `Integrators`
+  exports (it was the only one still exported).
+  **Breaking** (for direct callers of the stub): use the public constructors
+  (`SciML(...)`, `ADNLP(...)`, `Ipopt(...)`, etc.) instead.
+
+---
+
 ## [0.4.31-beta] - 2026-07-22
 
 ### Removed
@@ -36,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Strategies.metadata(SciML{P})` specialized on the device (option set currently
     identical for both — `P` marks the seam where GPU-specific defaults/validators
     land later); bare `metadata(SciML)` delegates through `SciML{CPU}`.
-  - `build_sciml_integrator(SciMLTag, P; …)` builds a `SciML{P,…}`.
+  - `_build_sciml_integrator(SciMLTag, P; …)` builds a `SciML{P,…}`.
   - `__consistent_initial_condition(parameter_type, u0)` stub (core, returns `true`);
     the `CTSolversCUDA` extension adds device-aware methods: a `CuArray` `u0` is
     inconsistent with `SciML{CPU}`, a host `Array` `u0` inconsistent with `SciML{GPU}`.
@@ -215,7 +230,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     their existing solver-backend trigger) since they dispatch on
     `NLPModels.AbstractNLPModel`.
   - Core modeler stubs follow the Ipopt tag-dispatch pattern:
-    `build_adnlp_modeler` / `build_exa_modeler` throw `ExtensionError` when their
+    `_build_adnlp_modeler` / `_build_exa_modeler` throw `ExtensionError` when their
     respective extension is not loaded; `Strategies.metadata` stubs do the same.
   - `validate_backend_override` in core is rewritten to use two tag-dispatch helpers
     (`__is_adbackend_type` / `__is_adbackend_instance`) so it no longer references

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTSolvers"
 uuid = "d3e8d392-8e4b-4d9b-8e92-d7d4e3650ef6"
-version = "0.4.31-beta"
+version = "0.4.32-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -224,8 +224,8 @@ CTBase.Strategies.parameter(::Type{<:Solvers.Ipopt{P}}) where {P<:CPU} = P
 # Constructor chain: resolve P, then dispatch on the tag and parameter TYPES
 Solvers.Ipopt(; kwargs...) =
     Solvers.Ipopt{CTBase.Strategies.default_parameter(Solvers.Ipopt)}(; kwargs...)
-Solvers.Ipopt{P}(; kwargs...) where {P<:CPU} = build_ipopt_solver(IpoptTag, P; kwargs...)
-build_ipopt_solver(::Type{<:Core.AbstractTag}, ::Type{<:AbstractStrategyParameter}; kwargs...) =
+Solvers.Ipopt{P}(; kwargs...) where {P<:CPU} = _build_ipopt_solver(IpoptTag, P; kwargs...)
+_build_ipopt_solver(::Type{<:Core.AbstractTag}, ::Type{<:AbstractStrategyParameter}; kwargs...) =
     throw(ExtensionError(:NLPModelsIpopt))
 ```
 
@@ -233,7 +233,7 @@ build_ipopt_solver(::Type{<:Core.AbstractTag}, ::Type{<:AbstractStrategyParamete
 
 ```julia
 metadata(::Type{Solvers.Ipopt{P}}) where {P<:CPU} = StrategyMetadata(...)
-build_ipopt_solver(::Type{Solvers.IpoptTag}, P::Type{<:AbstractStrategyParameter}; kwargs...) =
+_build_ipopt_solver(::Type{Solvers.IpoptTag}, P::Type{<:AbstractStrategyParameter}; kwargs...) =
     Solvers.Ipopt{P}(validated_opts)
 CommonSolve.solve(nlp, solver::Solvers.Ipopt; display) = ipopt(nlp; options_dict(solver)...)
 ```

--- a/docs/src/guides/implementing_a_modeler.md
+++ b/docs/src/guides/implementing_a_modeler.md
@@ -123,12 +123,12 @@ end
 
 # Parameterized constructor → tag dispatch, tag and parameter passed as TYPES
 function Modelers.ADNLP{P}(; mode::Symbol=:strict, kwargs...) where {P<:CPU}
-    return build_adnlp_modeler(ADNLPTag, P; mode=mode, kwargs...)
+    return _build_adnlp_modeler(ADNLPTag, P; mode=mode, kwargs...)
 end
 
 # Stub — throws until ADNLPModels is loaded; the extension provides the
-# typed method build_adnlp_modeler(::Type{ADNLPTag}, ::Type{<:CPU}; ...)
-function build_adnlp_modeler(
+# typed method _build_adnlp_modeler(::Type{ADNLPTag}, ::Type{<:CPU}; ...)
+function _build_adnlp_modeler(
     ::Type{<:CTBase.Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter};
     kwargs...,
 )
@@ -146,7 +146,7 @@ showerror(IOContext(stdout, :color => false), e) # hide
 end # hide
 ```
 
-With `using ADNLPModels`, the extension's `build_adnlp_modeler` validates the options
+With `using ADNLPModels`, the extension's `_build_adnlp_modeler` validates the options
 against the metadata and returns the configured instance:
 
 ```julia
@@ -231,7 +231,7 @@ CTBase.Strategies.default_parameter(::Type{<:Modelers.Exa}) = CPU
 CTBase.Strategies.parameter(::Type{<:Modelers.Exa{P}}) where {P<:Union{CPU,GPU}} = P
 
 function Modelers.Exa{P}(; mode::Symbol=:strict, kwargs...) where {P<:AbstractStrategyParameter}
-    return build_exa_modeler(ExaTag, P; mode=mode, kwargs...)
+    return _build_exa_modeler(ExaTag, P; mode=mode, kwargs...)
 end
 ```
 

--- a/docs/src/guides/implementing_a_solver.md
+++ b/docs/src/guides/implementing_a_solver.md
@@ -94,11 +94,11 @@ end
 
 # Parameterized → tag dispatch, IpoptTag and P passed as TYPES
 function Solvers.Ipopt{P}(; mode::Symbol = :strict, kwargs...) where {P<:CPU}
-    return build_ipopt_solver(IpoptTag, P; mode = mode, kwargs...)
+    return _build_ipopt_solver(IpoptTag, P; mode = mode, kwargs...)
 end
 
 # Stub — real implementation in ext/CTSolversIpopt.jl
-function build_ipopt_solver(
+function _build_ipopt_solver(
     ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
 )
     throw(Exceptions.ExtensionError(
@@ -143,10 +143,10 @@ Solvers.Ipopt(; mode = :strict, kwargs...) =
     Solvers.Ipopt{CTBase.Strategies.default_parameter(Solvers.Ipopt)}(; mode, kwargs...)
 
 Solvers.Ipopt{P}(; mode = :strict, kwargs...) where {P<:CPU} =
-    build_ipopt_solver(IpoptTag, P; mode, kwargs...)
+    _build_ipopt_solver(IpoptTag, P; mode, kwargs...)
 
 # Stub — throws until NLPModelsIpopt is loaded
-build_ipopt_solver(::Type{<:Core.AbstractTag}, ::Type{<:AbstractStrategyParameter}; kwargs...) =
+_build_ipopt_solver(::Type{<:Core.AbstractTag}, ::Type{<:AbstractStrategyParameter}; kwargs...) =
     throw(Exceptions.ExtensionError(:NLPModelsIpopt))
 ```
 
@@ -157,7 +157,7 @@ build_ipopt_solver(::Type{<:Core.AbstractTag}, ::Type{<:AbstractStrategyParamete
 CTBase.Strategies.metadata(::Type{Solvers.Ipopt{P}}) where {P<:CPU} = StrategyMetadata(...)
 
 # Real constructor — validates options for the parameterized type and builds the struct
-build_ipopt_solver(::Type{Solvers.IpoptTag}, parameter::Type{<:AbstractStrategyParameter}; mode, kwargs...) =
+_build_ipopt_solver(::Type{Solvers.IpoptTag}, parameter::Type{<:AbstractStrategyParameter}; mode, kwargs...) =
     Solvers.Ipopt{parameter}(CTBase.Strategies.build_strategy_options(Solvers.Ipopt{parameter}; mode, kwargs...))
 
 # Solve method — dispatches on NLP type and solver type
@@ -244,7 +244,7 @@ end
 **2. Constructor** — builds validated options for the parameterized type and returns the solver:
 
 ```julia
-function Solvers.build_ipopt_solver(
+function Solvers._build_ipopt_solver(
     ::Type{Solvers.IpoptTag},
     parameter::Type{<:AbstractStrategyParameter};
     mode::Symbol = :strict,

--- a/docs/src/guides/implementing_an_integrator.md
+++ b/docs/src/guides/implementing_an_integrator.md
@@ -107,11 +107,11 @@ The constructor delegates to a `build_*` function that dispatches on the tag. Th
 
 ```julia
 function SciML(; mode::Symbol = :strict, kwargs...)
-    return build_sciml_integrator(SciMLTag; mode = mode, kwargs...)
+    return _build_sciml_integrator(SciMLTag; mode = mode, kwargs...)
 end
 
 # Stub — real implementation in ext/CTSolversSciMLIntegrator.jl
-function build_sciml_integrator(::Type{<:Core.AbstractTag}; kwargs...)
+function _build_sciml_integrator(::Type{<:Core.AbstractTag}; kwargs...)
     throw(Exceptions.ExtensionError(
         :OrdinaryDiffEqTsit5;
         message = "to construct a SciML integrator",
@@ -132,10 +132,10 @@ src/Integrators/sciml.jl                ext/CTSolversSciMLIntegrator.jl
 SciML <: AbstractSciMLIntegrator        metadata(::Type{SciML})
 SciMLTag <: Core.AbstractTag              → StrategyMetadata(option defs...)
 
-SciML(; kwargs...)                      build_sciml_integrator(::Type{SciMLTag}; …)
-  → build_sciml_integrator(SciMLTag; …)   → SciML(opts, options_point, options_traj)
+SciML(; kwargs...)                      _build_sciml_integrator(::Type{SciMLTag}; …)
+  → _build_sciml_integrator(SciMLTag; …)   → SciML(opts, options_point, options_traj)
 
-build_sciml_integrator(::AbstractTag)   solve(prob::AbstractODEProblem, ::SciML)
+_build_sciml_integrator(::AbstractTag)   solve(prob::AbstractODEProblem, ::SciML)
   → ExtensionError(:OrdinaryDiffEqTsit5)  → SciMLIntegrationResult
 
 solve(prob, ::AbstractIntegrator)       SciMLIntegrationResult (with accessors)
@@ -148,7 +148,7 @@ The split is:
 |----------|----------|
 | `src/Integrators/sciml.jl` | Struct, `id`/`description`, tag, constructor stub, `metadata`/`build` stubs, accessors |
 | `src/Integrators/contract.jl` | Generic `solve` stub, `merge` stub, `__unsafe` default |
-| `ext/CTSolversSciMLIntegrator.jl` | `metadata`, `build_sciml_integrator`, `SciMLIntegrationResult`, the typed `solve`, `merge` |
+| `ext/CTSolversSciMLIntegrator.jl` | `metadata`, `_build_sciml_integrator`, `SciMLIntegrationResult`, the typed `solve`, `merge` |
 
 This keeps CTSolvers lightweight — `SciMLBase`/`DiffEqBase` are only loaded when the user loads an ODE backend.
 
@@ -199,7 +199,7 @@ end
 **2. Constructor** — builds validated options and resolves the `:auto` sentinel into the cached point/trajectory dictionaries:
 
 ```julia
-function Integrators.build_sciml_integrator(::Type{Integrators.SciMLTag}; mode = :strict, kwargs...)
+function Integrators._build_sciml_integrator(::Type{Integrators.SciMLTag}; mode = :strict, kwargs...)
     opts = CTBase.Strategies.build_strategy_options(Integrators.SciML; mode = mode, kwargs...)
     raw  = CTBase.Strategies.options_dict(opts)
     options_point = copy(raw); options_trajectory = copy(raw)

--- a/ext/CTSolversADNLPModels.jl
+++ b/ext/CTSolversADNLPModels.jl
@@ -91,7 +91,7 @@ AD backend overrides for individual derivative operations.
 - `CTBase.Strategies.StrategyMetadata`: metadata object with all option definitions
 
 See also: [`CTSolvers.Modelers.ADNLP`](@ref),
-[`CTSolvers.Modelers.build_adnlp_modeler`](@ref)
+[`CTSolvers.Modelers._build_adnlp_modeler`](@ref)
 """
 function Strategies.metadata(::Type{Modelers.ADNLP{P}}) where {P<:CPU}
     return Strategies.StrategyMetadata(
@@ -202,9 +202,9 @@ and `:backend` should be used instead.
 - `CTSolvers.Modelers.ADNLP{parameter}`: configured modeler instance
 
 See also: [`CTSolvers.Modelers.ADNLP`](@ref),
-[`CTSolvers.Modelers.build_adnlp_modeler`](@ref)
+[`CTSolvers.Modelers._build_adnlp_modeler`](@ref)
 """
-function Modelers.build_adnlp_modeler(
+function Modelers._build_adnlp_modeler(
     ::Type{Modelers.ADNLPTag},
     parameter::Type{<:AbstractStrategyParameter};
     mode::Symbol=:strict,

--- a/ext/CTSolversExaModels.jl
+++ b/ext/CTSolversExaModels.jl
@@ -33,7 +33,7 @@ are loaded. Covers `:base_type` (floating-point precision) and `:backend`
 - `CTBase.Strategies.StrategyMetadata`: metadata object with all option definitions
 
 See also: [`CTSolvers.Modelers.Exa`](@ref),
-[`CTSolvers.Modelers.build_exa_modeler`](@ref)
+[`CTSolvers.Modelers._build_exa_modeler`](@ref)
 """
 function Strategies.metadata(::Type{Modelers.Exa{P}}) where {P<:Union{CPU,GPU}}
     return Strategies.StrategyMetadata(
@@ -86,9 +86,9 @@ is issued and `:backend` should be used instead.
 - `CTSolvers.Modelers.Exa{parameter}`: configured modeler instance
 
 See also: [`CTSolvers.Modelers.Exa`](@ref),
-[`CTSolvers.Modelers.build_exa_modeler`](@ref)
+[`CTSolvers.Modelers._build_exa_modeler`](@ref)
 """
-function Modelers.build_exa_modeler(
+function Modelers._build_exa_modeler(
     ::Type{Modelers.ExaTag},
     parameter::Type{<:AbstractStrategyParameter};
     mode::Symbol=:strict,

--- a/ext/CTSolversIpopt.jl
+++ b/ext/CTSolversIpopt.jl
@@ -560,13 +560,13 @@ Build an Ipopt with validated options.
 
 ```julia
 # Conceptual usage
-solver = build_ipopt_solver(IpoptTag; max_iter=1000)
-solver_permissive = build_ipopt_solver(IpoptTag; max_iter=1000, custom_option=123; mode=:permissive)
+solver = _build_ipopt_solver(IpoptTag; max_iter=1000)
+solver_permissive = _build_ipopt_solver(IpoptTag; max_iter=1000, custom_option=123; mode=:permissive)
 ```
 
 See also: `Solvers.Ipopt`, `Strategies.build_strategy_options`
 """
-function Solvers.build_ipopt_solver(
+function Solvers._build_ipopt_solver(
     ::Type{Solvers.IpoptTag},
     parameter::Type{<:AbstractStrategyParameter};
     mode::Symbol=:strict,

--- a/ext/CTSolversKnitro.jl
+++ b/ext/CTSolversKnitro.jl
@@ -213,11 +213,11 @@ Build a Knitro with validated options.
 
 ```julia
 # Conceptual usage
-solver = build_knitro_solver(KnitroTag; max_iter=1000)
-solver_permissive = build_knitro_solver(KnitroTag; max_iter=1000, custom_option=123; mode=:permissive)
+solver = _build_knitro_solver(KnitroTag; max_iter=1000)
+solver_permissive = _build_knitro_solver(KnitroTag; max_iter=1000, custom_option=123; mode=:permissive)
 ```
 """
-function Solvers.build_knitro_solver(
+function Solvers._build_knitro_solver(
     ::Type{Solvers.KnitroTag},
     parameter::Type{<:AbstractStrategyParameter};
     mode::Symbol=:strict,

--- a/ext/CTSolversMadNCL.jl
+++ b/ext/CTSolversMadNCL.jl
@@ -371,11 +371,11 @@ Build a MadNCL with validated options.
 
 ```julia
 # Conceptual usage
-solver_cpu = build_madncl_solver(MadNCLTag(), CPU(); max_iter=1000)
-solver_gpu = build_madncl_solver(MadNCLTag(), GPU(); max_iter=1000)  # requires MadNLPGPU
+solver_cpu = _build_madncl_solver(MadNCLTag(), CPU(); max_iter=1000)
+solver_gpu = _build_madncl_solver(MadNCLTag(), GPU(); max_iter=1000)  # requires MadNLPGPU
 ```
 """
-function Solvers.build_madncl_solver(
+function Solvers._build_madncl_solver(
     ::Type{Solvers.MadNCLTag},
     parameter::Type{<:AbstractStrategyParameter};
     mode::Symbol=:strict,

--- a/ext/CTSolversMadNLP.jl
+++ b/ext/CTSolversMadNLP.jl
@@ -471,11 +471,11 @@ Build a MadNLP with validated options.
 
 ```julia
 # Conceptual usage
-solver_cpu = build_madnlp_solver(MadNLPTag(), CPU(); max_iter=1000)
-solver_gpu = build_madnlp_solver(MadNLPTag(), GPU(); max_iter=1000)  # requires MadNLPGPU
+solver_cpu = _build_madnlp_solver(MadNLPTag(), CPU(); max_iter=1000)
+solver_gpu = _build_madnlp_solver(MadNLPTag(), GPU(); max_iter=1000)  # requires MadNLPGPU
 ```
 """
-function Solvers.build_madnlp_solver(
+function Solvers._build_madnlp_solver(
     ::Type{Solvers.MadNLPTag},
     parameter::Type{<:AbstractStrategyParameter};
     mode::Symbol=:strict,

--- a/ext/CTSolversSciMLIntegrator.jl
+++ b/ext/CTSolversSciMLIntegrator.jl
@@ -7,7 +7,7 @@ Activated automatically when `DiffEqBase` and `SciMLBase` are loaded together wi
 This extension provides:
 - `real_norm` overload for grid invariance (array case)
 - `Strategies.metadata` for `Integrators.SciML` options
-- `build_sciml_integrator` — constructs a `SciML` integrator with pre-computed option caches
+- `_build_sciml_integrator` — constructs a `SciML` integrator with pre-computed option caches
 - `SciMLIntegrationResult` — wraps `SciMLBase.AbstractODESolution`
 - `CommonSolve.solve(prob::AbstractODEProblem, integ::SciML)` — integrates and returns a result
 - `status`/`successful` — termination status derived from the ODE solution's `retcode`
@@ -271,7 +271,7 @@ function Strategies.metadata(
 end
 
 # =============================================================================
-# build_sciml_integrator — actual implementation
+# _build_sciml_integrator — actual implementation
 # =============================================================================
 
 """
@@ -287,7 +287,7 @@ integrator construction into two cached dictionaries:
 Users can override automatic resolution by providing explicit `true`/`false` values
 when constructing the integrator.
 
-See also: [`CTSolvers.Integrators.build_sciml_integrator`](@ref).
+See also: [`CTSolvers.Integrators._build_sciml_integrator`](@ref).
 """
 const _AUTO_OPTION_KEYS = (:dense, :save_everystep, :save_start)
 
@@ -316,7 +316,7 @@ cached dictionaries `options_point` (`:auto` → `false`) and `options_trajector
 
 See also: [`CTSolvers.Integrators.SciML`](@ref).
 """
-function Integrators.build_sciml_integrator(
+function Integrators._build_sciml_integrator(
     ::Type{Integrators.SciMLTag}, ::Type{P}; mode::Symbol=:strict, kwargs...
 ) where {P<:Strategies.AbstractStrategyParameter}
     opts = Strategies.build_strategy_options(Integrators.SciML{P}; mode=mode, kwargs...)

--- a/ext/CTSolversUno.jl
+++ b/ext/CTSolversUno.jl
@@ -304,13 +304,13 @@ Build a Uno solver with validated options.
 
 ```julia
 # Conceptual usage
-solver = build_uno_solver(UnoTag; max_iterations=1000)
-solver_permissive = build_uno_solver(UnoTag; max_iterations=1000, custom_option=123; mode=:permissive)
+solver = _build_uno_solver(UnoTag; max_iterations=1000)
+solver_permissive = _build_uno_solver(UnoTag; max_iterations=1000, custom_option=123; mode=:permissive)
 ```
 
 See also: `Solvers.Uno`, `Strategies.build_strategy_options`
 """
-function Solvers.build_uno_solver(
+function Solvers._build_uno_solver(
     ::Type{Solvers.UnoTag},
     parameter::Type{<:AbstractStrategyParameter};
     mode::Symbol=:strict,

--- a/src/Integrators/Integrators.jl
+++ b/src/Integrators/Integrators.jl
@@ -56,7 +56,6 @@ export AbstractIntegrator, AbstractSciMLIntegrator, SciML, SciMLTag, Tsit5Tag
 export AbstractIntegrationResult, final_state, times, evaluate_at, status, successful
 
 # Public API - construction and accessors
-export build_sciml_integrator
 export options_point, options_trajectory
 
 # Public API - multi-phase

--- a/src/Integrators/sciml.jl
+++ b/src/Integrators/sciml.jl
@@ -178,7 +178,7 @@ Construct a `SciML{CPU}` integrator (the default device). Equivalent to
 # Throws
 - `CTBase.Exceptions.ExtensionError`: If the `CTSolversSciMLIntegrator` extension is not loaded.
 
-See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTSolvers.Integrators.build_sciml_integrator`](@ref).
+See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTSolvers.Integrators._build_sciml_integrator`](@ref).
 """
 function SciML(; mode::Symbol=:strict, kwargs...)
     P = Strategies.default_parameter(SciML)
@@ -189,7 +189,7 @@ end
 $(TYPEDSIGNATURES)
 
 Construct a parameterized `SciML{P}` integrator for the execution device `P`
-(`CPU` or `GPU`). Delegates to `build_sciml_integrator`, which is overridden by the
+(`CPU` or `GPU`). Delegates to `_build_sciml_integrator`, which is overridden by the
 `CTSolversSciMLIntegrator` package extension.
 
 # Arguments
@@ -199,10 +199,10 @@ Construct a parameterized `SciML{P}` integrator for the execution device `P`
 # Throws
 - `CTBase.Exceptions.ExtensionError`: If the `CTSolversSciMLIntegrator` extension is not loaded.
 
-See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTSolvers.Integrators.build_sciml_integrator`](@ref).
+See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTSolvers.Integrators._build_sciml_integrator`](@ref).
 """
 function SciML{P}(; mode::Symbol=:strict, kwargs...) where {P<:AbstractStrategyParameter}
-    return build_sciml_integrator(SciMLTag, P; mode=mode, kwargs...)
+    return _build_sciml_integrator(SciMLTag, P; mode=mode, kwargs...)
 end
 
 """
@@ -212,7 +212,7 @@ Stub builder for `SciML`. The real implementation is provided by
 `CTSolversSciMLIntegrator`; this stub throws `ExtensionError` until the extension
 is loaded.
 """
-function build_sciml_integrator(
+function _build_sciml_integrator(
     ::Type{<:Core.AbstractTag}, ::Type{<:AbstractStrategyParameter}; kwargs...
 )
     return throw(

--- a/src/Modelers/adnlp.jl
+++ b/src/Modelers/adnlp.jl
@@ -313,10 +313,10 @@ Requires the CTSolversADNLPModels extension to be loaded.
 - `CTBase.Exceptions.ExtensionError`: If the ADNLPModels extension is not loaded
 - `CTBase.Exceptions.IncorrectArgument`: If option validation fails
 
-See also: `Modelers.ADNLP`, `build_adnlp_modeler`
+See also: `Modelers.ADNLP`, `_build_adnlp_modeler`
 """
 function Modelers.ADNLP{P}(; mode::Symbol=:strict, kwargs...) where {P<:CPU}
-    return build_adnlp_modeler(ADNLPTag, P; mode=mode, kwargs...)
+    return _build_adnlp_modeler(ADNLPTag, P; mode=mode, kwargs...)
 end
 
 """
@@ -330,7 +330,7 @@ Real implementation provided by the extension.
 
 See also: `Modelers.ADNLP`, `Strategies.metadata`
 """
-function build_adnlp_modeler(
+function _build_adnlp_modeler(
     ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
 )
     return throw(
@@ -374,7 +374,7 @@ modeler = Modelers.ADNLP(backend=:optimized, custom_option=123; mode=:permissive
 - `CTBase.Exceptions.ExtensionError`: If the ADNLPModels extension is not loaded
 - `CTBase.Exceptions.IncorrectArgument`: If option validation fails
 
-See also: `Modelers.ADNLP`, `Modelers.ADNLP{CPU}`, `build_adnlp_modeler`
+See also: `Modelers.ADNLP`, `Modelers.ADNLP{CPU}`, `_build_adnlp_modeler`
 """
 function Modelers.ADNLP(; mode::Symbol=:strict, kwargs...)
     P = Strategies.default_parameter(Modelers.ADNLP)

--- a/src/Modelers/exa.jl
+++ b/src/Modelers/exa.jl
@@ -333,12 +333,12 @@ Requires the CTSolversExaModels extension to be loaded.
 - `CTBase.Exceptions.ExtensionError`: If the ExaModels extension is not loaded
 - `CTBase.Exceptions.IncorrectArgument`: If option validation fails
 
-See also: `Modelers.Exa`, `build_exa_modeler`
+See also: `Modelers.Exa`, `_build_exa_modeler`
 """
 function Modelers.Exa{P}(;
     mode::Symbol=:strict, kwargs...
 ) where {P<:AbstractStrategyParameter}
-    return build_exa_modeler(ExaTag, P; mode=mode, kwargs...)
+    return _build_exa_modeler(ExaTag, P; mode=mode, kwargs...)
 end
 
 """
@@ -352,7 +352,7 @@ Real implementation provided by the extension.
 
 See also: `Modelers.Exa`, `Strategies.metadata`
 """
-function build_exa_modeler(
+function _build_exa_modeler(
     ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
 )
     return throw(
@@ -386,7 +386,7 @@ Requires the CTSolversExaModels extension to be loaded.
 - `CTBase.Exceptions.ExtensionError`: If the ExaModels extension is not loaded
 - `CTBase.Exceptions.IncorrectArgument`: If option validation fails
 
-See also: `Modelers.Exa`, `Modelers.Exa{CPU}`, `Modelers.Exa{GPU}`, `build_exa_modeler`
+See also: `Modelers.Exa`, `Modelers.Exa{CPU}`, `Modelers.Exa{GPU}`, `_build_exa_modeler`
 """
 function Modelers.Exa(; mode::Symbol=:strict, kwargs...)
     P = Strategies.default_parameter(Modelers.Exa)

--- a/src/Solvers/ipopt.jl
+++ b/src/Solvers/ipopt.jl
@@ -192,7 +192,7 @@ solver_permissive = Ipopt(max_iter=1000, custom_option=123; mode=:permissive)
 # Throws
 - `CTBase.Exceptions.ExtensionError`: If the NLPModelsIpopt extension is not loaded
 
-See also: `Ipopt`, `build_ipopt_solver`
+See also: `Ipopt`, `_build_ipopt_solver`
 """
 function Solvers.Ipopt(; mode::Symbol=:strict, kwargs...)
     P = Strategies.default_parameter(Solvers.Ipopt)
@@ -227,7 +227,7 @@ solver_cpu = Solvers.Ipopt{CPU}(max_iter=1000, tol=1e-6)
 See also: `Ipopt`, `CPU`
 """
 function Solvers.Ipopt{P}(; mode::Symbol=:strict, kwargs...) where {P<:CPU}
-    return build_ipopt_solver(IpoptTag, P; mode=mode, kwargs...)
+    return _build_ipopt_solver(IpoptTag, P; mode=mode, kwargs...)
 end
 
 """
@@ -241,7 +241,7 @@ Real implementation provided by the extension.
 
 See also: `Ipopt`, `Strategies.metadata`
 """
-function build_ipopt_solver(
+function _build_ipopt_solver(
     ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
 )
     return throw(

--- a/src/Solvers/knitro.jl
+++ b/src/Solvers/knitro.jl
@@ -195,7 +195,7 @@ solver_permissive = Knitro(maxit=1000, custom_option=123; mode=:permissive)
 # Throws
 - `CTBase.Exceptions.ExtensionError`: If the NLPModelsKnitro extension is not loaded
 
-See also: `Knitro`, `build_knitro_solver`
+See also: `Knitro`, `_build_knitro_solver`
 """
 function Solvers.Knitro(; mode::Symbol=:strict, kwargs...)
     P = Strategies.default_parameter(Solvers.Knitro)
@@ -230,7 +230,7 @@ solver_cpu = Solvers.Knitro{CPU}(maxit=1000, outlev=2)
 See also: `Knitro`, `CPU`
 """
 function Solvers.Knitro{P}(; mode::Symbol=:strict, kwargs...) where {P<:CPU}
-    return build_knitro_solver(KnitroTag, P; mode=mode, kwargs...)
+    return _build_knitro_solver(KnitroTag, P; mode=mode, kwargs...)
 end
 
 """
@@ -244,7 +244,7 @@ Real implementation provided by the extension.
 
 See also: `Knitro`, `Strategies.metadata`
 """
-function build_knitro_solver(
+function _build_knitro_solver(
     ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
 )
     return throw(

--- a/src/Solvers/madncl.jl
+++ b/src/Solvers/madncl.jl
@@ -149,7 +149,7 @@ solver_permissive = Solvers.MadNCL(max_iter=1000, custom_option=123; mode=:permi
 # Throws
 - `CTBase.Exceptions.ExtensionError`: If the MadNCL extension is not loaded
 
-See also: `MadNCL`, `build_madncl_solver`
+See also: `MadNCL`, `_build_madncl_solver`
 """
 function Solvers.MadNCL(; mode::Symbol=:strict, kwargs...)
     P = Strategies.default_parameter(Solvers.MadNCL)
@@ -187,7 +187,7 @@ See also: `MadNCL`, `CPU`, `GPU`
 function Solvers.MadNCL{P}(;
     mode::Symbol=:strict, kwargs...
 ) where {P<:AbstractStrategyParameter}
-    return build_madncl_solver(MadNCLTag, P; mode=mode, kwargs...)
+    return _build_madncl_solver(MadNCLTag, P; mode=mode, kwargs...)
 end
 
 """
@@ -201,7 +201,7 @@ Real implementation provided by the extension.
 
 See also: `MadNCL`, `Strategies.metadata`
 """
-function build_madncl_solver(
+function _build_madncl_solver(
     ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
 )
     return throw(

--- a/src/Solvers/madnlp.jl
+++ b/src/Solvers/madnlp.jl
@@ -155,7 +155,7 @@ solver_permissive = MadNLP(max_iter=1000, custom_option=123; mode=:permissive)
 # Throws
 - `CTBase.Exceptions.ExtensionError`: If the MadNLP extension is not loaded
 
-See also: `MadNLP`, `build_madnlp_solver`
+See also: `MadNLP`, `_build_madnlp_solver`
 """
 function Solvers.MadNLP(; mode::Symbol=:strict, kwargs...)
     P = Strategies.default_parameter(Solvers.MadNLP)
@@ -193,7 +193,7 @@ See also: `MadNLP`, `CPU`, `GPU`
 function Solvers.MadNLP{P}(;
     mode::Symbol=:strict, kwargs...
 ) where {P<:AbstractStrategyParameter}
-    return build_madnlp_solver(MadNLPTag, P; mode=mode, kwargs...)
+    return _build_madnlp_solver(MadNLPTag, P; mode=mode, kwargs...)
 end
 
 """
@@ -207,7 +207,7 @@ Real implementation provided by the extension.
 
 See also: `MadNLP`, `Strategies.metadata`
 """
-function build_madnlp_solver(
+function _build_madnlp_solver(
     ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
 )
     return throw(

--- a/src/Solvers/uno.jl
+++ b/src/Solvers/uno.jl
@@ -221,7 +221,7 @@ solver_permissive = Uno(max_iter=1000, custom_option=123; mode=:permissive)
 # Throws
 - `CTBase.Exceptions.ExtensionError`: If the UnoSolver extension is not loaded
 
-See also: `Uno`, `build_uno_solver`
+See also: `Uno`, `_build_uno_solver`
 """
 function Solvers.Uno(; mode::Symbol=:strict, kwargs...)
     P = Strategies.default_parameter(Solvers.Uno)
@@ -256,7 +256,7 @@ solver_cpu = Solvers.Uno{CPU}(max_iter=1000, tol=1e-6)
 See also: `Uno`, `CPU`
 """
 function Solvers.Uno{P}(; mode::Symbol=:strict, kwargs...) where {P<:CPU}
-    return build_uno_solver(UnoTag, P; mode=mode, kwargs...)
+    return _build_uno_solver(UnoTag, P; mode=mode, kwargs...)
 end
 
 """
@@ -270,7 +270,7 @@ Real implementation provided by the extension.
 
 See also: `Uno`, `Strategies.metadata`
 """
-function build_uno_solver(
+function _build_uno_solver(
     ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
 )
     return throw(

--- a/test/suite/integrators/test_integrator_exports.jl
+++ b/test/suite/integrators/test_integrator_exports.jl
@@ -57,7 +57,6 @@ function test_integrator_exports()
                 :evaluate_at,
                 :status,
                 :successful,
-                :build_sciml_integrator,
                 :options_point,
                 :options_trajectory,
                 :merge,
@@ -74,7 +73,7 @@ function test_integrator_exports()
         # ====================================================================
 
         Test.@testset "Internal symbols (not exported)" begin
-            for sym in (:__unsafe, :__default_sciml_algorithm, :deepvalue, :real_norm)
+            for sym in (:__unsafe, :__default_sciml_algorithm, :deepvalue, :real_norm, :_build_sciml_integrator)
                 Test.@testset "$sym" begin
                     Test.@test isdefined(Integrators, sym)
                     Test.@test !(sym in names(Integrators))

--- a/test/suite/integrators/test_integrator_stubs.jl
+++ b/test/suite/integrators/test_integrator_stubs.jl
@@ -10,7 +10,7 @@ using CommonSolve: CommonSolve
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
 
-# Fake tag never implemented by any extension: build_sciml_integrator stub must throw
+# Fake tag never implemented by any extension: _build_sciml_integrator stub must throw
 # even when the SciML extension is loaded (it only implements the concrete SciMLTag).
 struct DummyTag <: Core.AbstractTag end
 
@@ -30,17 +30,17 @@ function test_integrator_stubs()
     Test.@testset "Integrator Extension Stubs" verbose=VERBOSE showtiming=SHOWTIMING begin
 
         # ====================================================================
-        # build_sciml_integrator stub (DummyTag never implemented)
+        # _build_sciml_integrator stub (DummyTag never implemented)
         # ====================================================================
 
-        Test.@testset "build_sciml_integrator stub" begin
-            Test.@test_throws Exceptions.ExtensionError Integrators.build_sciml_integrator(
+        Test.@testset "_build_sciml_integrator stub" begin
+            Test.@test_throws Exceptions.ExtensionError Integrators._build_sciml_integrator(
                 DummyTag, Strategies.CPU
             )
 
             err = nothing
             try
-                Integrators.build_sciml_integrator(DummyTag, Strategies.CPU)
+                Integrators._build_sciml_integrator(DummyTag, Strategies.CPU)
             catch e
                 err = e
             end

--- a/test/suite/solvers/test_extension_stubs.jl
+++ b/test/suite/solvers/test_extension_stubs.jl
@@ -29,15 +29,15 @@ function test_extension_stubs()
         # ====================================================================
 
         Test.@testset "Solvers.Ipopt stub" begin
-            # Test that build_ipopt_solver throws ExtensionError with IpoptTag
-            Test.@test_throws Exceptions.ExtensionError Solvers.build_ipopt_solver(
+            # Test that _build_ipopt_solver throws ExtensionError with IpoptTag
+            Test.@test_throws Exceptions.ExtensionError Solvers._build_ipopt_solver(
                 DummyTag, Strategies.CPU
             )
 
             # Capture the error and verify its content
             err = nothing
             try
-                Solvers.build_ipopt_solver(DummyTag, Strategies.CPU)
+                Solvers._build_ipopt_solver(DummyTag, Strategies.CPU)
             catch e
                 err = e
             end
@@ -59,11 +59,11 @@ function test_extension_stubs()
 
         # Commented out - no Knitro license available
         # Test.@testset "Solvers.Knitro stub" begin
-        #     Test.@test_throws Exceptions.ExtensionError Solvers.build_knitro_solver(DummyTag())
+        #     Test.@test_throws Exceptions.ExtensionError Solvers._build_knitro_solver(DummyTag())
         #     
         #     err = nothing
         #     try
-        #         Solvers.build_knitro_solver(DummyTag())
+        #         Solvers._build_knitro_solver(DummyTag())
         #     catch e
         #         err = e
         #     end
@@ -81,13 +81,13 @@ function test_extension_stubs()
         # ====================================================================
 
         Test.@testset "Solvers.MadNLP stub" begin
-            Test.@test_throws Exceptions.ExtensionError Solvers.build_madnlp_solver(
+            Test.@test_throws Exceptions.ExtensionError Solvers._build_madnlp_solver(
                 DummyTag, Strategies.CPU
             )
 
             err = nothing
             try
-                Solvers.build_madnlp_solver(DummyTag, Strategies.CPU)
+                Solvers._build_madnlp_solver(DummyTag, Strategies.CPU)
             catch e
                 err = e
             end
@@ -107,13 +107,13 @@ function test_extension_stubs()
         # ====================================================================
 
         Test.@testset "Solvers.Uno stub" begin
-            Test.@test_throws Exceptions.ExtensionError Solvers.build_uno_solver(
+            Test.@test_throws Exceptions.ExtensionError Solvers._build_uno_solver(
                 DummyTag, Strategies.CPU
             )
 
             err = nothing
             try
-                Solvers.build_uno_solver(DummyTag, Strategies.CPU)
+                Solvers._build_uno_solver(DummyTag, Strategies.CPU)
             catch e
                 err = e
             end
@@ -133,13 +133,13 @@ function test_extension_stubs()
         # ====================================================================
 
         Test.@testset "Solvers.MadNCL stub" begin
-            Test.@test_throws Exceptions.ExtensionError Solvers.build_madncl_solver(
+            Test.@test_throws Exceptions.ExtensionError Solvers._build_madncl_solver(
                 DummyTag, Strategies.CPU
             )
 
             err = nothing
             try
-                Solvers.build_madncl_solver(DummyTag, Strategies.CPU)
+                Solvers._build_madncl_solver(DummyTag, Strategies.CPU)
             catch e
                 err = e
             end
@@ -161,12 +161,12 @@ function test_extension_stubs()
         Test.@testset "All stubs throw ExtensionError" begin
             # Verify that all build_*_solver stubs throw ExtensionError
             stubs = [
-                () -> Solvers.build_ipopt_solver(DummyTag, Strategies.CPU),
+                () -> Solvers._build_ipopt_solver(DummyTag, Strategies.CPU),
                 # Commented out - no Knitro license available
-                # () -> Solvers.build_knitro_solver(DummyTag()),
-                () -> Solvers.build_madnlp_solver(DummyTag, Strategies.CPU),
-                () -> Solvers.build_madncl_solver(DummyTag, Strategies.CPU),
-                () -> Solvers.build_uno_solver(DummyTag, Strategies.CPU),
+                # () -> Solvers._build_knitro_solver(DummyTag()),
+                () -> Solvers._build_madnlp_solver(DummyTag, Strategies.CPU),
+                () -> Solvers._build_madncl_solver(DummyTag, Strategies.CPU),
+                () -> Solvers._build_uno_solver(DummyTag, Strategies.CPU),
             ]
 
             for stub in stubs


### PR DESCRIPTION
All internal builder stubs renamed with _ prefix following the Handbook convention for unexported internal functions. build_sciml_integrator also removed from Integrators exports. Breaking: direct callers should use public constructors (SciML(...), ADNLP(...), Ipopt(...), etc.) instead. All 2630 tests pass. Version bumped to 0.4.32-beta.