### PR TITLE
ci: stop label-gated workflows from re-triggering on every subsequent label

### DIFF
--- a/.github/workflows/Breakage.yml
+++ b/.github/workflows/Breakage.yml
@@ -9,7 +9,14 @@ on:
 
 jobs:
   call:
-    if: contains(github.event.pull_request.labels.*.name, 'run breakage')
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (synchronize/reopened), fall back to
+    # checking the current label set as before.
+    if: >
+      (github.event.action == 'labeled' && github.event.label.name == 'run breakage') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run breakage'))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,15 @@ on:
 jobs:
   # Job pour les runners GitHub hosted (ubuntu, windows, macos)
   test-cpu-github:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run ci cpu')
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (synchronize/reopened), fall back to
+    # checking the current label set as before.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run ci cpu') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run ci cpu'))
     uses: control-toolbox/CTActions/.github/workflows/ci.yml@main
     with:
       runs_on: '["ubuntu-latest", "macos-latest"]'
@@ -22,7 +30,11 @@ jobs:
 
   # Job pour le runner self-hosted kkt (GPU/CUDA)
   test-gpu-kkt:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run ci gpu')
+    # See the comment on test-cpu-github above.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run ci gpu') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run ci gpu'))
     uses: control-toolbox/CTActions/.github/workflows/ci.yml@main
     with:
       versions: '["1"]'

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -10,7 +10,15 @@ on:
   
 jobs:
   call:
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run documentation')
+    # A 'labeled' event fires once per label added, and re-evaluates against the PR's
+    # *current* full label set — so adding several labels in a row would otherwise
+    # re-run this job on every subsequent label add. Only react to 'labeled' when it's
+    # this specific label; for other trigger types (synchronize/reopened), fall back to
+    # checking the current label set as before.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run documentation') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run documentation'))
     uses: control-toolbox/CTActions/.github/workflows/documentation.yml@main
     with:
       use_ct_registry: true


### PR DESCRIPTION
## Summary

GitHub fires a separate `pull_request` event of type `labeled` for **each label added individually**, and the job's `if` condition is re-evaluated against the PR's *current full label set* every time — not just the label that triggered this specific event. So if several run-gating labels are added to a PR one after another (e.g. `run ci cpu`, then `run ci gpu`, then `run documentation`), a job already matched by an earlier label gets needlessly re-run again on each subsequent label-add event, since its label is still present. This wastes CI runs and confuses people watching the Actions tab.

## Fix

For the `labeled` event specifically, check `github.event.label.name` against the job's own gating label; for every other trigger type (`synchronize`/`reopened`/etc.), keep the existing full-label-set check unchanged.

## Files touched

- `.github/workflows/CI.yml`
  - `test-cpu-github`: gated on `run ci cpu`
  - `test-gpu-kkt`: gated on `run ci gpu`
- `.github/workflows/Breakage.yml`
  - `call`: gated on `run breakage`
- `.github/workflows/Documentation.yml`
  - `call`: gated on `run documentation`

## Files deliberately left untouched

Verified via `grep -rl "labeled" .github/workflows/` that no other workflow file references the `labeled` event type. `AddToProject.yml`, `AutoAssign.yml`, `CompatHelper.yml`, `Coverage.yml`, `Formatter.yml`, `SpellCheck.yml`, `TagBot.yml`, and `UpdateReadme.yml` do not use this pattern and were not modified.

## Validation

All three edited files parse correctly with `python3 -c "import yaml; ..."`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)