### PR TITLE
refactor: unify Integrators.status/successful with CTModels.Solutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.33-beta] - 2026-07-28
+
+### Changed
+
+- **`Integrators.status`/`Integrators.successful` are now `CTModels.Solutions` generics** —
+  CTSolvers no longer owns these two generic functions; it adds methods for
+  `AbstractIntegrationResult` (and, via the SciML extension, `SciMLIntegrationResult`) to the
+  generics already owned by `CTModels.Solutions`. This lets a single `status`/`successful`
+  work uniformly on an OCP solution and on an integration result. **Non-breaking**: every
+  existing call site keeps working; only `parentmodule(Integrators.status)` changes, and
+  importing both `CTSolvers.Integrators: status` and `CTModels.Solutions: status` into the
+  same module now succeeds instead of erroring.
+
+---
+
 ## [0.4.32-beta] - 2026-07-22
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTSolvers"
 uuid = "d3e8d392-8e4b-4d9b-8e92-d7d4e3650ef6"
-version = "0.4.32-beta"
+version = "0.4.33-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]

--- a/src/Integrators/Integrators.jl
+++ b/src/Integrators/Integrators.jl
@@ -37,6 +37,8 @@ import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES, TYPEDFIELDS
 using CommonSolve: CommonSolve
 import CTBase.Exceptions
 import CTBase.Core
+import CTModels.Solutions
+import CTModels.Solutions: status, successful
 
 # CTBase generic infrastructure
 using CTBase.Strategies

--- a/src/Integrators/integration_result.jl
+++ b/src/Integrators/integration_result.jl
@@ -98,6 +98,10 @@ $(TYPEDSIGNATURES)
 
 Return the termination status of the integration result, as a `Symbol`.
 
+This generic is owned by `CTModels.Solutions`; `CTSolvers.Integrators` contributes the
+methods for `AbstractIntegrationResult` subtypes so that a single `status` works uniformly
+on OCP solutions and on integration results.
+
 # Arguments
 - `r::AbstractIntegrationResult`: The integration result.
 
@@ -106,7 +110,7 @@ Return the termination status of the integration result, as a `Symbol`.
 
 See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref), [`CTSolvers.Integrators.successful`](@ref).
 """
-function status(r::AbstractIntegrationResult)::Symbol
+function Solutions.status(r::AbstractIntegrationResult)::Symbol
     return throw(
         Exceptions.NotImplemented(
             "status not implemented";
@@ -122,6 +126,10 @@ $(TYPEDSIGNATURES)
 
 Return whether the integration terminated successfully.
 
+This generic is owned by `CTModels.Solutions`; `CTSolvers.Integrators` contributes the
+methods for `AbstractIntegrationResult` subtypes so that a single `successful` works
+uniformly on OCP solutions and on integration results.
+
 # Arguments
 - `r::AbstractIntegrationResult`: The integration result.
 
@@ -130,7 +138,7 @@ Return whether the integration terminated successfully.
 
 See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref), [`CTSolvers.Integrators.status`](@ref).
 """
-function successful(r::AbstractIntegrationResult)::Bool
+function Solutions.successful(r::AbstractIntegrationResult)::Bool
     return throw(
         Exceptions.NotImplemented(
             "successful not implemented";

--- a/test/suite/integrators/test_integrator_stubs.jl
+++ b/test/suite/integrators/test_integrator_stubs.jl
@@ -5,6 +5,8 @@ import CTBase.Core
 import CTBase.Exceptions
 import CTBase.Strategies
 import CTSolvers.Integrators
+import CTModels.Solutions
+import CTModels.Components
 using CommonSolve: CommonSolve
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
@@ -90,6 +92,16 @@ function test_integrator_stubs()
             )
             Test.@test_throws Exceptions.NotImplemented Integrators.status(FakeResult())
             Test.@test_throws Exceptions.NotImplemented Integrators.successful(FakeResult())
+        end
+
+        # ====================================================================
+        # status/successful are CTModels.Solutions generics, not CTSolvers ones
+        # ====================================================================
+
+        Test.@testset "status/successful unified with CTModels.Solutions" begin
+            Test.@test Integrators.status === Solutions.status
+            Test.@test Integrators.successful === Solutions.successful
+            Test.@test Integrators.times !== Components.times
         end
     end
 end


### PR DESCRIPTION
## Summary

- `CTSolvers.Integrators.status`/`successful` were two distinct generics with the same name
  and meaning as `CTModels.Solutions.status`/`successful`, so importing both into one module
  (e.g. in OptimalControl) errored instead of merging.
- `Integrators` now imports and extends the `CTModels.Solutions` generics directly
  (`import CTModels.Solutions` for the qualified `Solutions.status(...)` /
  `Solutions.successful(...)` definitions, plus `import CTModels.Solutions: status, successful`
  so the names stay locally bound and exported from `Integrators`).
- `times` is deliberately left untouched — it is a distinct concept
  (`CTModels.Components.times` is a model component, `Integrators.times` is the time grid).
- Added a regression test asserting `Integrators.status === CTModels.Solutions.status` (and
  `successful`), plus a negative assertion that `times` stays distinct.
- Bumped to `0.4.33-beta`, updated docstrings and `CHANGELOG.md`.

Non-breaking: every existing call site keeps working; only
`parentmodule(Integrators.status)` changes.

Closes control-toolbox/CTSolvers.jl#187. Plan: `.reports/2026-07-28_unify-status-successful-with-ctmodels.md`.

## Test plan

- [x] `suite/integrators` targeted suite: 178/178 passing
- [x] `suite/meta/test_aqua` (piracy check): 11/11 passing, no piracy introduced
- [x] Full test suite: 2633/2633 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)