### PR TITLE
test(strategies): cover Integrators family in describe/registry tests

### DIFF
--- a/test/suite/strategies/test_describe_registry.jl
+++ b/test/suite/strategies/test_describe_registry.jl
@@ -8,6 +8,8 @@ using CTSolvers: CTSolvers
 import CTBase.Strategies
 import CTBase.Options
 import CTSolvers.Modelers
+import CTSolvers.Solvers
+import CTSolvers.Integrators
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
@@ -27,6 +29,10 @@ function get_strategy_registry()::Strategies.StrategyRegistry
             (CTSolvers.Solvers.MadNLP, [Strategies.CPU, Strategies.GPU]),
             (CTSolvers.Solvers.MadNCL, [Strategies.CPU, Strategies.GPU]),
             (CTSolvers.Solvers.Knitro, [Strategies.CPU]),
+            (CTSolvers.Solvers.Uno, [Strategies.CPU]),
+        ),
+        CTSolvers.Integrators.AbstractIntegrator => (
+            (CTSolvers.Integrators.SciML, [Strategies.CPU, Strategies.GPU]),
         ),
     )
 end
@@ -164,6 +170,50 @@ function test_describe_registry()
             Test.@test occursin("CPU", output)
         end
 
+        Test.@testset "Uno (extension not loaded)" begin
+            buf = IOBuffer()
+            Strategies.describe(buf, :uno, registry)
+            output = String(take!(buf))
+
+            # Test individual components without relying on exact color formatting
+            Test.@test occursin("Uno", output)
+            Test.@test occursin("id", output)
+            Test.@test occursin("uno", output)
+            Test.@test occursin("family", output)
+            Test.@test occursin("AbstractNLPSolver", output)
+            Test.@test occursin("parameters", output)
+            Test.@test occursin("CPU", output)
+
+            # Check graceful ExtensionError handling
+            Test.@test occursin("requires", output) || occursin("options", output)
+        end
+
+        # ====================================================================
+        # UNIT TESTS - Integrators family
+        # ====================================================================
+
+        Test.@testset "SciML (extension not loaded, 4 type params — CTBase#516 regression)" begin
+            # SciML has four type parameters (P, O, OP, OT), the only strategy in the
+            # ecosystem with 3+. Before CTBase#516 (fixed in CTBase 0.28.8-beta),
+            # `_strategy_base_name`/`_strategy_type_name` only peeled one `UnionAll`
+            # layer and threw `FieldError` here. This is the regression coverage.
+            buf = IOBuffer()
+            Strategies.describe(buf, :sciml, registry)
+            output = String(take!(buf))
+
+            Test.@test occursin("SciML", output)
+            Test.@test occursin("id", output)
+            Test.@test occursin("sciml", output)
+            Test.@test occursin("family", output)
+            Test.@test occursin("AbstractIntegrator", output)
+            Test.@test occursin("parameters", output)
+            Test.@test occursin("CPU", output)
+            Test.@test occursin("GPU", output)
+
+            # Check graceful ExtensionError handling
+            Test.@test occursin("requires", output) || occursin("options", output)
+        end
+
         # ====================================================================
         # ERROR TESTS - Unknown ID
         # ====================================================================
@@ -176,11 +226,54 @@ function test_describe_registry()
         end
 
         # ====================================================================
+        # UNIT TESTS - Parameter path on the full registry (incl. SciML)
+        # ====================================================================
+
+        # `describe(:cpu/:gpu, registry)` walks every registered strategy to list which
+        # ones support the parameter (`_find_strategies_using_parameter`), so a single
+        # undescribable strategy took the parameter introspection down with it too —
+        # this is the CTBase#516 regression coverage for that path.
+        Test.@testset "describe(:cpu, registry) - full registry incl. SciML" begin
+            buf = IOBuffer()
+            Strategies.describe(buf, :cpu, registry)
+            output = String(take!(buf))
+
+            Test.@test occursin("CPU", output)
+            Test.@test occursin("parameter", output)
+            Test.@test occursin("used", output)
+            Test.@test occursin("strategies", output)
+            Test.@test occursin(":sciml", output)
+            Test.@test occursin("SciML", output)
+        end
+
+        Test.@testset "describe(:gpu, registry) - full registry incl. SciML" begin
+            buf = IOBuffer()
+            Strategies.describe(buf, :gpu, registry)
+            output = String(take!(buf))
+
+            Test.@test occursin("GPU", output)
+            Test.@test occursin("parameter", output)
+            Test.@test occursin("used", output)
+            Test.@test occursin("strategies", output)
+            Test.@test occursin(":sciml", output)
+            Test.@test occursin("SciML", output)
+        end
+
+        # ====================================================================
         # OUTPUT VERIFICATION - Print all strategies for visual check
         # ====================================================================
 
         Test.@testset "Print all strategies" begin
-            for strat_id in (:adnlp, :exa, :ipopt, :madnlp, :madncl, :knitro)
+            # Table-driven over strategy_ids across all three families so a newly
+            # registered strategy is covered by construction. `strategy_ids` returns a
+            # `Tuple{Symbol,...}`, so splat (not vcat, which would nest the tuples) to
+            # get a flat collection of ids.
+            ids = (
+                Strategies.strategy_ids(CTSolvers.Modelers.AbstractNLPModeler, registry)...,
+                Strategies.strategy_ids(CTSolvers.Solvers.AbstractNLPSolver, registry)...,
+                Strategies.strategy_ids(CTSolvers.Integrators.AbstractIntegrator, registry)...,
+            )
+            for strat_id in ids
                 buf = IOBuffer()
                 Test.@test_nowarn Strategies.describe(buf, strat_id, registry)
                 output = String(take!(buf))


### PR DESCRIPTION
## Summary

`test/suite/strategies/test_describe_registry.jl` only ever built a registry from
`AbstractNLPModeler` + `AbstractNLPSolver`, so `SciML` (Integrators) and `Uno` (Solvers)
had zero `describe`/registry coverage. That gap is why CTBase#516
(`describe()` throwing `FieldError` on strategies with 3+ type parameters — `SciML` has
four, the only one in the ecosystem that does) went unnoticed.

- Extend `get_strategy_registry()` to cover all three families
  (`AbstractNLPModeler`, `AbstractNLPSolver`, `AbstractIntegrator`), adding `Uno` and
  `SciML`.
- Add `:uno` and `:sciml` `describe` testsets.
- Add `describe(:cpu, registry)` / `describe(:gpu, registry)` testsets on the merged
  registry — the parameter-introspection path that a single undescribable strategy could
  take down with it.
- Make the "print all strategies" loop table-driven over `Strategies.strategy_ids`
  instead of a hardcoded id tuple, so newly registered strategies are covered by
  construction.

CTBase#516 was fixed and released as CTBase 0.28.8-beta while this was in progress, so
the new `:sciml`/`:cpu`/`:gpu` assertions are real (not `@test_broken`) — verified
against the actual `describe()` output.

No source changes — test-only, per the issue ("nothing here needs to change about the
type itself").

Closes #191

## Test plan

- [x] `Pkg.test(; test_args=["suite/strategies"])` — 447/447 passed (111 in
      `test_describe_registry.jl`, up from 66)
- [x] `Pkg.test()` (full suite) — 2691/2691 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
