### PR TITLE
refactor: enforce Handbook tenet 2 — using, never import

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1041,9 +1041,9 @@ adnlp = ADNLP{CPU}(backend=:enzyme)  # now works reliably
 # Use the new extension pattern
 module CTSolversMyBackend
 using CTSolvers
-import CTSolvers.Modelers: validate_adnlp_backend, ADNLPTag
+using CTSolvers: Modelers
 
-function validate_adnlp_backend(::Val{:mybackend})
+function Modelers.validate_adnlp_backend(::Val{:mybackend})
     # Your validation logic here
     return true
 end

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -11,7 +11,7 @@ CTSolvers.jl is typically installed as a dependency of another package in the ec
 To install it directly:
 
 ```julia
-import Pkg
+using Pkg: Pkg
 Pkg.add("CTSolvers")
 ```
 

--- a/docs/src/guides/implementing_a_solver.md
+++ b/docs/src/guides/implementing_a_solver.md
@@ -17,9 +17,9 @@ A solver must satisfy **three contracts**:
 2. **Solve contract** — `CommonSolve.solve(nlp, solver; display) → ExecutionStats`
 3. **Tag Dispatch** — separates type definition from backend implementation
 
-Solvers are **parameterized** by an execution parameter `P <: AbstractStrategyParameter`
-(see Strategy Parameters in CTBase.jl documentation). `Solvers.Ipopt{P<:CPU}` is CPU-only;
-`Solvers.MadNLP` and `Solvers.MadNCL` accept `Union{CPU,GPU}`.
+Solvers are **parameterized** by an execution parameter `P <: CTBase.Strategies.AbstractStrategyParameter`
+(see Strategy Parameters in CTBase.jl documentation). `Solvers.Ipopt{P<:CTBase.Strategies.CPU}` is CPU-only;
+`Solvers.MadNLP` and `Solvers.MadNCL` accept `Union{CTBase.Strategies.CPU,CTBase.Strategies.GPU}`.
 
 ```text
 AbstractStrategy
@@ -56,7 +56,7 @@ execution parameter — Ipopt supports CPU only:
 
 ```julia
 # In module Solvers (src/Solvers/ipopt.jl)
-struct Ipopt{P<:CPU} <: AbstractNLPSolver
+struct Ipopt{P<:CTBase.Strategies.CPU} <: AbstractNLPSolver
     options::CTBase.Strategies.StrategyOptions
 end
 ```
@@ -74,8 +74,8 @@ CTBase.Strategies.id(CTSolvers.Solvers.Ipopt)
 ```
 
 ```julia
-CTBase.Strategies.default_parameter(::Type{<:Solvers.Ipopt}) = CPU
-CTBase.Strategies.parameter(::Type{<:Solvers.Ipopt{P}}) where {P<:CPU} = P
+CTBase.Strategies.default_parameter(::Type{<:Solvers.Ipopt}) = CTBase.Strategies.CPU
+CTBase.Strategies.parameter(::Type{<:Solvers.Ipopt{P}}) where {P<:CTBase.Strategies.CPU} = P
 ```
 
 ### Step 4 — Constructors with Tag Dispatch
@@ -93,13 +93,13 @@ function Solvers.Ipopt(; mode::Symbol = :strict, kwargs...)
 end
 
 # Parameterized → tag dispatch, IpoptTag and P passed as TYPES
-function Solvers.Ipopt{P}(; mode::Symbol = :strict, kwargs...) where {P<:CPU}
+function Solvers.Ipopt{P}(; mode::Symbol = :strict, kwargs...) where {P<:CTBase.Strategies.CPU}
     return _build_ipopt_solver(IpoptTag, P; mode = mode, kwargs...)
 end
 
 # Stub — real implementation in ext/CTSolversIpopt.jl
 function _build_ipopt_solver(
-    ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
+    ::Type{<:Core.AbstractTag}, parameter::Type{<:CTBase.Strategies.AbstractStrategyParameter}; kwargs...
 )
     throw(Exceptions.ExtensionError(
         :NLPModelsIpopt;
@@ -130,23 +130,23 @@ end # hide
 ```julia
 struct IpoptTag <: Core.AbstractTag end
 
-struct Ipopt{P<:CPU} <: AbstractNLPSolver
+struct Ipopt{P<:CTBase.Strategies.CPU} <: AbstractNLPSolver
     options::CTBase.Strategies.StrategyOptions
 end
 
 CTBase.Strategies.id(::Type{<:Solvers.Ipopt}) = :ipopt
-CTBase.Strategies.default_parameter(::Type{<:Solvers.Ipopt}) = CPU
-CTBase.Strategies.parameter(::Type{<:Solvers.Ipopt{P}}) where {P<:CPU} = P
+CTBase.Strategies.default_parameter(::Type{<:Solvers.Ipopt}) = CTBase.Strategies.CPU
+CTBase.Strategies.parameter(::Type{<:Solvers.Ipopt{P}}) where {P<:CTBase.Strategies.CPU} = P
 
 # Constructors — resolve the parameter, then dispatch via tag (types, not instances)
 Solvers.Ipopt(; mode = :strict, kwargs...) =
     Solvers.Ipopt{CTBase.Strategies.default_parameter(Solvers.Ipopt)}(; mode, kwargs...)
 
-Solvers.Ipopt{P}(; mode = :strict, kwargs...) where {P<:CPU} =
+Solvers.Ipopt{P}(; mode = :strict, kwargs...) where {P<:CTBase.Strategies.CPU} =
     _build_ipopt_solver(IpoptTag, P; mode, kwargs...)
 
 # Stub — throws until NLPModelsIpopt is loaded
-_build_ipopt_solver(::Type{<:Core.AbstractTag}, ::Type{<:AbstractStrategyParameter}; kwargs...) =
+_build_ipopt_solver(::Type{<:Core.AbstractTag}, ::Type{<:CTBase.Strategies.AbstractStrategyParameter}; kwargs...) =
     throw(Exceptions.ExtensionError(:NLPModelsIpopt))
 ```
 
@@ -154,10 +154,10 @@ _build_ipopt_solver(::Type{<:Core.AbstractTag}, ::Type{<:AbstractStrategyParamet
 
 ```julia
 # Option definitions (parameterized on P)
-CTBase.Strategies.metadata(::Type{Solvers.Ipopt{P}}) where {P<:CPU} = StrategyMetadata(...)
+CTBase.Strategies.metadata(::Type{Solvers.Ipopt{P}}) where {P<:CTBase.Strategies.CPU} = StrategyMetadata(...)
 
 # Real constructor — validates options for the parameterized type and builds the struct
-_build_ipopt_solver(::Type{Solvers.IpoptTag}, parameter::Type{<:AbstractStrategyParameter}; mode, kwargs...) =
+_build_ipopt_solver(::Type{Solvers.IpoptTag}, parameter::Type{<:CTBase.Strategies.AbstractStrategyParameter}; mode, kwargs...) =
     Solvers.Ipopt{parameter}(CTBase.Strategies.build_strategy_options(Solvers.Ipopt{parameter}; mode, kwargs...))
 
 # Solve method — dispatches on NLP type and solver type
@@ -175,14 +175,14 @@ solver simply widens the bound and provides GPU-specific defaults through the
 parameterized metadata:
 
 ```julia
-struct MadNLP{P<:Union{CPU,GPU}} <: AbstractNLPSolver
+struct MadNLP{P<:Union{CTBase.Strategies.CPU,CTBase.Strategies.GPU}} <: AbstractNLPSolver
     options::CTBase.Strategies.StrategyOptions
 end
 
 # GPU-specific option defaults selected by the parameter
-CTBase.Strategies.metadata(::Type{Solvers.MadNLP{GPU}}) = StrategyMetadata(...)  # CUDA defaults
+CTBase.Strategies.metadata(::Type{Solvers.MadNLP{CTBase.Strategies.GPU}}) = StrategyMetadata(...)  # CUDA defaults
 
-Solvers.MadNLP{GPU}(max_iter = 1000)   # requires the CUDA-related extensions
+Solvers.MadNLP{CTBase.Strategies.GPU}(max_iter = 1000)   # requires the CUDA-related extensions
 ```
 
 See the Strategy Parameters guide in CTBase.jl documentation for the full parameter contract.
@@ -215,20 +215,22 @@ The extension module provides three things:
 ```julia
 module CTSolversIpopt
 
-using CTSolvers, CTSolvers.Solvers, CTBase.Strategies, CTBase.Options
-using CTBase.Exceptions
-using NLPModelsIpopt, NLPModels, SolverCore
+using CTSolvers: CTSolvers, Solvers
+using CTBase: Strategies, Options, Exceptions
+using NLPModelsIpopt: NLPModelsIpopt
+using NLPModels: NLPModels
+using SolverCore: SolverCore
 
-function CTBase.Strategies.metadata(::Type{Solvers.Ipopt{P}}) where {P<:CPU}
-    return CTBase.Strategies.StrategyMetadata(
-        CTBase.Options.OptionDefinition(
+function Strategies.metadata(::Type{Solvers.Ipopt{P}}) where {P<:Strategies.CPU}
+    return Strategies.StrategyMetadata(
+        Options.OptionDefinition(
             name = :tol,
             type = Real,
             default = 1e-8,
             description = "Desired convergence tolerance (relative)",
             validator = x -> x > 0 || throw(Exceptions.IncorrectArgument(...)),
         ),
-        CTBase.Options.OptionDefinition(
+        Options.OptionDefinition(
             name = :max_iter,
             type = Integer,
             default = 1000,
@@ -246,11 +248,11 @@ end
 ```julia
 function Solvers._build_ipopt_solver(
     ::Type{Solvers.IpoptTag},
-    parameter::Type{<:AbstractStrategyParameter};
+    parameter::Type{<:Strategies.AbstractStrategyParameter};
     mode::Symbol = :strict,
     kwargs...,
 )
-    opts = CTBase.Strategies.build_strategy_options(Solvers.Ipopt{parameter}; mode = mode, kwargs...)
+    opts = Strategies.build_strategy_options(Solvers.Ipopt{parameter}; mode = mode, kwargs...)
     return Solvers.Ipopt{parameter}(opts)
 end
 ```
@@ -325,15 +327,15 @@ To add a new solver (e.g., `MySolver` backed by `MyBackend`):
 ### In `src/Solvers/`
 
 1. Define `MyTag <: Core.AbstractTag`
-2. Define the parameterized struct `MySolver{P<:CPU} <: AbstractNLPSolver` with `options::CTBase.Strategies.StrategyOptions` (widen the bound to `Union{CPU,GPU}` for GPU-capable backends)
-3. Implement `CTBase.Strategies.id(::Type{<:MySolver}) = :my_solver`, `CTBase.Strategies.default_parameter(::Type{<:MySolver}) = CPU`, and `CTBase.Strategies.parameter(::Type{<:MySolver{P}}) where {P<:CPU} = P`
+2. Define the parameterized struct `MySolver{P<:CTBase.Strategies.CPU} <: AbstractNLPSolver` with `options::CTBase.Strategies.StrategyOptions` (widen the bound to `Union{CTBase.Strategies.CPU,CTBase.Strategies.GPU}` for GPU-capable backends)
+3. Implement `CTBase.Strategies.id(::Type{<:MySolver}) = :my_solver`, `CTBase.Strategies.default_parameter(::Type{<:MySolver}) = CTBase.Strategies.CPU`, and `CTBase.Strategies.parameter(::Type{<:MySolver{P}}) where {P<:CTBase.Strategies.CPU} = P`
 4. Write the constructor chain: `MySolver(; ...)` → `MySolver{P}(; ...)` → `build_my_solver(MyTag, P; mode, kwargs...)`
-5. Write stub: `build_my_solver(::Type{<:Core.AbstractTag}, ::Type{<:AbstractStrategyParameter}; kwargs...) = throw(ExtensionError(...))`
+5. Write stub: `build_my_solver(::Type{<:Core.AbstractTag}, ::Type{<:CTBase.Strategies.AbstractStrategyParameter}; kwargs...) = throw(ExtensionError(...))`
 
 ### In `ext/CTSolversMyBackend.jl`
 
-6. Implement `CTBase.Strategies.metadata(::Type{MySolver{P}}) where {P<:CPU}` with all option definitions
-7. Implement `Solvers.build_my_solver(::Type{Solvers.MyTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...)` — real constructor
+6. Implement `CTBase.Strategies.metadata(::Type{MySolver{P}}) where {P<:CTBase.Strategies.CPU}` with all option definitions
+7. Implement `Solvers.build_my_solver(::Type{Solvers.MyTag}, parameter::Type{<:CTBase.Strategies.AbstractStrategyParameter}; kwargs...)` — real constructor
 8. Implement `CommonSolve.solve(nlp, solver::MySolver; display)` — solve method invoking the backend
 
 ### In `Project.toml`

--- a/ext/CTSolversADNLPModels.jl
+++ b/ext/CTSolversADNLPModels.jl
@@ -7,14 +7,12 @@ functionality that requires ADNLPModels types.
 """
 module CTSolversADNLPModels
 
-import DocStringExtensions: TYPEDSIGNATURES
-import CTSolvers.Modelers
-import CTBase.Strategies
-import CTBase.Core
-import CTBase.Exceptions
+using DocStringExtensions: TYPEDSIGNATURES
+using CTSolvers: Modelers
+using CTBase: Strategies
+using CTBase: Core
+using CTBase: Exceptions
 using ADNLPModels: ADNLPModels
-
-using CTBase.Strategies: CPU, AbstractStrategyParameter
 
 # ============================================================================
 # ADBackend type-check helpers (override weak-dep stubs in core)
@@ -93,7 +91,7 @@ AD backend overrides for individual derivative operations.
 See also: [`CTSolvers.Modelers.ADNLP`](@ref),
 [`CTSolvers.Modelers._build_adnlp_modeler`](@ref)
 """
-function Strategies.metadata(::Type{Modelers.ADNLP{P}}) where {P<:CPU}
+function Strategies.metadata(::Type{Modelers.ADNLP{P}}) where {P<:Strategies.CPU}
     return Strategies.StrategyMetadata(
         # === Basic Options ===
         Strategies.OptionDefinition(;
@@ -194,7 +192,7 @@ Whenever the deprecated keyword `:adnlp_backend` is passed, a warning is issued
 and `:backend` should be used instead.
 
 # Arguments
-- `parameter::Type{<:AbstractStrategyParameter}`: strategy parameter type (e.g. `CPU`)
+- `parameter::Type{<:Strategies.AbstractStrategyParameter}`: strategy parameter type (e.g. `Strategies.CPU`)
 - `mode::Symbol`: validation mode, `:strict` (default) or `:permissive`
 - `kwargs...`: options forwarded to [`CTBase.Strategies.build_strategy_options`](@extref)
 
@@ -206,7 +204,7 @@ See also: [`CTSolvers.Modelers.ADNLP`](@ref),
 """
 function Modelers._build_adnlp_modeler(
     ::Type{Modelers.ADNLPTag},
-    parameter::Type{<:AbstractStrategyParameter};
+    parameter::Type{<:Strategies.AbstractStrategyParameter};
     mode::Symbol=:strict,
     kwargs...,
 )

--- a/ext/CTSolversCUDA.jl
+++ b/ext/CTSolversCUDA.jl
@@ -8,9 +8,9 @@ Extension providing CUDA functionality for CTSolvers:
 
 module CTSolversCUDA
 
-import CTSolvers.Modelers
-import CTSolvers.Integrators
-import CTBase.Strategies
+using CTSolvers: Modelers
+using CTSolvers: Integrators
+using CTBase: Strategies
 using CUDA: CUDA
 using DocStringExtensions: DocStringExtensions
 
@@ -39,7 +39,7 @@ $(DocStringExtensions.TYPEDSIGNATURES)
 Check if CUDA backend is consistent with CPU parameter.
 
 # Arguments
-- `parameter_type::Type{CPU}`: CPU parameter type
+- `parameter_type::Type{Strategies.CPU}`: CPU parameter type
 - `backend::CUDA.CUDABackend`: CUDA backend to check
 
 # Returns
@@ -59,7 +59,7 @@ $(DocStringExtensions.TYPEDSIGNATURES)
 Check if no backend is consistent with GPU parameter.
 
 # Arguments
-- `parameter_type::Type{GPU}`: GPU parameter type
+- `parameter_type::Type{Strategies.GPU}`: GPU parameter type
 - `backend::Nothing`: No backend
 
 # Returns
@@ -79,7 +79,7 @@ $(DocStringExtensions.TYPEDSIGNATURES)
 Check if CUDA backend is consistent with GPU parameter.
 
 # Arguments
-- `parameter_type::Type{GPU}`: GPU parameter type
+- `parameter_type::Type{Strategies.GPU}`: GPU parameter type
 - `backend::CUDA.CUDABackend`: CUDA backend to check
 
 # Returns

--- a/ext/CTSolversEnzyme.jl
+++ b/ext/CTSolversEnzyme.jl
@@ -8,8 +8,8 @@ ExtensionError behavior for the ADNLPTag.
 
 module CTSolversEnzyme
 
-import DocStringExtensions: TYPEDSIGNATURES
-import CTSolvers.Modelers
+using DocStringExtensions: TYPEDSIGNATURES
+using CTSolvers: Modelers
 
 """
 $(TYPEDSIGNATURES)

--- a/ext/CTSolversExaModels.jl
+++ b/ext/CTSolversExaModels.jl
@@ -7,14 +7,12 @@ functionality that requires ExaModels/KernelAbstractions types.
 """
 module CTSolversExaModels
 
-import DocStringExtensions: TYPEDSIGNATURES
-import CTSolvers.Modelers
-import CTBase.Strategies
-import CTBase.Core
+using DocStringExtensions: TYPEDSIGNATURES
+using CTSolvers: Modelers
+using CTBase: Strategies
+using CTBase: Core
 using ExaModels: ExaModels
 using KernelAbstractions: KernelAbstractions
-
-using CTBase.Strategies: CPU, GPU, AbstractStrategyParameter
 
 # ============================================================================
 # Metadata definition
@@ -35,7 +33,7 @@ are loaded. Covers `:base_type` (floating-point precision) and `:backend`
 See also: [`CTSolvers.Modelers.Exa`](@ref),
 [`CTSolvers.Modelers._build_exa_modeler`](@ref)
 """
-function Strategies.metadata(::Type{Modelers.Exa{P}}) where {P<:Union{CPU,GPU}}
+function Strategies.metadata(::Type{Modelers.Exa{P}}) where {P<:Union{Strategies.CPU,Strategies.GPU}}
     return Strategies.StrategyMetadata(
         Strategies.OptionDefinition(;
             name=:base_type,
@@ -53,7 +51,7 @@ function Strategies.metadata(::Type{Modelers.Exa{P}}) where {P<:Union{CPU,GPU}}
             aliases=(:exa_backend,),
             validator=function (backend)
                 if !Modelers.__consistent_backend(P, backend)
-                    param_str = P == CPU ? "CPU" : "GPU"
+                    param_str = P == Strategies.CPU ? "CPU" : "GPU"
                     backend_str =
                         backend === nothing ? "no backend" : string(typeof(backend))
                     @warn "Inconsistent backend ($backend_str) for $param_str parameter" maxlog=1
@@ -78,7 +76,7 @@ are loaded. Whenever the deprecated keyword `:exa_backend` is passed, a warning
 is issued and `:backend` should be used instead.
 
 # Arguments
-- `parameter::Type{<:AbstractStrategyParameter}`: strategy parameter type (e.g. `CPU`, `GPU`)
+- `parameter::Type{<:Strategies.AbstractStrategyParameter}`: strategy parameter type (e.g. `Strategies.CPU`, `Strategies.GPU`)
 - `mode::Symbol`: validation mode, `:strict` (default) or `:permissive`
 - `kwargs...`: options forwarded to [`CTBase.Strategies.build_strategy_options`](@extref)
 
@@ -90,7 +88,7 @@ See also: [`CTSolvers.Modelers.Exa`](@ref),
 """
 function Modelers._build_exa_modeler(
     ::Type{Modelers.ExaTag},
-    parameter::Type{<:AbstractStrategyParameter};
+    parameter::Type{<:Strategies.AbstractStrategyParameter};
     mode::Symbol=:strict,
     kwargs...,
 )

--- a/ext/CTSolversForwardDiff.jl
+++ b/ext/CTSolversForwardDiff.jl
@@ -13,10 +13,10 @@ ForwardDiff dual numbers.
 """
 module CTSolversForwardDiff
 
-import DocStringExtensions: TYPEDSIGNATURES
+using DocStringExtensions: TYPEDSIGNATURES
 using ForwardDiff: ForwardDiff
 
-using CTSolvers.Integrators: Integrators
+using CTSolvers: Integrators
 
 """
 $(TYPEDSIGNATURES)

--- a/ext/CTSolversIpopt.jl
+++ b/ext/CTSolversIpopt.jl
@@ -6,19 +6,16 @@ Implements the complete Solvers.Ipopt functionality with proper option definitio
 """
 module CTSolversIpopt
 
-import DocStringExtensions: TYPEDSIGNATURES
-import CTSolvers.Solvers
+using DocStringExtensions: TYPEDSIGNATURES
+using CTSolvers: Solvers
 using CommonSolve: CommonSolve
-import CTBase.Strategies
-import CTBase.Options
-import CTBase.Core
-import CTBase.Exceptions
+using CTBase: Strategies
+using CTBase: Options
+using CTBase: Core
+using CTBase: Exceptions
 using NLPModelsIpopt: NLPModelsIpopt
 using NLPModels: NLPModels
 using SolverCore: SolverCore
-
-# Import parameter types
-using CTBase.Strategies: CPU, GPU, AbstractStrategyParameter
 
 # ============================================================================
 # Metadata definition
@@ -29,7 +26,7 @@ $(TYPEDSIGNATURES)
 
 Return metadata defining Ipopt options and their specifications.
 """
-function Strategies.metadata(::Type{Solvers.Ipopt{P}}) where {P<:CPU}
+function Strategies.metadata(::Type{Solvers.Ipopt{P}}) where {P<:Strategies.CPU}
     return Strategies.StrategyMetadata(
         # ====================================================================
         # Termination options
@@ -568,7 +565,7 @@ See also: `Solvers.Ipopt`, `Strategies.build_strategy_options`
 """
 function Solvers._build_ipopt_solver(
     ::Type{Solvers.IpoptTag},
-    parameter::Type{<:AbstractStrategyParameter};
+    parameter::Type{<:Strategies.AbstractStrategyParameter};
     mode::Symbol=:strict,
     kwargs...,
 )

--- a/ext/CTSolversKnitro.jl
+++ b/ext/CTSolversKnitro.jl
@@ -6,18 +6,15 @@ Implements the complete Solvers.Knitro functionality with proper option definiti
 """
 module CTSolversKnitro
 
-import DocStringExtensions: TYPEDSIGNATURES
-import CTSolvers.Solvers
+using DocStringExtensions: TYPEDSIGNATURES
+using CTSolvers: Solvers
 using CommonSolve: CommonSolve
-import CTBase.Strategies
-import CTBase.Options
-import CTBase.Exceptions
+using CTBase: Strategies
+using CTBase: Options
+using CTBase: Exceptions
 using NLPModelsKnitro: NLPModelsKnitro
 using NLPModels: NLPModels
 using SolverCore: SolverCore
-
-# Import parameter types
-using CTBase.Strategies: CPU, GPU, AbstractStrategyParameter
 
 # ============================================================================
 # Metadata Definition
@@ -28,7 +25,7 @@ $(TYPEDSIGNATURES)
 
 Return metadata defining Knitro options and their specifications.
 """
-function Strategies.metadata(::Type{Solvers.Knitro{P}}) where {P<:CPU}
+function Strategies.metadata(::Type{Solvers.Knitro{P}}) where {P<:Strategies.CPU}
     return Strategies.StrategyMetadata(
         # ====================================================================
         # TERMINATION OPTIONS
@@ -219,7 +216,7 @@ solver_permissive = _build_knitro_solver(KnitroTag; max_iter=1000, custom_option
 """
 function Solvers._build_knitro_solver(
     ::Type{Solvers.KnitroTag},
-    parameter::Type{<:AbstractStrategyParameter};
+    parameter::Type{<:Strategies.AbstractStrategyParameter};
     mode::Symbol=:strict,
     kwargs...,
 )

--- a/ext/CTSolversMadNCL.jl
+++ b/ext/CTSolversMadNCL.jl
@@ -6,21 +6,18 @@ Implements the complete Solvers.MadNCL functionality with proper option definiti
 """
 module CTSolversMadNCL
 
-import DocStringExtensions: TYPEDSIGNATURES
-import CTSolvers.Solvers
+using DocStringExtensions: TYPEDSIGNATURES
+using CTSolvers: Solvers
 using CommonSolve: CommonSolve
-import CTBase.Strategies
-import CTBase.Options
-import CTBase.Core
-import CTSolvers.Optimization
-import CTBase.Exceptions
+using CTBase: Strategies
+using CTBase: Options
+using CTBase: Core
+using CTSolvers: Optimization
+using CTBase: Exceptions
 using MadNCL: MadNCL
 using MadNLP: MadNLP
 using NLPModels: NLPModels
 using SolverCore: SolverCore
-
-# Import parameter types
-using CTBase.Strategies: CPU, GPU, AbstractStrategyParameter
 
 # ============================================================================
 # Helper Functions
@@ -46,7 +43,7 @@ The metadata is parameterized by the execution backend (CPU or GPU).
 For GPU execution, the default linear solver is automatically set to
 `MadNLPGPU.CUDSSSolver` instead of `MadNLP.MumpsSolver`.
 """
-function Strategies.metadata(::Type{Solvers.MadNCL{P}}) where {P<:AbstractStrategyParameter}
+function Strategies.metadata(::Type{Solvers.MadNCL{P}}) where {P<:Strategies.AbstractStrategyParameter}
     return Strategies.StrategyMetadata(
         Strategies.OptionDefinition(;
             name=:max_iter,
@@ -95,7 +92,7 @@ function Strategies.metadata(::Type{Solvers.MadNCL{P}}) where {P<:AbstractStrate
             computed=true,  # Default is computed from parameter P
             validator=function (linear_solver)
                 if !Solvers.__madnlp_suite_consistent_linear_solver(P, linear_solver)
-                    param_str = P == CPU ? "CPU" : "GPU"
+                    param_str = P == Strategies.CPU ? "CPU" : "GPU"
                     @warn "Inconsistent linear solver ($linear_solver) for $param_str parameter" maxlog=1
                 end
                 return linear_solver
@@ -361,7 +358,7 @@ Build a MadNCL with validated options.
 
 # Arguments
 - `tag::Solvers.MadNCLTag`: Tag for dispatch
-- `parameter::AbstractStrategyParameter`: Execution parameter (CPU or GPU)
+- `parameter::Strategies.AbstractStrategyParameter`: Execution parameter (CPU or GPU)
 - `mode::Symbol=:strict`: Validation mode (`:strict` or `:permissive`)
   - `:strict` (default): Rejects unknown options with detailed error message
   - `:permissive`: Accepts unknown options with warning, stores with `:user` source
@@ -371,13 +368,13 @@ Build a MadNCL with validated options.
 
 ```julia
 # Conceptual usage
-solver_cpu = _build_madncl_solver(MadNCLTag(), CPU(); max_iter=1000)
-solver_gpu = _build_madncl_solver(MadNCLTag(), GPU(); max_iter=1000)  # requires MadNLPGPU
+solver_cpu = _build_madncl_solver(MadNCLTag(), Strategies.CPU(); max_iter=1000)
+solver_gpu = _build_madncl_solver(MadNCLTag(), Strategies.GPU(); max_iter=1000)  # requires MadNLPGPU
 ```
 """
 function Solvers._build_madncl_solver(
     ::Type{Solvers.MadNCLTag},
-    parameter::Type{<:AbstractStrategyParameter};
+    parameter::Type{<:Strategies.AbstractStrategyParameter};
     mode::Symbol=:strict,
     kwargs...,
 )

--- a/ext/CTSolversMadNLP.jl
+++ b/ext/CTSolversMadNLP.jl
@@ -6,20 +6,17 @@ Implements the complete Solvers.MadNLP functionality with proper option definiti
 """
 module CTSolversMadNLP
 
-import DocStringExtensions: TYPEDSIGNATURES
-import CTSolvers.Optimization
-import CTSolvers.Solvers
+using DocStringExtensions: TYPEDSIGNATURES
+using CTSolvers: Optimization
+using CTSolvers: Solvers
 using CommonSolve: CommonSolve
-import CTBase.Strategies
-import CTBase.Options
-import CTBase.Core
-import CTBase.Exceptions
+using CTBase: Strategies
+using CTBase: Options
+using CTBase: Core
+using CTBase: Exceptions
 using MadNLP: MadNLP
 using NLPModels: NLPModels
 using SolverCore: SolverCore
-
-# Import parameter types
-using CTBase.Strategies: CPU, GPU, AbstractStrategyParameter
 
 # ============================================================================
 # Helper Functions
@@ -42,7 +39,7 @@ $(TYPEDSIGNATURES)
 Check if MumpsSolver is consistent with GPU parameter.
 
 # Arguments
-- `parameter_type::Type{GPU}`: GPU parameter type
+- `parameter_type::Type{Strategies.GPU}`: GPU parameter type
 - `linear_solver::Type{MadNLP.MumpsSolver}`: CPU linear solver
 
 # Returns
@@ -64,7 +61,7 @@ $(TYPEDSIGNATURES)
 Check if UmfpackSolver is consistent with GPU parameter.
 
 # Arguments
-- `parameter_type::Type{GPU}`: GPU parameter type
+- `parameter_type::Type{Strategies.GPU}`: GPU parameter type
 - `linear_solver::Type{MadNLP.UmfpackSolver}`: CPU linear solver
 
 # Returns
@@ -86,7 +83,7 @@ $(TYPEDSIGNATURES)
 Check if LapackCPUSolver is consistent with GPU parameter.
 
 # Arguments
-- `parameter_type::Type{GPU}`: GPU parameter type
+- `parameter_type::Type{Strategies.GPU}`: GPU parameter type
 - `linear_solver::Type{MadNLP.LapackCPUSolver}`: CPU linear solver
 
 # Returns
@@ -108,7 +105,7 @@ $(TYPEDSIGNATURES)
 Check if LDLSolver is consistent with GPU parameter.
 
 # Arguments
-- `parameter_type::Type{GPU}`: GPU parameter type
+- `parameter_type::Type{Strategies.GPU}`: GPU parameter type
 - `linear_solver::Type{MadNLP.LDLSolver}`: CPU linear solver
 
 # Returns
@@ -130,7 +127,7 @@ $(TYPEDSIGNATURES)
 Check if CHOLMODSolver is consistent with GPU parameter.
 
 # Arguments
-- `parameter_type::Type{GPU}`: GPU parameter type
+- `parameter_type::Type{Strategies.GPU}`: GPU parameter type
 - `linear_solver::Type{MadNLP.CHOLMODSolver}`: CPU linear solver
 
 # Returns
@@ -159,7 +156,7 @@ The metadata is parameterized by the execution backend (CPU or GPU).
 For GPU execution, the default linear solver is automatically set to
 `MadNLPGPU.CUDSSSolver` instead of `MadNLP.MumpsSolver`.
 """
-function Strategies.metadata(::Type{Solvers.MadNLP{P}}) where {P<:AbstractStrategyParameter}
+function Strategies.metadata(::Type{Solvers.MadNLP{P}}) where {P<:Strategies.AbstractStrategyParameter}
     return Strategies.StrategyMetadata(
         Strategies.OptionDefinition(;
             name=:max_iter,
@@ -208,7 +205,7 @@ function Strategies.metadata(::Type{Solvers.MadNLP{P}}) where {P<:AbstractStrate
             computed=true,  # Default is computed from parameter P
             validator=function (linear_solver)
                 if !Solvers.__madnlp_suite_consistent_linear_solver(P, linear_solver)
-                    param_str = P == CPU ? "CPU" : "GPU"
+                    param_str = P == Strategies.CPU ? "CPU" : "GPU"
                     @warn "Inconsistent linear solver ($linear_solver) for $param_str parameter" maxlog=1
                 end
                 return linear_solver
@@ -461,7 +458,7 @@ Build a MadNLP with validated options.
 
 # Arguments
 - `tag::Solvers.MadNLPTag`: Tag for dispatch
-- `parameter::AbstractStrategyParameter`: Execution parameter (CPU or GPU)
+- `parameter::Strategies.AbstractStrategyParameter`: Execution parameter (CPU or GPU)
 - `mode::Symbol=:strict`: Validation mode (`:strict` or `:permissive`)
   - `:strict` (default): Rejects unknown options with detailed error message
   - `:permissive`: Accepts unknown options with warning, stores with `:user` source
@@ -471,13 +468,13 @@ Build a MadNLP with validated options.
 
 ```julia
 # Conceptual usage
-solver_cpu = _build_madnlp_solver(MadNLPTag(), CPU(); max_iter=1000)
-solver_gpu = _build_madnlp_solver(MadNLPTag(), GPU(); max_iter=1000)  # requires MadNLPGPU
+solver_cpu = _build_madnlp_solver(MadNLPTag(), Strategies.CPU(); max_iter=1000)
+solver_gpu = _build_madnlp_solver(MadNLPTag(), Strategies.GPU(); max_iter=1000)  # requires MadNLPGPU
 ```
 """
 function Solvers._build_madnlp_solver(
     ::Type{Solvers.MadNLPTag},
-    parameter::Type{<:AbstractStrategyParameter};
+    parameter::Type{<:Strategies.AbstractStrategyParameter};
     mode::Symbol=:strict,
     kwargs...,
 )

--- a/ext/CTSolversMadNLPGPU.jl
+++ b/ext/CTSolversMadNLPGPU.jl
@@ -7,8 +7,8 @@ Implements GPU-specific linear solver defaults and consistency validation.
 
 module CTSolversMadNLPGPU
 
-import CTSolvers.Solvers
-import CTBase.Strategies
+using CTSolvers: Solvers
+using CTBase: Strategies
 using MadNLPGPU: MadNLPGPU
 using DocStringExtensions: DocStringExtensions
 
@@ -34,7 +34,7 @@ $(DocStringExtensions.TYPEDSIGNATURES)
 Check if `linear_solver` is consistent with CPU parameter.
 
 # Arguments
-- `parameter_type::Type{CPU}`: CPU parameter type
+- `parameter_type::Type{Strategies.CPU}`: CPU parameter type
 - `linear_solver::Type`: Linear solver type
 
 # Returns
@@ -62,7 +62,7 @@ $(DocStringExtensions.TYPEDSIGNATURES)
 Check if `linear_solver` is consistent with GPU parameter.
 
 # Arguments
-- `parameter_type::Type{GPU}`: GPU parameter type
+- `parameter_type::Type{Strategies.GPU}`: GPU parameter type
 - `linear_solver::Type`: Linear solver type
 
 # Returns

--- a/ext/CTSolversOrdinaryDiffEqTsit5.jl
+++ b/ext/CTSolversOrdinaryDiffEqTsit5.jl
@@ -6,8 +6,8 @@ Activated automatically when `OrdinaryDiffEqTsit5` is loaded together with `CTSo
 """
 module CTSolversOrdinaryDiffEqTsit5
 
-import DocStringExtensions: TYPEDSIGNATURES
-using CTSolvers.Integrators: Integrators
+using DocStringExtensions: TYPEDSIGNATURES
+using CTSolvers: Integrators
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5
 
 """

--- a/ext/CTSolversSciMLIntegrator.jl
+++ b/ext/CTSolversSciMLIntegrator.jl
@@ -19,13 +19,13 @@ The domain glue that turns a control system/config into an `ODEProblem` (`build_
 """
 module CTSolversSciMLIntegrator
 
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 using CommonSolve: CommonSolve
-import CTBase.Exceptions
-import CTBase.Strategies
-import CTBase.Core
+using CTBase: Exceptions
+using CTBase: Strategies
+using CTBase: Core
 
-using CTSolvers.Integrators: Integrators
+using CTSolvers: Integrators
 using DiffEqBase: DiffEqBase
 using SciMLBase: SciMLBase
 
@@ -62,9 +62,10 @@ Return metadata defining `Integrators.SciML{P}` options and their specifications
 The `internalnorm` option defaults to `real_norm`, which extracts the primal (Float64)
 part of ForwardDiff dual numbers to ensure grid invariance (IND) when ForwardDiff is loaded.
 
-The metadata is specialized on the execution device `P` (`CPU`/`GPU`); the option set is
-currently identical for both — `P` marks the seam where GPU-specific defaults/validators land
-as they are discovered. The bare `metadata(SciML)` (core) delegates here through `SciML{CPU}`.
+The metadata is specialized on the execution device `P` (`Strategies.CPU`/`Strategies.GPU`);
+the option set is currently identical for both — `P` marks the seam where GPU-specific
+defaults/validators land as they are discovered. The bare `metadata(SciML)` (core) delegates
+here through `SciML{Strategies.CPU}`.
 """
 function Strategies.metadata(
     ::Type{Integrators.SciML{P}}
@@ -303,7 +304,8 @@ cached dictionaries `options_point` (`:auto` → `false`) and `options_trajector
 
 # Arguments
 - `::Type{Integrators.SciMLTag}`: The SciML integrator tag type.
-- `::Type{P}`: The execution device parameter (`CPU`/`GPU`); threaded into the built `SciML{P}`.
+- `::Type{P}`: The execution device parameter (`Strategies.CPU`/`Strategies.GPU`); threaded
+  into the built `SciML{P}`.
 - `mode::Symbol`: Validation mode for strategy options (`:strict` or `:permissive`).
 - `kwargs...`: User-provided option values. Explicit `true`/`false` override `:auto` resolution.
 

--- a/ext/CTSolversUno.jl
+++ b/ext/CTSolversUno.jl
@@ -6,19 +6,16 @@ Implements the complete Solvers.Uno functionality with proper option definitions
 """
 module CTSolversUno
 
-import DocStringExtensions: TYPEDSIGNATURES
-import CTSolvers.Solvers
+using DocStringExtensions: TYPEDSIGNATURES
+using CTSolvers: Solvers
 using CommonSolve: CommonSolve
-import CTBase.Strategies
-import CTBase.Options
-import CTBase.Core
-import CTBase.Exceptions
+using CTBase: Strategies
+using CTBase: Options
+using CTBase: Core
+using CTBase: Exceptions
 using NLPModels: NLPModels
 using SolverCore: SolverCore
 using UnoSolver: UnoSolver
-
-# Import parameter types
-using CTBase.Strategies: CPU, GPU, AbstractStrategyParameter
 
 # ============================================================================
 # Metadata definition
@@ -29,7 +26,7 @@ $(TYPEDSIGNATURES)
 
 Return metadata defining Uno options and their specifications.
 """
-function Strategies.metadata(::Type{Solvers.Uno{P}}) where {P<:CPU}
+function Strategies.metadata(::Type{Solvers.Uno{P}}) where {P<:Strategies.CPU}
     return Strategies.StrategyMetadata(
         # ====================================================================
         # Presets
@@ -312,7 +309,7 @@ See also: `Solvers.Uno`, `Strategies.build_strategy_options`
 """
 function Solvers._build_uno_solver(
     ::Type{Solvers.UnoTag},
-    parameter::Type{<:AbstractStrategyParameter};
+    parameter::Type{<:Strategies.AbstractStrategyParameter};
     mode::Symbol=:strict,
     kwargs...,
 )

--- a/ext/CTSolversZygote.jl
+++ b/ext/CTSolversZygote.jl
@@ -8,8 +8,8 @@ ExtensionError behavior for the ADNLPTag.
 
 module CTSolversZygote
 
-import CTSolvers.Modelers
-import DocStringExtensions: TYPEDSIGNATURES
+using CTSolvers: Modelers
+using DocStringExtensions: TYPEDSIGNATURES
 
 """
 $(TYPEDSIGNATURES)

--- a/src/DOCP/DOCP.jl
+++ b/src/DOCP/DOCP.jl
@@ -16,14 +16,14 @@ the solver/modeler infrastructure provided by CTSolvers.
 module DOCP
 
 # Imports
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 using SolverCore: SolverCore
 using CTModels: CTModels
-import CTBase.Core
-import CTBase.Exceptions
+using CTBase: Core
+using CTBase: Exceptions
 
 # CTBase generic infrastructure
-using CTBase.Strategies
+using CTBase: Strategies
 
 # Internal CTSolvers API
 using ..CTSolvers.Optimization

--- a/src/Integrators/Integrators.jl
+++ b/src/Integrators/Integrators.jl
@@ -42,7 +42,16 @@ using CTModels: Solutions
 # `Integrators.status`/`Integrators.successful` are aliases onto the CTModels.Solutions
 # generics (same Function objects), so extending `Integrators.status` and calling it
 # unqualified both act on `Solutions.status` — see BREAKING.md.
+"""
+Alias for [`CTModels.Solutions.status`](@extref) — same `Function` object, so
+`Integrators.status === CTModels.Solutions.status`, and extending either extends both.
+"""
 const status = Solutions.status
+
+"""
+Alias for [`CTModels.Solutions.successful`](@extref) — same `Function` object, so
+`Integrators.successful === CTModels.Solutions.successful`, and extending either extends both.
+"""
 const successful = Solutions.successful
 
 # CTBase generic infrastructure

--- a/src/Integrators/Integrators.jl
+++ b/src/Integrators/Integrators.jl
@@ -33,16 +33,21 @@ See also: `AbstractIntegrator`, `Integrators.SciML`.
 module Integrators
 
 # Imports
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES, TYPEDFIELDS
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES, TYPEDFIELDS
 using CommonSolve: CommonSolve
-import CTBase.Exceptions
-import CTBase.Core
-import CTModels.Solutions
-import CTModels.Solutions: status, successful
+using CTBase: Exceptions
+using CTBase: Core
+using CTModels: Solutions
+
+# `Integrators.status`/`Integrators.successful` are aliases onto the CTModels.Solutions
+# generics (same Function objects), so extending `Integrators.status` and calling it
+# unqualified both act on `Solutions.status` — see BREAKING.md.
+const status = Solutions.status
+const successful = Solutions.successful
 
 # CTBase generic infrastructure
-using CTBase.Strategies
-using CTBase.Options
+using CTBase: Strategies
+using CTBase: Options
 
 # Include submodules
 include(joinpath(@__DIR__, "abstract_integrator.jl"))

--- a/src/Integrators/integration_result.jl
+++ b/src/Integrators/integration_result.jl
@@ -16,7 +16,7 @@ Subtypes must implement:
 - `status(r::SubType)`: Return the termination status as a `Symbol`.
 - `successful(r::SubType)`: Return whether the integration succeeded.
 
-See also: [`CTSolvers.Integrators.final_state`](@ref), [`CTSolvers.Integrators.times`](@ref), [`CTSolvers.Integrators.evaluate_at`](@ref), [`CTSolvers.Integrators.status`](@ref), [`CTSolvers.Integrators.successful`](@ref).
+See also: [`CTSolvers.Integrators.final_state`](@ref), [`CTSolvers.Integrators.times`](@ref), [`CTSolvers.Integrators.evaluate_at`](@ref), [`CTModels.Solutions.status`](@extref), [`CTModels.Solutions.successful`](@extref).
 """
 abstract type AbstractIntegrationResult end
 
@@ -108,7 +108,7 @@ on OCP solutions and on integration results.
 # Throws
 - [`CTBase.Exceptions.NotImplemented`](@extref): If not implemented by the concrete type.
 
-See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref), [`CTSolvers.Integrators.successful`](@ref).
+See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref), [`CTModels.Solutions.successful`](@extref).
 """
 function Solutions.status(r::AbstractIntegrationResult)::Symbol
     return throw(
@@ -136,7 +136,7 @@ uniformly on OCP solutions and on integration results.
 # Throws
 - [`CTBase.Exceptions.NotImplemented`](@extref): If not implemented by the concrete type.
 
-See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref), [`CTSolvers.Integrators.status`](@ref).
+See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref), [`CTModels.Solutions.status`](@extref).
 """
 function Solutions.successful(r::AbstractIntegrationResult)::Bool
     return throw(

--- a/src/Integrators/sciml.jl
+++ b/src/Integrators/sciml.jl
@@ -45,10 +45,10 @@ file declares the type and **stubs** that throw `ExtensionError` until the
 extension is loaded.
 
 Parameterized on the execution device `P`:
-- `SciML{CPU}`: CPU execution (default);
-- `SciML{GPU}`: GPU execution (state on device arrays, e.g. `CuArray`).
+- `SciML{Strategies.CPU}`: CPU execution (default);
+- `SciML{Strategies.GPU}`: GPU execution (state on device arrays, e.g. `CuArray`).
 
-`SciML(...)` builds a `SciML{CPU}` — the device parameterization is fully backward
+`SciML(...)` builds a `SciML{Strategies.CPU}` — the device parameterization is fully backward
 compatible with existing call sites.
 
 To activate the extension, load any of:
@@ -61,7 +61,7 @@ To activate the extension, load any of:
 $(TYPEDFIELDS)
 """
 struct SciML{
-    P<:Union{CPU,GPU},
+    P<:Union{Strategies.CPU,Strategies.GPU},
     O<:Strategies.StrategyOptions,
     OP<:Dict{Symbol,Any},
     OT<:Dict{Symbol,Any},
@@ -105,28 +105,28 @@ $(TYPEDSIGNATURES)
 
 Return the execution parameter type of a parameterized `SciML{P}` integrator.
 
-Extracts the type parameter `P` from `SciML{P}`, which can be either `CPU` or `GPU`
+Extracts the type parameter `P` from `SciML{P}`, which can be either `Strategies.CPU` or `Strategies.GPU`
 since `SciML` supports both execution devices. More specific than the bare
 `parameter(::Type{<:SciML})` above, so it wins for a concrete `SciML{P}`.
 
 # Returns
-- `Type{<:Union{CPU,GPU}}`: the execution parameter type.
+- `Type{<:Union{Strategies.CPU,Strategies.GPU}}`: the execution parameter type.
 
 See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref)
 """
-Strategies.parameter(::Type{<:SciML{P}}) where {P<:Union{CPU,GPU}} = P
+Strategies.parameter(::Type{<:SciML{P}}) where {P<:Union{Strategies.CPU,Strategies.GPU}} = P
 
 """
 $(TYPEDSIGNATURES)
 
 Return the default execution parameter for `SciML` when none is specified.
 
-Returns `CPU`, so `SciML(...)` builds a `SciML{CPU}` and every existing call site is
+Returns `Strategies.CPU`, so `SciML(...)` builds a `SciML{Strategies.CPU}` and every existing call site is
 unaffected by the device parameterization.
 
 See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTBase.Strategies.CPU`](@extref)
 """
-Strategies.default_parameter(::Type{<:SciML}) = CPU
+Strategies.default_parameter(::Type{<:SciML}) = Strategies.CPU
 
 """
 $(TYPEDSIGNATURES)
@@ -168,8 +168,8 @@ options_trajectory(integ::SciML) = integ.options_trajectory
 """
 $(TYPEDSIGNATURES)
 
-Construct a `SciML{CPU}` integrator (the default device). Equivalent to
-`SciML{CPU}(...)`; delegates through [`CTBase.Strategies.default_parameter`](@extref).
+Construct a `SciML{Strategies.CPU}` integrator (the default device). Equivalent to
+`SciML{Strategies.CPU}(...)`; delegates through [`CTBase.Strategies.default_parameter`](@extref).
 
 # Arguments
 - `mode::Symbol=:strict`: Validation mode (`:strict` or `:permissive`).
@@ -189,7 +189,7 @@ end
 $(TYPEDSIGNATURES)
 
 Construct a parameterized `SciML{P}` integrator for the execution device `P`
-(`CPU` or `GPU`). Delegates to `_build_sciml_integrator`, which is overridden by the
+(`Strategies.CPU` or `Strategies.GPU`). Delegates to `_build_sciml_integrator`, which is overridden by the
 `CTSolversSciMLIntegrator` package extension.
 
 # Arguments
@@ -201,7 +201,7 @@ Construct a parameterized `SciML{P}` integrator for the execution device `P`
 
 See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTSolvers.Integrators._build_sciml_integrator`](@ref).
 """
-function SciML{P}(; mode::Symbol=:strict, kwargs...) where {P<:AbstractStrategyParameter}
+function SciML{P}(; mode::Symbol=:strict, kwargs...) where {P<:Strategies.AbstractStrategyParameter}
     return _build_sciml_integrator(SciMLTag, P; mode=mode, kwargs...)
 end
 
@@ -213,7 +213,7 @@ Stub builder for `SciML`. The real implementation is provided by
 is loaded.
 """
 function _build_sciml_integrator(
-    ::Type{<:Core.AbstractTag}, ::Type{<:AbstractStrategyParameter}; kwargs...
+    ::Type{<:Core.AbstractTag}, ::Type{<:Strategies.AbstractStrategyParameter}; kwargs...
 )
     return throw(
         Exceptions.ExtensionError(
@@ -250,7 +250,7 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Fallback for the non-parameterized `SciML` type that delegates to `SciML{CPU}`.
+Fallback for the non-parameterized `SciML` type that delegates to `SciML{Strategies.CPU}`.
 
 Preserves backward compatibility for `metadata(SciML)` once the extension defines only
 the parameterized `metadata(SciML{P})`. Delegates through
@@ -287,12 +287,12 @@ of a `SciML{P}` integrator.
 
 Mirrors `Modelers.__consistent_backend`: the default returns `true` (all combinations
 allowed); the `CTSolversCUDA` extension adds the device-aware methods that flag a `CuArray`
-`u0` under `SciML{CPU}`, or a host `Array` `u0` under `SciML{GPU}`. The seam is defined here,
+`u0` under `SciML{Strategies.CPU}`, or a host `Array` `u0` under `SciML{Strategies.GPU}`. The seam is defined here,
 next to the integrator; the consuming package (e.g. CTFlows) calls it where a concrete `u0`
 is available (problem construction / solve), since `SciML` does not receive `u0` at build time.
 
 # Arguments
-- `parameter_type::Type{<:AbstractStrategyParameter}`: `CPU` or `GPU`.
+- `parameter_type::Type{<:Strategies.AbstractStrategyParameter}`: `Strategies.CPU` or `Strategies.GPU`.
 - `u0`: The initial condition array to check.
 
 # Returns
@@ -300,6 +300,6 @@ is available (problem construction / solve), since `SciML` does not receive `u0`
 
 See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref).
 """
-function __consistent_initial_condition(::Type{<:AbstractStrategyParameter}, u0)
+function __consistent_initial_condition(::Type{<:Strategies.AbstractStrategyParameter}, u0)
     return true
 end

--- a/src/Modelers/Modelers.jl
+++ b/src/Modelers/Modelers.jl
@@ -17,14 +17,14 @@ orchestration and option routing.
 module Modelers
 
 # Imports
-import CTBase.Exceptions
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+using CTBase: Exceptions
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
 using SolverCore: SolverCore
-import CTBase.Core
+using CTBase: Core
 
 # CTBase generic infrastructure
-using CTBase.Options
-using CTBase.Strategies
+using CTBase: Options
+using CTBase: Strategies
 
 # Internal CTSolvers API
 using ..Optimization

--- a/src/Modelers/adnlp.jl
+++ b/src/Modelers/adnlp.jl
@@ -80,7 +80,7 @@ identification.
 ## Parameterized Types
 
 The modeler supports parameterization for execution backend:
-- `ADNLP{CPU}`: CPU execution (default and only supported parameter)
+- `ADNLP{Strategies.CPU}`: CPU execution (default and only supported parameter)
 
 **Note:** Unlike `Exa`, `MadNLP`, and `MadNCL`, this modeler only supports CPU execution.
 GPU execution is not available for ADNLP.
@@ -92,7 +92,7 @@ GPU execution is not available for ADNLP.
 Modelers.ADNLP(; mode::Symbol=:strict, kwargs...)
 
 # Explicit parameter specification (only CPU supported)
-Modelers.ADNLP{CPU}(; mode::Symbol=:strict, kwargs...)
+Modelers.ADNLP{Strategies.CPU}(; mode::Symbol=:strict, kwargs...)
 ```
 
 # Arguments
@@ -140,7 +140,7 @@ or an `ADBackend` instance (used directly).
 modeler = Modelers.ADNLP()
 
 # Explicit CPU specification
-modeler = Modelers.ADNLP{CPU}()
+modeler = Modelers.ADNLP{Strategies.CPU}()
 
 # With custom options
 modeler = Modelers.ADNLP(
@@ -153,7 +153,7 @@ modeler = Modelers.ADNLP(
 ## Invalid Usage
 ```julia
 # GPU is NOT supported - will throw IncorrectArgument
-modeler = Modelers.ADNLP{GPU}()  # ❌ Error!
+modeler = Modelers.ADNLP{Strategies.GPU}()  # ❌ Error!
 ```
 
 ## Advanced Backend Configuration
@@ -196,7 +196,7 @@ modeler = Modelers.ADNLP(
 
 # See also
 
-- `CPU`: CPU parameter type
+- `Strategies.CPU`: CPU parameter type
 - `Modelers.Exa`: Alternative modeler using ExaModels (supports GPU)
 - `Optimization.build_model`: Build a backend NLP model from a problem and a modeler
 - `Optimization.build_solution`: Build a problem-level solution from execution statistics
@@ -213,7 +213,7 @@ modeler = Modelers.ADNLP(
 - ADNLPModels.jl: [https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl](https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl)
 - Automatic Differentiation in Julia: [https://github.com/JuliaDiff/](https://github.com/JuliaDiff/)
 """
-struct ADNLP{P<:CPU} <: AbstractNLPModeler
+struct ADNLP{P<:Strategies.CPU} <: AbstractNLPModeler
     "Solver configuration options containing validated option values"
     options::Strategies.StrategyOptions
 end
@@ -236,31 +236,31 @@ $(TYPEDSIGNATURES)
 
 Default parameter type for ADNLP when not explicitly specified.
 
-Returns `CPU` as the default execution parameter.
+Returns `Strategies.CPU` as the default execution parameter.
 
 # Implementation Notes
 
 This method is part of the `AbstractStrategy` parameter contract and must be
 implemented by all parameterized strategies.
 
-See also: `ADNLP`, `CPU`
+See also: `ADNLP`, `Strategies.CPU`
 """
-Strategies.default_parameter(::Type{<:Modelers.ADNLP}) = CPU
+Strategies.default_parameter(::Type{<:Modelers.ADNLP}) = Strategies.CPU
 
 """
 $(TYPEDSIGNATURES)
 
 Return the execution parameter type of an `ADNLP` strategy.
 
-Extracts the type parameter `P` from `ADNLP{P}`, which is always `CPU` since
+Extracts the type parameter `P` from `ADNLP{P}`, which is always `Strategies.CPU` since
 ADNLP is CPU-only.
 
 # Returns
-- `Type{CPU}`: the execution parameter type.
+- `Type{Strategies.CPU}`: the execution parameter type.
 
 See also: [`CTSolvers.Modelers.ADNLP`](@ref), [`CTBase.Strategies.CPU`](@extref)
 """
-Strategies.parameter(::Type{<:Modelers.ADNLP{P}}) where {P<:CPU} = P
+Strategies.parameter(::Type{<:Modelers.ADNLP{P}}) where {P<:Strategies.CPU} = P
 
 # Strategy metadata with option definitions (parameterized)
 """
@@ -273,7 +273,7 @@ Stub — real implementation provided by the CTSolversADNLPModels extension.
 
 See also: `Modelers.ADNLP`, `Strategies.StrategyMetadata`
 """
-function Strategies.metadata(::Type{<:Modelers.ADNLP{P}}) where {P<:CPU}
+function Strategies.metadata(::Type{<:Modelers.ADNLP{P}}) where {P<:Strategies.CPU}
     return throw(
         Exceptions.ExtensionError(
             :ADNLPModels;
@@ -315,7 +315,7 @@ Requires the CTSolversADNLPModels extension to be loaded.
 
 See also: `Modelers.ADNLP`, `_build_adnlp_modeler`
 """
-function Modelers.ADNLP{P}(; mode::Symbol=:strict, kwargs...) where {P<:CPU}
+function Modelers.ADNLP{P}(; mode::Symbol=:strict, kwargs...) where {P<:Strategies.CPU}
     return _build_adnlp_modeler(ADNLPTag, P; mode=mode, kwargs...)
 end
 
@@ -331,7 +331,7 @@ Real implementation provided by the extension.
 See also: `Modelers.ADNLP`, `Strategies.metadata`
 """
 function _build_adnlp_modeler(
-    ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
+    ::Type{<:Core.AbstractTag}, parameter::Type{<:Strategies.AbstractStrategyParameter}; kwargs...
 )
     return throw(
         Exceptions.ExtensionError(
@@ -356,7 +356,7 @@ Create an Modelers.ADNLP with validated options (defaults to CPU).
 - `kwargs...`: Modeler options (see `Modelers.ADNLP` documentation)
 
 # Returns
-- `Modelers.ADNLP{CPU}`: Configured modeler instance with CPU parameter
+- `Modelers.ADNLP{Strategies.CPU}`: Configured modeler instance with CPU parameter
 
 # Examples
 ```julia
@@ -374,7 +374,7 @@ modeler = Modelers.ADNLP(backend=:optimized, custom_option=123; mode=:permissive
 - `CTBase.Exceptions.ExtensionError`: If the ADNLPModels extension is not loaded
 - `CTBase.Exceptions.IncorrectArgument`: If option validation fails
 
-See also: `Modelers.ADNLP`, `Modelers.ADNLP{CPU}`, `_build_adnlp_modeler`
+See also: `Modelers.ADNLP`, `Modelers.ADNLP{Strategies.CPU}`, `_build_adnlp_modeler`
 """
 function Modelers.ADNLP(; mode::Symbol=:strict, kwargs...)
     P = Strategies.default_parameter(Modelers.ADNLP)
@@ -402,10 +402,10 @@ Factory function that returns a backend validator for the specified tag type.
 
 # Examples
 ```julia-repl
-julia> using CTSolvers.Modelers
+julia> using CTSolvers: Modelers
 
 julia> # Get validator for ADNLP (with extensions loaded)
-julia> validator = get_validate_adnlp_backend(ADNLPTag)
+julia> validator = Modelers.get_validate_adnlp_backend(Modelers.ADNLPTag)
 (backend)->validate_adnlp_backend(#=method=#1, #=generic#=)
 
 julia> validator(:default)
@@ -415,7 +415,7 @@ julia> validator(:enzyme)  # Works with CTSolversEnzyme extension
 :enzyme
 
 julia> # Get validator for dummy tag (no extensions)
-julia> dummy_validator = get_validate_adnlp_backend(DummyTag)
+julia> dummy_validator = Modelers.get_validate_adnlp_backend(Modelers.DummyTag)
 (backend)->validate_adnlp_backend(#=method=#1, #=generic#=)
 
 julia> dummy_validator(:enzyme)  # Throws ExtensionError

--- a/src/Modelers/exa.jl
+++ b/src/Modelers/exa.jl
@@ -40,7 +40,7 @@ Return the default execution backend for CPU parameter.
 
 Always returns `nothing` for CPU execution.
 """
-__exa_model_backend(::Type{CPU}) = nothing
+__exa_model_backend(::Type{Strategies.CPU}) = nothing
 
 """
 $(TYPEDSIGNATURES)
@@ -49,7 +49,7 @@ Return the default execution backend for GPU parameter.
 
 Returns CUDA backend if available, throws ExtensionError otherwise.
 """
-function __exa_model_backend(P::Type{GPU})
+function __exa_model_backend(P::Type{Strategies.GPU})
     return __get_cuda_backend(P)
 end
 
@@ -71,7 +71,7 @@ and returns an appropriate CUDA backend.
 - Issues a warning if CUDA is loaded but not functional
 - Uses CUDA.CUDABackend() for GPU execution
 """
-function __get_cuda_backend(::Type{<:GPU})
+function __get_cuda_backend(::Type{<:Strategies.GPU})
     return throw(
         Exceptions.ExtensionError(
             :CUDA;
@@ -88,7 +88,7 @@ $(TYPEDSIGNATURES)
 Check if backend is consistent with parameter type.
 
 # Arguments
-- `parameter_type::Type{<:AbstractStrategyParameter}`: CPU or GPU parameter
+- `parameter_type::Type{<:Strategies.AbstractStrategyParameter}`: CPU or GPU parameter
 - `backend`: Backend to check consistency for
 
 # Returns
@@ -98,7 +98,7 @@ Check if backend is consistent with parameter type.
 - Default implementation returns true (all combinations allowed)
 - Specific implementations in extensions provide actual consistency checks
 """
-function __consistent_backend(::Type{<:AbstractStrategyParameter}, backend)
+function __consistent_backend(::Type{<:Strategies.AbstractStrategyParameter}, backend)
     return true
 end
 
@@ -118,8 +118,8 @@ support for various execution backends (CPU, GPU) and floating-point types.
 ## Parameterized Types
 
 The modeler supports parameterization for execution backend:
-- `Exa{CPU}`: CPU execution (default)
-- `Exa{GPU}`: GPU execution (requires CUDA.jl)
+- `Exa{Strategies.CPU}`: CPU execution (default)
+- `Exa{Strategies.GPU}`: GPU execution (requires CUDA.jl)
 
 # Constructors
 
@@ -128,8 +128,8 @@ The modeler supports parameterization for execution backend:
 Modelers.Exa(; mode::Symbol=:strict, kwargs...)
 
 # Explicit parameter specification
-Modelers.Exa{CPU}(; mode::Symbol=:strict, kwargs...)
-Modelers.Exa{GPU}(; mode::Symbol=:strict, kwargs...)
+Modelers.Exa{Strategies.CPU}(; mode::Symbol=:strict, kwargs...)
+Modelers.Exa{Strategies.GPU}(; mode::Symbol=:strict, kwargs...)
 ```
 
 # Arguments
@@ -152,10 +152,10 @@ Modelers.Exa{GPU}(; mode::Symbol=:strict, kwargs...)
 modeler = Modelers.Exa()
 
 # Explicit CPU modeler
-modeler = Modelers.Exa{CPU}()
+modeler = Modelers.Exa{Strategies.CPU}()
 
 # GPU modeler (requires CUDA.jl)
-modeler = Modelers.Exa{GPU}()
+modeler = Modelers.Exa{Strategies.GPU}()
 ```
 
 ## Type Specification
@@ -170,10 +170,10 @@ modeler = Modelers.Exa(base_type=Float64)
 ## Backend Configuration
 ```julia
 # CPU backend (default for Exa{CPU})
-modeler = Modelers.Exa{CPU}(backend=nothing)
+modeler = Modelers.Exa{Strategies.CPU}(backend=nothing)
 
 # GPU backend (default for Exa{GPU})
-modeler = Modelers.Exa{GPU}()  # Uses CUDA backend automatically
+modeler = Modelers.Exa{Strategies.GPU}()  # Uses CUDA backend automatically
 ```
 
 ## Validation Modes
@@ -192,7 +192,7 @@ modeler = Modelers.Exa(
 ## Complete Configuration
 ```julia
 # Full configuration with type and backend
-modeler = Modelers.Exa{GPU}(
+modeler = Modelers.Exa{Strategies.GPU}(
     base_type=Float32;
     mode=:permissive
 )
@@ -209,7 +209,7 @@ modeler = Modelers.Exa{GPU}(
 - `Modelers.ADNLP`: Alternative modeler using ADNLPModels
 - `build_model`: Build model from problem and modeler
 - `solve!`: Solve optimization problem
-- `CPU`, `GPU`: Strategy parameters
+- `Strategies.CPU`, `Strategies.GPU`: Strategy parameters
 
 # Notes
 
@@ -224,7 +224,7 @@ modeler = Modelers.Exa{GPU}(
 - ExaModels.jl: [https://github.com/JuliaSmoothOptimizers/ExaModels.jl](https://github.com/JuliaSmoothOptimizers/ExaModels.jl)
 - KernelAbstractions.jl: [https://github.com/JuliaGPU/KernelAbstractions.jl](https://github.com/JuliaGPU/KernelAbstractions.jl)
 """
-struct Exa{P<:Union{CPU,GPU}} <: AbstractNLPModeler
+struct Exa{P<:Union{Strategies.CPU,Strategies.GPU}} <: AbstractNLPModeler
     options::Strategies.StrategyOptions
 end
 
@@ -246,31 +246,31 @@ $(TYPEDSIGNATURES)
 
 Default parameter type for Exa when not explicitly specified.
 
-Returns `CPU` as the default execution parameter.
+Returns `Strategies.CPU` as the default execution parameter.
 
 # Implementation Notes
 
 This method is part of the `AbstractStrategy` parameter contract and must be
 implemented by all parameterized strategies.
 
-See also: `Exa`, `CPU`
+See also: `Exa`, `Strategies.CPU`
 """
-Strategies.default_parameter(::Type{<:Modelers.Exa}) = CPU
+Strategies.default_parameter(::Type{<:Modelers.Exa}) = Strategies.CPU
 
 """
 $(TYPEDSIGNATURES)
 
 Return the execution parameter type of an `Exa` strategy.
 
-Extracts the type parameter `P` from `Exa{P}`, which can be either `CPU` or
-`GPU` since Exa supports both execution backends.
+Extracts the type parameter `P` from `Exa{P}`, which can be either `Strategies.CPU` or
+`Strategies.GPU` since Exa supports both execution backends.
 
 # Returns
-- `Type{<:Union{CPU,GPU}}`: the execution parameter type.
+- `Type{<:Union{Strategies.CPU,Strategies.GPU}}`: the execution parameter type.
 
 See also: [`CTSolvers.Modelers.Exa`](@ref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref)
 """
-Strategies.parameter(::Type{<:Modelers.Exa{P}}) where {P<:Union{CPU,GPU}} = P
+Strategies.parameter(::Type{<:Modelers.Exa{P}}) where {P<:Union{Strategies.CPU,Strategies.GPU}} = P
 
 # Strategy metadata with option definitions (parameterized)
 """
@@ -283,7 +283,7 @@ Stub — real implementation provided by the CTSolversExaModels extension.
 
 See also: `Modelers.Exa`, `Strategies.StrategyMetadata`
 """
-function Strategies.metadata(::Type{<:Modelers.Exa{P}}) where {P<:Union{CPU,GPU}}
+function Strategies.metadata(::Type{<:Modelers.Exa{P}}) where {P<:Union{Strategies.CPU,Strategies.GPU}}
     return throw(
         Exceptions.ExtensionError(
             :ExaModels;
@@ -297,13 +297,13 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Fallback for non-parameterized `Exa` type that delegates to `Exa{CPU}`.
+Fallback for non-parameterized `Exa` type that delegates to `Exa{Strategies.CPU}`.
 
 This provides backward compatibility and a sensible default when the parameter
-is not specified. The call will delegate to `metadata(Exa{CPU})`.
+is not specified. The call will delegate to `metadata(Exa{Strategies.CPU})`.
 
 # Returns
-- `StrategyMetadata`: Metadata for `Exa{CPU}`
+- `StrategyMetadata`: Metadata for `Exa{Strategies.CPU}`
 """
 function Strategies.metadata(::Type{Modelers.Exa})
     return Strategies.metadata(Modelers.Exa{Strategies.default_parameter(Modelers.Exa)})
@@ -337,7 +337,7 @@ See also: `Modelers.Exa`, `_build_exa_modeler`
 """
 function Modelers.Exa{P}(;
     mode::Symbol=:strict, kwargs...
-) where {P<:AbstractStrategyParameter}
+) where {P<:Strategies.AbstractStrategyParameter}
     return _build_exa_modeler(ExaTag, P; mode=mode, kwargs...)
 end
 
@@ -353,7 +353,7 @@ Real implementation provided by the extension.
 See also: `Modelers.Exa`, `Strategies.metadata`
 """
 function _build_exa_modeler(
-    ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
+    ::Type{<:Core.AbstractTag}, parameter::Type{<:Strategies.AbstractStrategyParameter}; kwargs...
 )
     return throw(
         Exceptions.ExtensionError(
@@ -380,13 +380,13 @@ Requires the CTSolversExaModels extension to be loaded.
 - `kwargs...`: Modeler options (see `Modelers.Exa` documentation)
 
 # Returns
-- `Modelers.Exa{CPU}`: Configured modeler instance with CPU parameter
+- `Modelers.Exa{Strategies.CPU}`: Configured modeler instance with CPU parameter
 
 # Throws
 - `CTBase.Exceptions.ExtensionError`: If the ExaModels extension is not loaded
 - `CTBase.Exceptions.IncorrectArgument`: If option validation fails
 
-See also: `Modelers.Exa`, `Modelers.Exa{CPU}`, `Modelers.Exa{GPU}`, `_build_exa_modeler`
+See also: `Modelers.Exa`, `Modelers.Exa{Strategies.CPU}`, `Modelers.Exa{Strategies.GPU}`, `_build_exa_modeler`
 """
 function Modelers.Exa(; mode::Symbol=:strict, kwargs...)
     P = Strategies.default_parameter(Modelers.Exa)

--- a/src/Modelers/validation.jl
+++ b/src/Modelers/validation.jl
@@ -143,16 +143,16 @@ Validate that the specified base type is appropriate for ExaModels.
 
 # Examples
 ```julia-repl
-julia> using CTSolvers.Modelers
+julia> using CTSolvers: Modelers
 
-julia> validate_exa_base_type(Float64)
+julia> Modelers.validate_exa_base_type(Float64)
 Float64
 
-julia> validate_exa_base_type(Float32)
+julia> Modelers.validate_exa_base_type(Float32)
 Float32
 
 # Throws IncorrectArgument for invalid types
-julia> validate_exa_base_type(Int)
+julia> Modelers.validate_exa_base_type(Int)
 ERROR: Control Toolbox Error
 ❌ Error: CTBase.Exceptions.IncorrectArgument, Invalid base type for Modelers.Exa
 ```

--- a/src/Optimization/Optimization.jl
+++ b/src/Optimization/Optimization.jl
@@ -19,8 +19,8 @@ Solver-side utilities (e.g. `extract_solver_infos`) live in `Solvers`.
 module Optimization
 
 # Imports
-import CTBase.Core
-import DocStringExtensions: TYPEDEF
+using CTBase: Core
+using DocStringExtensions: TYPEDEF
 
 # Submodules
 include(joinpath(@__DIR__, "abstract_types.jl"))

--- a/src/Solvers/Solvers.jl
+++ b/src/Solvers/Solvers.jl
@@ -42,15 +42,15 @@ See also: `AbstractNLPSolver`, `Solvers.Ipopt`
 module Solvers
 
 # Imports
-import DocStringExtensions: TYPEDEF, TYPEDSIGNATURES, TYPEDFIELDS
+using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES, TYPEDFIELDS
 using SolverCore: SolverCore
 using CommonSolve: CommonSolve
-import CTBase.Exceptions
-import CTBase.Core
+using CTBase: Exceptions
+using CTBase: Core
 
 # CTBase generic infrastructure
-using CTBase.Strategies
-using CTBase.Options
+using CTBase: Strategies
+using CTBase: Options
 
 # Internal CTSolvers modules
 using ..Optimization

--- a/src/Solvers/ipopt.jl
+++ b/src/Solvers/ipopt.jl
@@ -25,7 +25,7 @@ global convergence properties.
 ## Parameterized Types
 
 The solver supports parameterization for execution backend:
-- `Ipopt{CPU}`: CPU execution (default and only supported parameter)
+- `Ipopt{Strategies.CPU}`: CPU execution (default and only supported parameter)
 
 **Note:** Unlike `MadNLP` and `MadNCL`, this solver only supports CPU execution.
 GPU execution is not available for Ipopt.
@@ -37,7 +37,7 @@ GPU execution is not available for Ipopt.
 Solvers.Ipopt(; mode::Symbol=:strict, kwargs...)
 
 # Explicit parameter specification (only CPU supported)
-Solvers.Ipopt{CPU}(; mode::Symbol=:strict, kwargs...)
+Solvers.Ipopt{Strategies.CPU}(; mode::Symbol=:strict, kwargs...)
 ```
 
 # Fields
@@ -73,7 +73,7 @@ using NLPModelsIpopt
 solver = Ipopt(max_iter=1000, tol=1e-6, print_level=3)
 
 # Explicit CPU specification
-solver_cpu = Ipopt{CPU}(max_iter=1000, tol=1e-6)
+solver_cpu = Ipopt{Strategies.CPU}(max_iter=1000, tol=1e-6)
 
 nlp = ADNLPModel(x -> sum(x.^2), zeros(10))
 stats = solver(nlp, display=true)
@@ -82,7 +82,7 @@ stats = solver(nlp, display=true)
 ## Invalid Usage
 ```julia
 # GPU is NOT supported - will throw IncorrectArgument
-solver = Ipopt{GPU}()  # ❌ Error!
+solver = Ipopt{Strategies.GPU}()  # ❌ Error!
 ```
 
 # Extension Required
@@ -104,9 +104,9 @@ using NLPModelsIpopt
 - `CTBase.Exceptions.IncorrectArgument`: If GPU or other unsupported parameter is specified
 - `CTBase.Exceptions.ExtensionError`: If the NLPModelsIpopt extension is not loaded
 
-See also: `CPU`, `AbstractNLPSolver`, `MadNLP`, `Knitro`
+See also: `Strategies.CPU`, `AbstractNLPSolver`, `MadNLP`, `Knitro`
 """
-struct Ipopt{P<:CPU} <: AbstractNLPSolver
+struct Ipopt{P<:Strategies.CPU} <: AbstractNLPSolver
     "Solver configuration options containing validated option values"
     options::Strategies.StrategyOptions
 end
@@ -137,31 +137,31 @@ $(TYPEDSIGNATURES)
 
 Default parameter type for Ipopt when not explicitly specified.
 
-Returns `CPU` as the default execution parameter.
+Returns `Strategies.CPU` as the default execution parameter.
 
 # Implementation Notes
 
 This method is part of the `AbstractStrategy` parameter contract and must be
 implemented by all parameterized strategies.
 
-See also: `Ipopt`, `CPU`
+See also: `Ipopt`, `Strategies.CPU`
 """
-Strategies.default_parameter(::Type{<:Solvers.Ipopt}) = CPU
+Strategies.default_parameter(::Type{<:Solvers.Ipopt}) = Strategies.CPU
 
 """
 $(TYPEDSIGNATURES)
 
 Return the execution parameter type of an `Ipopt` strategy.
 
-Extracts the type parameter `P` from `Ipopt{P}`, which is always `CPU` since
+Extracts the type parameter `P` from `Ipopt{P}`, which is always `Strategies.CPU` since
 Ipopt is CPU-only.
 
 # Returns
-- `Type{CPU}`: the execution parameter type.
+- `Type{Strategies.CPU}`: the execution parameter type.
 
 See also: [`CTSolvers.Solvers.Ipopt`](@ref), [`CTBase.Strategies.CPU`](@extref)
 """
-Strategies.parameter(::Type{<:Solvers.Ipopt{P}}) where {P<:CPU} = P
+Strategies.parameter(::Type{<:Solvers.Ipopt{P}}) where {P<:Strategies.CPU} = P
 
 # ============================================================================
 # Constructor with Tag Dispatch
@@ -217,16 +217,16 @@ Requires the CTSolversIpopt extension to be loaded.
 ```julia
 # Conceptual usage (requires NLPModelsIpopt extension)
 using NLPModelsIpopt
-solver_cpu = Solvers.Ipopt{CPU}(max_iter=1000, tol=1e-6)
+solver_cpu = Solvers.Ipopt{Strategies.CPU}(max_iter=1000, tol=1e-6)
 ```
 
 # Throws
 - `CTBase.Exceptions.IncorrectArgument`: If GPU or other unsupported parameter is specified
 - `CTBase.Exceptions.ExtensionError`: If the NLPModelsIpopt extension is not loaded
 
-See also: `Ipopt`, `CPU`
+See also: `Ipopt`, `Strategies.CPU`
 """
-function Solvers.Ipopt{P}(; mode::Symbol=:strict, kwargs...) where {P<:CPU}
+function Solvers.Ipopt{P}(; mode::Symbol=:strict, kwargs...) where {P<:Strategies.CPU}
     return _build_ipopt_solver(IpoptTag, P; mode=mode, kwargs...)
 end
 
@@ -242,7 +242,7 @@ Real implementation provided by the extension.
 See also: `Ipopt`, `Strategies.metadata`
 """
 function _build_ipopt_solver(
-    ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
+    ::Type{<:Core.AbstractTag}, parameter::Type{<:Strategies.AbstractStrategyParameter}; kwargs...
 )
     return throw(
         Exceptions.ExtensionError(
@@ -260,14 +260,14 @@ $(TYPEDSIGNATURES)
 Stub function that throws ExtensionError if CTSolversIpopt extension is not loaded.
 Real metadata implementation provided by the extension.
 
-This stub is for parameterized types `Ipopt{P}` where `P <: AbstractStrategyParameter`.
+This stub is for parameterized types `Ipopt{P}` where `P <: Strategies.AbstractStrategyParameter`.
 
 # Throws
 - `CTBase.Exceptions.ExtensionError`: Always thrown by this stub implementation
 
 See also: `Ipopt`, `Strategies.StrategyMetadata`
 """
-function Strategies.metadata(::Type{<:Solvers.Ipopt{P}}) where {P<:CPU}
+function Strategies.metadata(::Type{<:Solvers.Ipopt{P}}) where {P<:Strategies.CPU}
     # Extension is missing
     return throw(
         Exceptions.ExtensionError(
@@ -282,15 +282,15 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Fallback for non-parameterized `Ipopt` type that delegates to `Ipopt{CPU}`.
+Fallback for non-parameterized `Ipopt` type that delegates to `Ipopt{Strategies.CPU}`.
 
 This provides backward compatibility and a sensible default when the parameter
-is not specified. The call will delegate to `metadata(Ipopt{CPU})`, which will
+is not specified. The call will delegate to `metadata(Ipopt{Strategies.CPU})`, which will
 either use the extension implementation (if loaded) or throw an ExtensionError
 (if not loaded).
 
 # Returns
-- `StrategyMetadata`: Metadata for `Ipopt{CPU}` (if extension loaded)
+- `StrategyMetadata`: Metadata for `Ipopt{Strategies.CPU}` (if extension loaded)
 
 # Throws
 - `CTBase.Exceptions.ExtensionError`: If extension not loaded (via delegation)

--- a/src/Solvers/knitro.jl
+++ b/src/Solvers/knitro.jl
@@ -25,7 +25,7 @@ It provides excellent performance and robustness for large-scale problems.
 ## Parameterized Types
 
 The solver supports parameterization for execution backend:
-- `Knitro{CPU}`: CPU execution (default and only supported parameter)
+- `Knitro{Strategies.CPU}`: CPU execution (default and only supported parameter)
 
 **Note:** Unlike `MadNLP` and `MadNCL`, this solver only supports CPU execution.
 GPU execution is not available for Knitro.
@@ -37,7 +37,7 @@ GPU execution is not available for Knitro.
 Solvers.Knitro(; mode::Symbol=:strict, kwargs...)
 
 # Explicit parameter specification (only CPU supported)
-Solvers.Knitro{CPU}(; mode::Symbol=:strict, kwargs...)
+Solvers.Knitro{Strategies.CPU}(; mode::Symbol=:strict, kwargs...)
 ```
 
 # Fields
@@ -73,7 +73,7 @@ using NLPModelsKnitro
 solver = Knitro(maxit=1000, maxtime=3600, ftol=1e-10, outlev=2)
 
 # Explicit CPU specification
-solver_cpu = Knitro{CPU}(maxit=1000, outlev=2)
+solver_cpu = Knitro{Strategies.CPU}(maxit=1000, outlev=2)
 
 nlp = ADNLPModel(x -> sum(x.^2), zeros(10))
 stats = solver(nlp, display=true)
@@ -82,7 +82,7 @@ stats = solver(nlp, display=true)
 ## Invalid Usage
 ```julia
 # GPU is NOT supported - will throw IncorrectArgument
-solver = Knitro{GPU}()  # ❌ Error!
+solver = Knitro{Strategies.GPU}()  # ❌ Error!
 ```
 
 # Extension Required
@@ -107,9 +107,9 @@ using NLPModelsKnitro
 - `CTBase.Exceptions.IncorrectArgument`: If GPU or other unsupported parameter is specified
 - `CTBase.Exceptions.ExtensionError`: If the NLPModelsKnitro extension is not loaded
 
-See also: `CPU`, `AbstractNLPSolver`, `Ipopt`, `MadNLP`
+See also: `Strategies.CPU`, `AbstractNLPSolver`, `Ipopt`, `MadNLP`
 """
-struct Knitro{P<:CPU} <: AbstractNLPSolver
+struct Knitro{P<:Strategies.CPU} <: AbstractNLPSolver
     "Solver configuration options containing validated option values"
     options::Strategies.StrategyOptions
 end
@@ -140,31 +140,31 @@ $(TYPEDSIGNATURES)
 
 Default parameter type for Knitro when not explicitly specified.
 
-Returns `CPU` as the default execution parameter.
+Returns `Strategies.CPU` as the default execution parameter.
 
 # Implementation Notes
 
 This method is part of the `AbstractStrategy` parameter contract and must be
 implemented by all parameterized strategies.
 
-See also: `Knitro`, `CPU`
+See also: `Knitro`, `Strategies.CPU`
 """
-Strategies.default_parameter(::Type{<:Solvers.Knitro}) = CPU
+Strategies.default_parameter(::Type{<:Solvers.Knitro}) = Strategies.CPU
 
 """
 $(TYPEDSIGNATURES)
 
 Return the execution parameter type of a `Knitro` strategy.
 
-Extracts the type parameter `P` from `Knitro{P}`, which is always `CPU` since
+Extracts the type parameter `P` from `Knitro{P}`, which is always `Strategies.CPU` since
 Knitro is CPU-only.
 
 # Returns
-- `Type{CPU}`: the execution parameter type.
+- `Type{Strategies.CPU}`: the execution parameter type.
 
 See also: [`CTSolvers.Solvers.Knitro`](@ref), [`CTBase.Strategies.CPU`](@extref)
 """
-Strategies.parameter(::Type{<:Solvers.Knitro{P}}) where {P<:CPU} = P
+Strategies.parameter(::Type{<:Solvers.Knitro{P}}) where {P<:Strategies.CPU} = P
 
 # ============================================================================
 # Constructor with Tag Dispatch
@@ -220,16 +220,16 @@ Requires the CTSolversKnitro extension to be loaded.
 ```julia
 # Conceptual usage (requires NLPModelsKnitro extension)
 using NLPModelsKnitro
-solver_cpu = Solvers.Knitro{CPU}(maxit=1000, outlev=2)
+solver_cpu = Solvers.Knitro{Strategies.CPU}(maxit=1000, outlev=2)
 ```
 
 # Throws
 - `CTBase.Exceptions.IncorrectArgument`: If GPU or other unsupported parameter is specified
 - `CTBase.Exceptions.ExtensionError`: If the NLPModelsKnitro extension is not loaded
 
-See also: `Knitro`, `CPU`
+See also: `Knitro`, `Strategies.CPU`
 """
-function Solvers.Knitro{P}(; mode::Symbol=:strict, kwargs...) where {P<:CPU}
+function Solvers.Knitro{P}(; mode::Symbol=:strict, kwargs...) where {P<:Strategies.CPU}
     return _build_knitro_solver(KnitroTag, P; mode=mode, kwargs...)
 end
 
@@ -245,7 +245,7 @@ Real implementation provided by the extension.
 See also: `Knitro`, `Strategies.metadata`
 """
 function _build_knitro_solver(
-    ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
+    ::Type{<:Core.AbstractTag}, parameter::Type{<:Strategies.AbstractStrategyParameter}; kwargs...
 )
     return throw(
         Exceptions.ExtensionError(
@@ -263,14 +263,14 @@ $(TYPEDSIGNATURES)
 Stub function that throws ExtensionError if CTSolversKnitro extension is not loaded.
 Real metadata implementation provided by the extension.
 
-This stub is for parameterized types `Knitro{P}` where `P <: AbstractStrategyParameter`.
+This stub is for parameterized types `Knitro{P}` where `P <: Strategies.AbstractStrategyParameter`.
 
 # Throws
 - `CTBase.Exceptions.ExtensionError`: Always thrown by this stub implementation
 
 See also: `Knitro`, `Strategies.StrategyMetadata`
 """
-function Strategies.metadata(::Type{<:Solvers.Knitro{P}}) where {P<:CPU}
+function Strategies.metadata(::Type{<:Solvers.Knitro{P}}) where {P<:Strategies.CPU}
     # Extension is missing
     return throw(
         Exceptions.ExtensionError(
@@ -285,15 +285,15 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Fallback for non-parameterized `Knitro` type that delegates to `Knitro{CPU}`.
+Fallback for non-parameterized `Knitro` type that delegates to `Knitro{Strategies.CPU}`.
 
 This provides backward compatibility and a sensible default when the parameter
-is not specified. The call will delegate to `metadata(Knitro{CPU})`, which will
+is not specified. The call will delegate to `metadata(Knitro{Strategies.CPU})`, which will
 either use the extension implementation (if loaded) or throw an ExtensionError
 (if not loaded).
 
 # Returns
-- `StrategyMetadata`: Metadata for `Knitro{CPU}` (if extension loaded)
+- `StrategyMetadata`: Metadata for `Knitro{Strategies.CPU}` (if extension loaded)
 
 # Throws
 - `CTBase.Exceptions.ExtensionError`: If extension not loaded (via delegation)

--- a/src/Solvers/madncl.jl
+++ b/src/Solvers/madncl.jl
@@ -25,8 +25,8 @@ challenging nonlinear optimization problems.
 ## Parameterized Types
 
 The solver supports parameterization for execution backend:
-- `MadNCL{CPU}`: CPU execution (default)
-- `MadNCL{GPU}`: GPU execution (requires CUDA.jl)
+- `MadNCL{Strategies.CPU}`: CPU execution (default)
+- `MadNCL{Strategies.GPU}`: GPU execution (requires CUDA.jl)
 
 # Fields
 
@@ -64,11 +64,11 @@ using MadNCL, MadNLP
 - Callable interface: `(solver::MadNCL{P})(nlp; display=true)`
 - Extends MadNLP with NCL-specific optimizations
 - Default backend is automatically selected based on the parameter type
-- **GPU linear solver**: When using `MadNCL{GPU}`, the linear solver automatically defaults to `MadNLPGPU.CUDSSSolver` instead of `MadNLP.MumpsSolver`. This ensures compatibility with GPU execution and avoids attempting to use CPU-only solvers on CUDA backends.
+- **GPU linear solver**: When using `MadNCL{Strategies.GPU}`, the linear solver automatically defaults to `MadNLPGPU.CUDSSSolver` instead of `MadNLP.MumpsSolver`. This ensures compatibility with GPU execution and avoids attempting to use CPU-only solvers on CUDA backends.
 
-See also: `AbstractNLPSolver`, `MadNLP`, `Ipopt`, `CPU`, `GPU`
+See also: `AbstractNLPSolver`, `MadNLP`, `Ipopt`, `Strategies.CPU`, `Strategies.GPU`
 """
-struct MadNCL{P<:Union{CPU,GPU}} <: AbstractNLPSolver
+struct MadNCL{P<:Union{Strategies.CPU,Strategies.GPU}} <: AbstractNLPSolver
     "Solver configuration options containing validated option values"
     options::Strategies.StrategyOptions
 end
@@ -99,26 +99,26 @@ $(TYPEDSIGNATURES)
 
 Default parameter type for MadNCL when not explicitly specified.
 
-Returns `CPU` as the default execution parameter.
+Returns `Strategies.CPU` as the default execution parameter.
 
-See also: `MadNCL`, `CPU`
+See also: `MadNCL`, `Strategies.CPU`
 """
-Strategies.default_parameter(::Type{<:Solvers.MadNCL}) = CPU
+Strategies.default_parameter(::Type{<:Solvers.MadNCL}) = Strategies.CPU
 
 """
 $(TYPEDSIGNATURES)
 
 Return the execution parameter type of a `MadNCL` strategy.
 
-Extracts the type parameter `P` from `MadNCL{P}`, which can be either `CPU` or
-`GPU` since MadNCL supports GPU execution via CUDA extensions.
+Extracts the type parameter `P` from `MadNCL{P}`, which can be either `Strategies.CPU` or
+`Strategies.GPU` since MadNCL supports GPU execution via CUDA extensions.
 
 # Returns
-- `Type{<:Union{CPU,GPU}}`: the execution parameter type.
+- `Type{<:Union{Strategies.CPU,Strategies.GPU}}`: the execution parameter type.
 
 See also: [`CTSolvers.Solvers.MadNCL`](@ref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref)
 """
-Strategies.parameter(::Type{<:Solvers.MadNCL{P}}) where {P<:Union{CPU,GPU}} = P
+Strategies.parameter(::Type{<:Solvers.MadNCL{P}}) where {P<:Union{Strategies.CPU,Strategies.GPU}} = P
 
 # ============================================================================
 # Constructor with tag dispatch
@@ -174,19 +174,19 @@ Requires the CTSolversMadNCL extension to be loaded.
 ```julia
 # Conceptual usage (requires MadNCL, MadNLP extensions)
 using MadNCL, MadNLP
-solver_cpu = Solvers.MadNCL{CPU}(max_iter=1000, tol=1e-6)
-solver_gpu = Solvers.MadNCL{GPU}(max_iter=1000, tol=1e-6)  # requires CUDA.jl
+solver_cpu = Solvers.MadNCL{Strategies.CPU}(max_iter=1000, tol=1e-6)
+solver_gpu = Solvers.MadNCL{Strategies.GPU}(max_iter=1000, tol=1e-6)  # requires CUDA.jl
 ```
 
 # Throws
 - `CTBase.Exceptions.ExtensionError`: If the MadNCL extension is not loaded
 - `CTBase.Exceptions.ExtensionError`: If GPU parameter used but CUDA not available
 
-See also: `MadNCL`, `CPU`, `GPU`
+See also: `MadNCL`, `Strategies.CPU`, `Strategies.GPU`
 """
 function Solvers.MadNCL{P}(;
     mode::Symbol=:strict, kwargs...
-) where {P<:AbstractStrategyParameter}
+) where {P<:Strategies.AbstractStrategyParameter}
     return _build_madncl_solver(MadNCLTag, P; mode=mode, kwargs...)
 end
 
@@ -202,7 +202,7 @@ Real implementation provided by the extension.
 See also: `MadNCL`, `Strategies.metadata`
 """
 function _build_madncl_solver(
-    ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
+    ::Type{<:Core.AbstractTag}, parameter::Type{<:Strategies.AbstractStrategyParameter}; kwargs...
 )
     return throw(
         Exceptions.ExtensionError(
@@ -221,7 +221,7 @@ $(TYPEDSIGNATURES)
 Stub function that throws ExtensionError if CTSolversMadNCL extension is not loaded.
 Real metadata implementation provided by the extension.
 
-This stub is for parameterized types `MadNCL{P}` where `P <: AbstractStrategyParameter`.
+This stub is for parameterized types `MadNCL{P}` where `P <: Strategies.AbstractStrategyParameter`.
 
 # Throws
 - `CTBase.Exceptions.ExtensionError`: Always thrown by this stub implementation
@@ -230,7 +230,7 @@ See also: `MadNCL`, `Strategies.StrategyMetadata`
 """
 function Strategies.metadata(
     ::Type{<:Solvers.MadNCL{P}}
-) where {P<:AbstractStrategyParameter}
+) where {P<:Strategies.AbstractStrategyParameter}
     return throw(
         Exceptions.ExtensionError(
             :MadNCL,
@@ -245,15 +245,15 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Fallback for non-parameterized `MadNCL` type that delegates to `MadNCL{CPU}`.
+Fallback for non-parameterized `MadNCL` type that delegates to `MadNCL{Strategies.CPU}`.
 
 This provides backward compatibility and a sensible default when the parameter
-is not specified. The call will delegate to `metadata(MadNCL{CPU})`, which will
+is not specified. The call will delegate to `metadata(MadNCL{Strategies.CPU})`, which will
 either use the extension implementation (if loaded) or throw an ExtensionError
 (if not loaded).
 
 # Returns
-- `StrategyMetadata`: Metadata for `MadNCL{CPU}` (if extension loaded)
+- `StrategyMetadata`: Metadata for `MadNCL{Strategies.CPU}` (if extension loaded)
 
 # Throws
 - `CTBase.Exceptions.ExtensionError`: If extension not loaded (via delegation)

--- a/src/Solvers/madnlp.jl
+++ b/src/Solvers/madnlp.jl
@@ -25,8 +25,8 @@ performance for large-scale optimization problems.
 ## Parameterized Types
 
 The solver supports parameterization for execution backend:
-- `MadNLP{CPU}`: CPU execution (default)
-- `MadNLP{GPU}`: GPU execution (requires CUDA.jl)
+- `MadNLP{Strategies.CPU}`: CPU execution (default)
+- `MadNLP{Strategies.GPU}`: GPU execution (requires CUDA.jl)
 
 # Fields
 
@@ -70,11 +70,11 @@ using MadNLP
 - Callable interface: `(solver::MadNLP{P}(nlp; display=true)`
 - Supports GPU acceleration when appropriate backends are loaded
 - Default backend is automatically selected based on the parameter type
-- **GPU linear solver**: When using `MadNLP{GPU}`, the linear solver automatically defaults to `MadNLPGPU.CUDSSSolver` instead of `MadNLP.MumpsSolver`. This ensures compatibility with GPU execution and avoids attempting to use CPU-only solvers on CUDA backends.
+- **GPU linear solver**: When using `MadNLP{Strategies.GPU}`, the linear solver automatically defaults to `MadNLPGPU.CUDSSSolver` instead of `MadNLP.MumpsSolver`. This ensures compatibility with GPU execution and avoids attempting to use CPU-only solvers on CUDA backends.
 
-See also: `AbstractNLPSolver`, `Ipopt`, `Solvers.MadNCL`, `CPU`, `GPU`
+See also: `AbstractNLPSolver`, `Ipopt`, `Solvers.MadNCL`, `Strategies.CPU`, `Strategies.GPU`
 """
-struct MadNLP{P<:Union{CPU,GPU}} <: AbstractNLPSolver
+struct MadNLP{P<:Union{Strategies.CPU,Strategies.GPU}} <: AbstractNLPSolver
     "Solver configuration options containing validated option values"
     options::Strategies.StrategyOptions
 end
@@ -105,26 +105,26 @@ $(TYPEDSIGNATURES)
 
 Default parameter type for MadNLP when not explicitly specified.
 
-Returns `CPU` as the default execution parameter.
+Returns `Strategies.CPU` as the default execution parameter.
 
-See also: `MadNLP`, `CPU`
+See also: `MadNLP`, `Strategies.CPU`
 """
-Strategies.default_parameter(::Type{<:Solvers.MadNLP}) = CPU
+Strategies.default_parameter(::Type{<:Solvers.MadNLP}) = Strategies.CPU
 
 """
 $(TYPEDSIGNATURES)
 
 Return the execution parameter type of a `MadNLP` strategy.
 
-Extracts the type parameter `P` from `MadNLP{P}`, which can be either `CPU` or
-`GPU` since MadNLP supports GPU execution via CUDA extensions.
+Extracts the type parameter `P` from `MadNLP{P}`, which can be either `Strategies.CPU` or
+`Strategies.GPU` since MadNLP supports GPU execution via CUDA extensions.
 
 # Returns
-- `Type{<:Union{CPU,GPU}}`: the execution parameter type.
+- `Type{<:Union{Strategies.CPU,Strategies.GPU}}`: the execution parameter type.
 
 See also: [`CTSolvers.Solvers.MadNLP`](@ref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref)
 """
-Strategies.parameter(::Type{<:Solvers.MadNLP{P}}) where {P<:Union{CPU,GPU}} = P
+Strategies.parameter(::Type{<:Solvers.MadNLP{P}}) where {P<:Union{Strategies.CPU,Strategies.GPU}} = P
 
 # ============================================================================
 # Constructor with tag dispatch
@@ -180,19 +180,19 @@ Requires the CTSolversMadNLP extension to be loaded.
 ```julia
 # Conceptual usage (requires MadNLP extension)
 using MadNLP
-solver_cpu = MadNLP{CPU}(max_iter=1000, tol=1e-6)
-solver_gpu = MadNLP{GPU}(max_iter=1000, tol=1e-6)  # requires CUDA.jl
+solver_cpu = MadNLP{Strategies.CPU}(max_iter=1000, tol=1e-6)
+solver_gpu = MadNLP{Strategies.GPU}(max_iter=1000, tol=1e-6)  # requires CUDA.jl
 ```
 
 # Throws
 - `CTBase.Exceptions.ExtensionError`: If the MadNLP extension is not loaded
 - `CTBase.Exceptions.ExtensionError`: If GPU parameter used but CUDA not available
 
-See also: `MadNLP`, `CPU`, `GPU`
+See also: `MadNLP`, `Strategies.CPU`, `Strategies.GPU`
 """
 function Solvers.MadNLP{P}(;
     mode::Symbol=:strict, kwargs...
-) where {P<:AbstractStrategyParameter}
+) where {P<:Strategies.AbstractStrategyParameter}
     return _build_madnlp_solver(MadNLPTag, P; mode=mode, kwargs...)
 end
 
@@ -208,7 +208,7 @@ Real implementation provided by the extension.
 See also: `MadNLP`, `Strategies.metadata`
 """
 function _build_madnlp_solver(
-    ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
+    ::Type{<:Core.AbstractTag}, parameter::Type{<:Strategies.AbstractStrategyParameter}; kwargs...
 )
     return throw(
         Exceptions.ExtensionError(
@@ -226,7 +226,7 @@ $(TYPEDSIGNATURES)
 Stub function that throws ExtensionError if CTSolversMadNLP extension is not loaded.
 Real metadata implementation provided by the extension.
 
-This stub is for parameterized types `MadNLP{P}` where `P <: AbstractStrategyParameter`.
+This stub is for parameterized types `MadNLP{P}` where `P <: Strategies.AbstractStrategyParameter`.
 
 # Throws
 - `CTBase.Exceptions.ExtensionError`: Always thrown by this stub implementation
@@ -235,7 +235,7 @@ See also: `MadNLP`, `Strategies.StrategyMetadata`
 """
 function Strategies.metadata(
     ::Type{<:Solvers.MadNLP{P}}
-) where {P<:AbstractStrategyParameter}
+) where {P<:Strategies.AbstractStrategyParameter}
     return throw(
         Exceptions.ExtensionError(
             :MadNLP;
@@ -249,15 +249,15 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Fallback for non-parameterized `MadNLP` type that delegates to `MadNLP{CPU}`.
+Fallback for non-parameterized `MadNLP` type that delegates to `MadNLP{Strategies.CPU}`.
 
 This provides backward compatibility and a sensible default when the parameter
-is not specified. The call will delegate to `metadata(MadNLP{CPU})`, which will
+is not specified. The call will delegate to `metadata(MadNLP{Strategies.CPU})`, which will
 either use the extension implementation (if loaded) or throw an ExtensionError
 (if not loaded).
 
 # Returns
-- `StrategyMetadata`: Metadata for `MadNLP{CPU}` (if extension loaded)
+- `StrategyMetadata`: Metadata for `MadNLP{Strategies.CPU}` (if extension loaded)
 
 # Throws
 - `CTBase.Exceptions.ExtensionError`: If extension not loaded (via delegation)

--- a/src/Solvers/madnlpsuite.jl
+++ b/src/Solvers/madnlpsuite.jl
@@ -11,7 +11,7 @@ $(TYPEDSIGNATURES)
 Return the default linear solver for the given parameter type.
 
 # Arguments
-- `parameter_type::Type{<:AbstractStrategyParameter}`: CPU or GPU parameter
+- `parameter_type::Type{<:Strategies.AbstractStrategyParameter}`: CPU or GPU parameter
 
 # Returns
 - `Type{<:MadNLP.AbstractLinearSolver}`: Default linear solver type
@@ -24,7 +24,7 @@ Return the default linear solver for the given parameter type.
 - CPU implementation provided by CTSolversMadNLP extension
 - GPU implementation provided by CTSolversMadNLPGPU extension
 """
-function __madnlp_suite_default_linear_solver(::Type{<:GPU})
+function __madnlp_suite_default_linear_solver(::Type{<:Strategies.GPU})
     return throw(
         Exceptions.ExtensionError(
             :MadNLPGPU;
@@ -41,7 +41,7 @@ $(TYPEDSIGNATURES)
 Check if linear solver is consistent with parameter type.
 
 # Arguments
-- `parameter_type::Type{<:AbstractStrategyParameter}`: CPU or GPU parameter
+- `parameter_type::Type{<:Strategies.AbstractStrategyParameter}`: CPU or GPU parameter
 - `linear_solver::Type`: Linear solver type
 
 # Returns
@@ -52,7 +52,7 @@ Check if linear solver is consistent with parameter type.
 - Specific implementations in extensions provide actual consistency checks
 """
 function __madnlp_suite_consistent_linear_solver(
-    ::Type{<:AbstractStrategyParameter}, linear_solver::Type
+    ::Type{<:Strategies.AbstractStrategyParameter}, linear_solver::Type
 )
     return true
 end
@@ -68,7 +68,7 @@ type to validate against, so the pair is treated as consistent (no warning). Thi
 metadata construction and `describe` robust on machines without a functional GPU.
 """
 function __madnlp_suite_consistent_linear_solver(
-    ::Type{<:AbstractStrategyParameter}, ::Nothing
+    ::Type{<:Strategies.AbstractStrategyParameter}, ::Nothing
 )
     return true
 end

--- a/src/Solvers/uno.jl
+++ b/src/Solvers/uno.jl
@@ -44,7 +44,7 @@ Uno provides presets that mimic existing solvers:
 ## Parameterized Types
 
 The solver supports parameterization for execution backend:
-- `Uno{CPU}`: CPU execution (default and only supported parameter)
+- `Uno{Strategies.CPU}`: CPU execution (default and only supported parameter)
 
 **Note:** This solver only supports CPU execution with ADNLP modeler.
 GPU execution is not available for Uno.
@@ -56,7 +56,7 @@ GPU execution is not available for Uno.
 Solvers.Uno(; mode::Symbol=:strict, kwargs...)
 
 # Explicit parameter specification (only CPU supported)
-Solvers.Uno{CPU}(; mode::Symbol=:strict, kwargs...)
+Solvers.Uno{Strategies.CPU}(; mode::Symbol=:strict, kwargs...)
 ```
 
 # Fields
@@ -95,7 +95,7 @@ solver = Uno(max_iterations=1000, primal_tolerance=1e-6, preset="ipopt")
 solver_sqp = Uno(max_iterations=1000, preset="filtersqp")
 
 # Explicit CPU specification
-solver_cpu = Uno{CPU}(max_iterations=1000, dual_tolerance=1e-6)
+solver_cpu = Uno{Strategies.CPU}(max_iterations=1000, dual_tolerance=1e-6)
 
 nlp = ADNLPModel(x -> sum(x.^2), zeros(10))
 stats = solver(nlp, display=true)
@@ -104,7 +104,7 @@ stats = solver(nlp, display=true)
 ## Invalid Usage
 ```julia
 # GPU is NOT supported - will throw IncorrectArgument
-solver = Uno{GPU}()  # ❌ Error!
+solver = Uno{Strategies.GPU}()  # ❌ Error!
 ```
 
 # Extension Required
@@ -133,9 +133,9 @@ using UnoSolver
 Vanaret, C., & Leyffer, S. (2026). Implementing a unified solver for nonlinearly 
 constrained optimization. Mathematical Programming Computation (accepted).
 
-See also: `CPU`, `AbstractNLPSolver`, `Ipopt`, `MadNLP`
+See also: `Strategies.CPU`, `AbstractNLPSolver`, `Ipopt`, `MadNLP`
 """
-struct Uno{P<:CPU} <: AbstractNLPSolver
+struct Uno{P<:Strategies.CPU} <: AbstractNLPSolver
     "Solver configuration options containing validated option values"
     options::Strategies.StrategyOptions
 end
@@ -166,31 +166,31 @@ $(TYPEDSIGNATURES)
 
 Default parameter type for Uno when not explicitly specified.
 
-Returns `CPU` as the default execution parameter.
+Returns `Strategies.CPU` as the default execution parameter.
 
 # Implementation Notes
 
 This method is part of the `AbstractStrategy` parameter contract and must be
 implemented by all parameterized strategies.
 
-See also: `Uno`, `CPU`
+See also: `Uno`, `Strategies.CPU`
 """
-Strategies.default_parameter(::Type{<:Solvers.Uno}) = CPU
+Strategies.default_parameter(::Type{<:Solvers.Uno}) = Strategies.CPU
 
 """
 $(TYPEDSIGNATURES)
 
 Return the execution parameter type of a `Uno` strategy.
 
-Extracts the type parameter `P` from `Uno{P}`, which is always `CPU` since
+Extracts the type parameter `P` from `Uno{P}`, which is always `Strategies.CPU` since
 Uno is CPU-only.
 
 # Returns
-- `Type{CPU}`: the execution parameter type.
+- `Type{Strategies.CPU}`: the execution parameter type.
 
 See also: [`CTSolvers.Solvers.Uno`](@ref), [`CTBase.Strategies.CPU`](@extref)
 """
-Strategies.parameter(::Type{<:Solvers.Uno{P}}) where {P<:CPU} = P
+Strategies.parameter(::Type{<:Solvers.Uno{P}}) where {P<:Strategies.CPU} = P
 
 # ============================================================================
 # Constructor with Tag Dispatch
@@ -246,16 +246,16 @@ Requires the CTSolversUno extension to be loaded.
 ```julia
 # Conceptual usage (requires UnoSolver extension)
 using UnoSolver
-solver_cpu = Solvers.Uno{CPU}(max_iter=1000, tol=1e-6)
+solver_cpu = Solvers.Uno{Strategies.CPU}(max_iter=1000, tol=1e-6)
 ```
 
 # Throws
 - `CTBase.Exceptions.IncorrectArgument`: If GPU or other unsupported parameter is specified
 - `CTBase.Exceptions.ExtensionError`: If the UnoSolver extension is not loaded
 
-See also: `Uno`, `CPU`
+See also: `Uno`, `Strategies.CPU`
 """
-function Solvers.Uno{P}(; mode::Symbol=:strict, kwargs...) where {P<:CPU}
+function Solvers.Uno{P}(; mode::Symbol=:strict, kwargs...) where {P<:Strategies.CPU}
     return _build_uno_solver(UnoTag, P; mode=mode, kwargs...)
 end
 
@@ -271,7 +271,7 @@ Real implementation provided by the extension.
 See also: `Uno`, `Strategies.metadata`
 """
 function _build_uno_solver(
-    ::Type{<:Core.AbstractTag}, parameter::Type{<:AbstractStrategyParameter}; kwargs...
+    ::Type{<:Core.AbstractTag}, parameter::Type{<:Strategies.AbstractStrategyParameter}; kwargs...
 )
     return throw(
         Exceptions.ExtensionError(
@@ -289,14 +289,14 @@ $(TYPEDSIGNATURES)
 Stub function that throws ExtensionError if CTSolversUno extension is not loaded.
 Real metadata implementation provided by the extension.
 
-This stub is for parameterized types `Uno{P}` where `P <: AbstractStrategyParameter`.
+This stub is for parameterized types `Uno{P}` where `P <: Strategies.AbstractStrategyParameter`.
 
 # Throws
 - `CTBase.Exceptions.ExtensionError`: Always thrown by this stub implementation
 
 See also: `Uno`, `Strategies.StrategyMetadata`
 """
-function Strategies.metadata(::Type{<:Solvers.Uno{P}}) where {P<:CPU}
+function Strategies.metadata(::Type{<:Solvers.Uno{P}}) where {P<:Strategies.CPU}
     # Extension is missing
     return throw(
         Exceptions.ExtensionError(
@@ -311,15 +311,15 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Fallback for non-parameterized `Uno` type that delegates to `Uno{CPU}`.
+Fallback for non-parameterized `Uno` type that delegates to `Uno{Strategies.CPU}`.
 
 This provides backward compatibility and a sensible default when the parameter
-is not specified. The call will delegate to `metadata(Uno{CPU})`, which will
+is not specified. The call will delegate to `metadata(Uno{Strategies.CPU})`, which will
 either use the extension implementation (if loaded) or throw an ExtensionError
 (if not loaded).
 
 # Returns
-- `StrategyMetadata`: Metadata for `Uno{CPU}` (if extension loaded)
+- `StrategyMetadata`: Metadata for `Uno{Strategies.CPU}` (if extension loaded)
 
 # Throws
 - `CTBase.Exceptions.ExtensionError`: If extension not loaded (via delegation)

--- a/test/problems/problems_definition.jl
+++ b/test/problems/problems_definition.jl
@@ -4,9 +4,9 @@
 # and implements the CTSolvers `build_model` / `build_solution` contract by
 # multiple dispatch on the modeler type.
 
-import CTSolvers.Optimization
-import CTSolvers.Modelers
-import CTBase.Strategies
+using CTSolvers: Optimization
+using CTSolvers: Modelers
+using CTBase: Strategies
 
 struct OptimizationProblem{A,E} <: CTSolvers.AbstractOptimizationProblem
     build_adnlp_model::A

--- a/test/suite/docp/test_docp.jl
+++ b/test/suite/docp/test_docp.jl
@@ -3,19 +3,17 @@ module TestDOCP
 using Test: Test
 using CTModels: CTModels
 using CTSolvers: CTSolvers
-import CTSolvers.DOCP
-import CTSolvers.Optimization
-import CTSolvers.Modelers
+using CTSolvers: DOCP
+using CTSolvers: Optimization
+using CTSolvers: Modelers
 using CTBase: CTBase
 using NLPModels: NLPModels
 using SolverCore: SolverCore
 using ADNLPModels: ADNLPModels
 using ExaModels: ExaModels
-using CTSolvers.DOCP  # For testing exported symbols
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
-const CurrentModule = TestDOCP
 
 # ============================================================================
 # FAKE TYPES FOR TESTING (TOP-LEVEL)
@@ -109,10 +107,11 @@ function test_docp()
             end
 
             Test.@testset "Exported Types" begin
-                for T in (DiscretizedModel, AbstractDiscretizer)
-                    Test.@testset "$(nameof(T))" begin
-                        Test.@test isdefined(DOCP, nameof(T))
-                        Test.@test isdefined(CurrentModule, nameof(T))
+                for name in (:DiscretizedModel, :AbstractDiscretizer)
+                    Test.@testset "$name" begin
+                        Test.@test isdefined(DOCP, name)
+                        Test.@test name in names(DOCP)
+                        T = getfield(DOCP, name)
                         Test.@test T isa DataType || T isa UnionAll
                     end
                 end
@@ -122,8 +121,8 @@ function test_docp()
                 for f in (:ocp_model, :nlp_model, :ocp_solution, :discretize)
                     Test.@testset "$f" begin
                         Test.@test isdefined(DOCP, f)
-                        Test.@test isdefined(CurrentModule, f)
-                        Test.@test getfield(CurrentModule, f) isa Function
+                        Test.@test f in names(DOCP)
+                        Test.@test getfield(DOCP, f) isa Function
                     end
                 end
             end

--- a/test/suite/extensions/__not_tested_test_knitro_extension.jl
+++ b/test/suite/extensions/__not_tested_test_knitro_extension.jl
@@ -4,17 +4,17 @@ using Test
 using CTBase: CTBase
 const Exceptions = CTBase.Exceptions
 using CTSolvers
-using CTSolvers.Solvers
-using CTBase.Strategies
-using CTBase.Options
-using CTSolvers.Modelers
-using CTSolvers.Optimization
+using CTSolvers: Solvers
+using CTBase: Strategies
+using CTBase: Options
+using CTSolvers: Modelers
+using CTSolvers: Optimization
 using CommonSolve
 using NLPModels
 using ADNLPModels
 
 include(joinpath(@__DIR__, "..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 # # Trigger extension loading
 # using NLPModelsKnitro

--- a/test/suite/extensions/test_generic_extract_solver_infos.jl
+++ b/test/suite/extensions/test_generic_extract_solver_infos.jl
@@ -1,7 +1,7 @@
 module TestExtGeneric
 
 using Test: Test
-import CTSolvers.Solvers
+using CTSolvers: Solvers
 using SolverCore: SolverCore
 using NLPModels: NLPModels
 using ADNLPModels: ADNLPModels

--- a/test/suite/extensions/test_helpers.jl
+++ b/test/suite/extensions/test_helpers.jl
@@ -1,10 +1,10 @@
 module TestExtensionHelpers
 
 using Test: Test
-import CTBase.Exceptions
+using CTBase: Exceptions
 using CTSolvers: CTSolvers
-import CTSolvers.Solvers
-import CTBase.Strategies: CPU, GPU
+using CTSolvers: Solvers
+using CTBase: Strategies
 using MadNLP: MadNLP
 using MadNCL: MadNCL
 
@@ -55,7 +55,7 @@ function test_helpers()
         # ====================================================================
 
         Test.@testset "MadNCL default linear solver - CPU" begin
-            solver_type = Solvers.__madnlp_suite_default_linear_solver(CPU)
+            solver_type = Solvers.__madnlp_suite_default_linear_solver(Strategies.CPU)
             Test.@test solver_type === MadNLP.MumpsSolver
         end
 
@@ -67,11 +67,11 @@ function test_helpers()
             # This should throw ExtensionError if the GPU solver extension is not armed
             if !Main.TestCapabilities.GPU_SOLVER_ARMED
                 Test.@test_throws Exceptions.ExtensionError Solvers.__madnlp_suite_default_linear_solver(
-                    GPU
+                    Strategies.GPU
                 )
             else
                 # If armed, should return CUDSSSolver
-                solver_type = Solvers.__madnlp_suite_default_linear_solver(GPU)
+                solver_type = Solvers.__madnlp_suite_default_linear_solver(Strategies.GPU)
                 Test.@test solver_type === Main.TestCapabilities.GPU_SOLVER
             end
         end
@@ -81,7 +81,7 @@ function test_helpers()
         # ====================================================================
 
         Test.@testset "MadNLP default linear solver - CPU" begin
-            solver_type = Solvers.__madnlp_suite_default_linear_solver(CPU)
+            solver_type = Solvers.__madnlp_suite_default_linear_solver(Strategies.CPU)
             Test.@test solver_type === MadNLP.MumpsSolver
         end
 
@@ -93,11 +93,11 @@ function test_helpers()
             # This should throw ExtensionError if the GPU solver extension is not armed
             if !Main.TestCapabilities.GPU_SOLVER_ARMED
                 Test.@test_throws Exceptions.ExtensionError Solvers.__madnlp_suite_default_linear_solver(
-                    GPU
+                    Strategies.GPU
                 )
             else
                 # If armed, should return CUDSSSolver
-                solver_type = Solvers.__madnlp_suite_default_linear_solver(GPU)
+                solver_type = Solvers.__madnlp_suite_default_linear_solver(Strategies.GPU)
                 Test.@test solver_type === Main.TestCapabilities.GPU_SOLVER
             end
         end
@@ -112,8 +112,8 @@ function test_helpers()
             Test.@test_nowarn CTSolversMadNCL.base_type(ncl_opts)
 
             # default_linear_solver should be type-stable for CPU
-            Test.@test_nowarn Solvers.__madnlp_suite_default_linear_solver(CPU)
-            Test.@test_nowarn Solvers.__madnlp_suite_default_linear_solver(CPU)
+            Test.@test_nowarn Solvers.__madnlp_suite_default_linear_solver(Strategies.CPU)
+            Test.@test_nowarn Solvers.__madnlp_suite_default_linear_solver(Strategies.CPU)
         end
     end
 end

--- a/test/suite/extensions/test_ipopt_extension.jl
+++ b/test/suite/extensions/test_ipopt_extension.jl
@@ -1,20 +1,20 @@
 module TestIpoptExtension
 
 using Test: Test
-import ExaModels: ExaModels  # trigger CTSolversExaModels extension
-import CTBase.Exceptions
+using ExaModels: ExaModels  # trigger CTSolversExaModels extension
+using CTBase: Exceptions
 using CTSolvers: CTSolvers
-import CTSolvers.Solvers
-import CTBase.Strategies
-import CTBase.Options
-import CTSolvers.Modelers
-import CTSolvers.Optimization
+using CTSolvers: Solvers
+using CTBase: Strategies
+using CTBase: Options
+using CTSolvers: Modelers
+using CTSolvers: Optimization
 using CommonSolve: CommonSolve
 using NLPModels: NLPModels
 using ADNLPModels: ADNLPModels
 
 include(joinpath(@__DIR__, "..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 # Get extension to access solve_with_ipopt
 using NLPModelsIpopt

--- a/test/suite/extensions/test_madncl_extension.jl
+++ b/test/suite/extensions/test_madncl_extension.jl
@@ -1,15 +1,15 @@
 module TestMadNCLExtension
 
 using Test: Test
-import ExaModels: ExaModels  # trigger CTSolversExaModels extension
-import CTBase.Exceptions
+using ExaModels: ExaModels  # trigger CTSolversExaModels extension
+using CTBase: Exceptions
 using CTSolvers: CTSolvers
-import CTSolvers.Solvers
-import CTBase.Strategies
-import CTBase.Options
-import CTBase.Core
-import CTSolvers.Modelers
-import CTSolvers.Optimization
+using CTSolvers: Solvers
+using CTBase: Strategies
+using CTBase: Options
+using CTBase: Core
+using CTSolvers: Modelers
+using CTSolvers: Optimization
 using CommonSolve: CommonSolve
 using CUDA: CUDA
 using CUDSS: CUDSS
@@ -20,7 +20,7 @@ using MadNLP: MadNLP
 using MadNLPGPU: MadNLPGPU
 
 include(joinpath(@__DIR__, "..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 # Trigger extension loading
 const CTSolversMadNCL = Base.get_extension(CTSolvers, :CTSolversMadNCL)

--- a/test/suite/extensions/test_madncl_extract_solver_infos.jl
+++ b/test/suite/extensions/test_madncl_extract_solver_infos.jl
@@ -1,11 +1,11 @@
 module TestExtMadNCL
 
 using Test: Test
-import ExaModels: ExaModels  # trigger CTSolversExaModels extension
+using ExaModels: ExaModels  # trigger CTSolversExaModels extension
 using CTSolvers: CTSolvers
-import CTSolvers.Optimization
-import CTSolvers.Solvers
-import CTSolvers.Modelers
+using CTSolvers: Optimization
+using CTSolvers: Solvers
+using CTSolvers: Modelers
 using MadNCL: MadNCL
 using MadNLP: MadNLP
 using NLPModels: NLPModels
@@ -13,7 +13,7 @@ using ADNLPModels: ADNLPModels
 using SolverCore: SolverCore
 
 include(joinpath(@__DIR__, "..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 # Default test options (can be overridden by Main.TestData if available)
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true

--- a/test/suite/extensions/test_madnlp_extension.jl
+++ b/test/suite/extensions/test_madnlp_extension.jl
@@ -1,14 +1,14 @@
 module TestMadNLPExtension
 
 using Test: Test
-import CTBase.Exceptions
+using CTBase: Exceptions
 using CTSolvers: CTSolvers
-import CTSolvers.Solvers
-import CTBase.Strategies
-import CTBase.Options
-import CTBase.Core
-import CTSolvers.Modelers
-import CTSolvers.Optimization
+using CTSolvers: Solvers
+using CTBase: Strategies
+using CTBase: Options
+using CTBase: Core
+using CTSolvers: Modelers
+using CTSolvers: Optimization
 using CommonSolve: CommonSolve
 using CUDA: CUDA
 using CUDSS: CUDSS
@@ -19,7 +19,7 @@ using ExaModels: ExaModels
 using MadNLPGPU: MadNLPGPU
 
 include(joinpath(@__DIR__, "..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 # Trigger extension loading
 const CTSolversMadNLP = Base.get_extension(CTSolvers, :CTSolversMadNLP)

--- a/test/suite/extensions/test_madnlp_extract_solver_infos.jl
+++ b/test/suite/extensions/test_madnlp_extract_solver_infos.jl
@@ -1,7 +1,7 @@
 module TestExtMadNLP
 
 using Test: Test
-import CTSolvers.Solvers
+using CTSolvers: Solvers
 using MadNLP: MadNLP
 using NLPModels: NLPModels
 using ADNLPModels: ADNLPModels

--- a/test/suite/extensions/test_uno_extension.jl
+++ b/test/suite/extensions/test_uno_extension.jl
@@ -1,20 +1,20 @@
 module TestUnoExtension
 
 using Test: Test
-import CTBase.Exceptions
+using CTBase: Exceptions
 using CTSolvers: CTSolvers
-import CTSolvers.Solvers
-import CTBase.Strategies
-import CTBase.Options
-import CTSolvers.Modelers
-import CTSolvers.Optimization
+using CTSolvers: Solvers
+using CTBase: Strategies
+using CTBase: Options
+using CTSolvers: Modelers
+using CTSolvers: Optimization
 using CommonSolve: CommonSolve
 using NLPModels: NLPModels
 using ADNLPModels: ADNLPModels
 using ExaModels: ExaModels
 
 include(joinpath(@__DIR__, "..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 # Get extension to access solve_with_uno
 using UnoSolver

--- a/test/suite/integration/__test_performance_validation.jl
+++ b/test/suite/integration/__test_performance_validation.jl
@@ -11,8 +11,8 @@ module TestPerformanceValidation
 
 using Test
 using CTSolvers
-using CTBase.Strategies
-using CTSolvers.Solvers
+using CTBase: Strategies
+using CTSolvers: Solvers
 using BenchmarkTools
 using Random
 

--- a/test/suite/integration/test_comprehensive_validation.jl
+++ b/test/suite/integration/test_comprehensive_validation.jl
@@ -14,16 +14,16 @@ Date: 2026-02-06
 module TestComprehensiveValidation
 
 using Test: Test
-import ADNLPModels: ADNLPModels # trigger CTSolversADNLPModels extension
-import ExaModels: ExaModels  # trigger CTSolversExaModels extension
-import CTBase.Exceptions
-import CTBase.Strategies
-import CTBase.Options
-import CTBase.Core
-import CTSolvers.Modelers
-import CTSolvers.Solvers
-import CTBase.Orchestration
-import CTSolvers.Optimization
+using ADNLPModels: ADNLPModels # trigger CTSolversADNLPModels extension
+using ExaModels: ExaModels  # trigger CTSolversExaModels extension
+using CTBase: Exceptions
+using CTBase: Strategies
+using CTBase: Options
+using CTBase: Core
+using CTSolvers: Modelers
+using CTSolvers: Solvers
+using CTBase: Orchestration
+using CTSolvers: Optimization
 
 # Load extensions if available for testing
 const IPOPT_AVAILABLE = try

--- a/test/suite/integration/test_end_to_end.jl
+++ b/test/suite/integration/test_end_to_end.jl
@@ -7,16 +7,16 @@ using ExaModels: ExaModels
 using MadNLP: MadNLP
 
 include(joinpath(@__DIR__, "..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
 
 # Import modules
-import CTSolvers.Modelers
-import CTSolvers.Optimization
-import CTSolvers.Solvers
-import CTSolvers.DOCP
+using CTSolvers: Modelers
+using CTSolvers: Optimization
+using CTSolvers: Solvers
+using CTSolvers: DOCP
 
 # ============================================================================
 # TEST FUNCTION

--- a/test/suite/integration/test_mode_propagation.jl
+++ b/test/suite/integration/test_mode_propagation.jl
@@ -9,9 +9,9 @@ end-to-end.
 module TestModePropagation
 
 using Test: Test
-import CTBase.Strategies
-import CTBase.Options
-import CTBase.Orchestration
+using CTBase: Strategies
+using CTBase: Options
+using CTBase: Orchestration
 
 # Test options for verbose output
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true

--- a/test/suite/integration/test_real_strategies_mode.jl
+++ b/test/suite/integration/test_real_strategies_mode.jl
@@ -7,13 +7,13 @@ Tests that the mode parameter works correctly with actual solver and modeler typ
 module TestRealStrategiesMode
 
 using Test: Test
-import ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
-import ExaModels: ExaModels  # trigger CTSolversExaModels extension
+using ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
+using ExaModels: ExaModels  # trigger CTSolversExaModels extension
 using CTSolvers: CTSolvers
-import CTBase.Strategies
-import CTBase.Options
-import CTSolvers.Modelers
-import CTSolvers.Solvers
+using CTBase: Strategies
+using CTBase: Options
+using CTSolvers: Modelers
+using CTSolvers: Solvers
 
 # Load extensions if available for testing
 try

--- a/test/suite/integration/test_route_to_comprehensive.jl
+++ b/test/suite/integration/test_route_to_comprehensive.jl
@@ -16,14 +16,14 @@ Date: 2026-02-06
 module TestRouteToComprehensive
 
 using Test: Test
-import ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
-import ExaModels: ExaModels  # trigger CTSolversExaModels extension
-import CTBase.Exceptions
-import CTBase.Strategies
-import CTBase.Orchestration
-import CTBase.Options
-import CTSolvers.Modelers
-import CTSolvers.Solvers
+using ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
+using ExaModels: ExaModels  # trigger CTSolversExaModels extension
+using CTBase: Exceptions
+using CTBase: Strategies
+using CTBase: Orchestration
+using CTBase: Options
+using CTSolvers: Modelers
+using CTSolvers: Solvers
 
 # Load extensions if available for real strategy testing
 const IPOPT_AVAILABLE = try

--- a/test/suite/integration/test_strict_permissive_integration.jl
+++ b/test/suite/integration/test_strict_permissive_integration.jl
@@ -8,9 +8,9 @@ to ensure the system works correctly end-to-end.
 module TestStrictPermissiveIntegration
 
 using Test: Test
-import CTBase.Strategies
-import CTBase.Options
-import CTBase.Orchestration
+using CTBase: Strategies
+using CTBase: Options
+using CTBase: Orchestration
 
 # Test options for verbose output
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true

--- a/test/suite/integrators/test_integrator_exports.jl
+++ b/test/suite/integrators/test_integrator_exports.jl
@@ -2,7 +2,7 @@ module TestIntegratorExports
 
 using Test: Test
 using CTSolvers: CTSolvers
-import CTSolvers.Integrators
+using CTSolvers: Integrators
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/integrators/test_integrator_forwarddiff.jl
+++ b/test/suite/integrators/test_integrator_forwarddiff.jl
@@ -2,7 +2,7 @@ module TestIntegratorForwardDiff
 
 using Test: Test
 using ForwardDiff: ForwardDiff
-import CTSolvers.Integrators
+using CTSolvers: Integrators
 using CommonSolve: CommonSolve
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5
 using SciMLBase: SciMLBase, ODEProblem

--- a/test/suite/integrators/test_integrator_metadata.jl
+++ b/test/suite/integrators/test_integrator_metadata.jl
@@ -1,10 +1,10 @@
 module TestIntegratorMetadata
 
 using Test: Test
-import CTBase.Core
-import CTBase.Exceptions
-import CTSolvers.Integrators
-import CTBase.Strategies
+using CTBase: Core
+using CTBase: Exceptions
+using CTSolvers: Integrators
+using CTBase: Strategies
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5
 using SciMLBase: SciMLBase
 using DiffEqBase: DiffEqBase

--- a/test/suite/integrators/test_integrator_solve.jl
+++ b/test/suite/integrators/test_integrator_solve.jl
@@ -1,8 +1,8 @@
 module TestIntegratorSolve
 
 using Test: Test
-import CTBase.Exceptions
-import CTSolvers.Integrators
+using CTBase: Exceptions
+using CTSolvers: Integrators
 using CommonSolve: CommonSolve
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5
 using SciMLBase: SciMLBase, ODEProblem

--- a/test/suite/integrators/test_integrator_stubs.jl
+++ b/test/suite/integrators/test_integrator_stubs.jl
@@ -1,12 +1,12 @@
 module TestIntegratorExtensionStubs
 
 using Test: Test
-import CTBase.Core
-import CTBase.Exceptions
-import CTBase.Strategies
-import CTSolvers.Integrators
-import CTModels.Solutions
-import CTModels.Components
+using CTBase: Core
+using CTBase: Exceptions
+using CTBase: Strategies
+using CTSolvers: Integrators
+using CTModels: Solutions
+using CTModels: Components
 using CommonSolve: CommonSolve
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true

--- a/test/suite/integrators/test_integrator_type_stability.jl
+++ b/test/suite/integrators/test_integrator_type_stability.jl
@@ -1,8 +1,8 @@
 module TestIntegratorTypeStability
 
 using Test: Test
-import CTSolvers.Integrators
-import CTBase.Strategies
+using CTSolvers: Integrators
+using CTBase: Strategies
 using OrdinaryDiffEqTsit5: OrdinaryDiffEqTsit5, Tsit5
 using SciMLBase: SciMLBase, ODEProblem
 using DiffEqBase: DiffEqBase

--- a/test/suite/integrators/test_integrator_types.jl
+++ b/test/suite/integrators/test_integrator_types.jl
@@ -1,9 +1,9 @@
 module TestIntegratorTypes
 
 using Test: Test
-import CTBase.Core
-import CTSolvers.Integrators
-import CTBase.Strategies
+using CTBase: Core
+using CTSolvers: Integrators
+using CTBase: Strategies
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/integrators/test_internal_norm.jl
+++ b/test/suite/integrators/test_internal_norm.jl
@@ -1,7 +1,7 @@
 module TestInternalNorm
 
 using Test: Test
-import CTSolvers.Integrators
+using CTSolvers: Integrators
 using ForwardDiff: ForwardDiff
 using DiffEqBase: DiffEqBase   # activates the array real_norm overload
 

--- a/test/suite/integrators/test_sciml_parameter.jl
+++ b/test/suite/integrators/test_sciml_parameter.jl
@@ -1,10 +1,10 @@
 module TestSciMLParameter
 
 using Test: Test
-import CTBase.Core
-import CTBase.Exceptions
-import CTSolvers.Integrators
-import CTBase.Strategies
+using CTBase: Core
+using CTBase: Exceptions
+using CTSolvers: Integrators
+using CTBase: Strategies
 
 # Extensions: CTSolversSciMLIntegrator (DiffEqBase + SciMLBase), the Tsit5 default alg
 # (OrdinaryDiffEqTsit5), and CTSolversCUDA (CUDA) for the device consistency validators.

--- a/test/suite/meta/test_no_import.jl
+++ b/test/suite/meta/test_no_import.jl
@@ -1,0 +1,49 @@
+"""
+Regression guard for the Handbook rule "using, never import" (tenet 2,
+`philosophy/modules.md#using-never-import`): flags any tracked `.jl` or `.md`
+file that still uses the `import` keyword, or the forbidden dotted
+`using Pkg.Sub` form (the canonical spelling is `using Pkg: Sub`).
+"""
+
+module TestNoImport
+
+using Test: Test
+
+const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
+const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
+
+const IMPORT_RE = r"^\s*import\b"
+const DOTTED_USING_RE = r"^\s*using\s+[A-Za-z_]\w*\.[A-Za-z_]"
+
+# CHANGELOG.md quotes `import` verbatim inside dated past-release entries describing what
+# shipped at the time — historical fact, not a current-convention violation.
+const IMPORT_EXEMPT = ("CHANGELOG.md",)
+const DOTTED_USING_EXEMPT = ()
+
+function test_no_import()
+    Test.@testset "No `import` / no dotted `using Pkg.Sub` (Handbook tenet 2)" verbose = VERBOSE showtiming =
+        SHOWTIMING begin
+        repo_root = joinpath(@__DIR__, "..", "..", "..")
+        tracked = filter(
+            f -> endswith(f, ".jl") || endswith(f, ".md"),
+            readlines(Cmd(`git ls-files`; dir=repo_root)),
+        )
+        for relpath in tracked
+            path = joinpath(repo_root, relpath)
+            check_import = !(basename(relpath) in IMPORT_EXEMPT)
+            check_dotted = !(basename(relpath) in DOTTED_USING_EXEMPT)
+            for line in eachline(path)
+                if check_import
+                    Test.@test !occursin(IMPORT_RE, line)
+                end
+                if check_dotted
+                    Test.@test !occursin(DOTTED_USING_RE, line)
+                end
+            end
+        end
+    end
+end
+
+end # module
+
+test_no_import() = TestNoImport.test_no_import()

--- a/test/suite/modelers/test_adnlp_metadata.jl
+++ b/test/suite/modelers/test_adnlp_metadata.jl
@@ -1,11 +1,11 @@
 module TestADNLPMetadata
 
 using Test: Test
-import ExaModels: ExaModels  # trigger CTSolversExaModels extension
-import CTBase.Exceptions
-import CTSolvers.Modelers
-import CTBase.Strategies
-import CTBase.Options
+using ExaModels: ExaModels  # trigger CTSolversExaModels extension
+using CTBase: Exceptions
+using CTSolvers: Modelers
+using CTBase: Strategies
+using CTBase: Options
 using ADNLPModels: ADNLPModels
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true

--- a/test/suite/modelers/test_adnlp_parameter_validation.jl
+++ b/test/suite/modelers/test_adnlp_parameter_validation.jl
@@ -1,13 +1,13 @@
 module TestADNLPParameterValidation
-import ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
-import ExaModels: ExaModels  # trigger CTSolversExaModels extension
+using ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
+using ExaModels: ExaModels  # trigger CTSolversExaModels extension
 
 using Test
-import CTBase.Core
+using CTBase: Core
 using CTSolvers
-using CTSolvers.Modelers
-using CTBase.Strategies
-using CTBase.Exceptions
+using CTSolvers: Modelers
+using CTBase: Strategies
+using CTBase: Exceptions
 using Enzyme
 using Zygote
 using KernelAbstractions
@@ -19,7 +19,7 @@ const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
 # Fake types for testing (must be at module top-level)
 # ============================================================================
 
-struct FakeParam <: AbstractStrategyParameter end
+struct FakeParam <: Strategies.AbstractStrategyParameter end
 Strategies.id(::Type{FakeParam}) = :fake
 
 # Dummy tag for testing extension behavior

--- a/test/suite/modelers/test_coverage_modelers.jl
+++ b/test/suite/modelers/test_coverage_modelers.jl
@@ -1,12 +1,12 @@
 module TestCoverageModelers
 
 using Test: Test
-import ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
-import CTBase.Exceptions
-import CTSolvers.Modelers
-import CTBase.Strategies
-import CTBase.Options
-import CTSolvers.Optimization
+using ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
+using CTBase: Exceptions
+using CTSolvers: Modelers
+using CTBase: Strategies
+using CTBase: Options
+using CTSolvers: Optimization
 using SolverCore: SolverCore
 using ExaModels: ExaModels
 

--- a/test/suite/modelers/test_coverage_validation.jl
+++ b/test/suite/modelers/test_coverage_validation.jl
@@ -1,9 +1,9 @@
 module TestCoverageValidation
 
 using Test: Test
-import CTBase.Core
-import CTBase.Exceptions
-import CTSolvers.Modelers
+using CTBase: Core
+using CTBase: Exceptions
+using CTSolvers: Modelers
 using ADNLPModels: ADNLPModels
 
 # Fake ADBackend for testing (must be at top-level)

--- a/test/suite/modelers/test_enhanced_options.jl
+++ b/test/suite/modelers/test_enhanced_options.jl
@@ -6,16 +6,16 @@
 module TestEnhancedOptions
 
 using Test: Test
-import CTBase.Exceptions
+using CTBase: Exceptions
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
 
 # Import the specific types we need
 using ADNLPModels: ADNLPModels
-import CTSolvers.Modelers
+using CTSolvers: Modelers
 using ExaModels: ExaModels
 using KernelAbstractions: KernelAbstractions
-import CTBase.Strategies
+using CTBase: Strategies
 
 # Define structs at top-level (crucial!)
 struct TestDummyModel end

--- a/test/suite/modelers/test_exa_gpu.jl
+++ b/test/suite/modelers/test_exa_gpu.jl
@@ -1,11 +1,11 @@
 module TestExaGPU
 
 using Test: Test
-import ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
-import CTBase.Exceptions
-import CTSolvers.Modelers
-import CTBase.Strategies
-import CTBase.Options
+using ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
+using CTBase: Exceptions
+using CTSolvers: Modelers
+using CTBase: Strategies
+using CTBase: Options
 using ExaModels: ExaModels
 using KernelAbstractions: KernelAbstractions
 using CUDA: CUDA

--- a/test/suite/modelers/test_internal_defaults_coverage.jl
+++ b/test/suite/modelers/test_internal_defaults_coverage.jl
@@ -1,8 +1,8 @@
 module TestInternalDefaultsCoverage
 
 using Test: Test
-import CTSolvers.Modelers
-import CTSolvers.Solvers
+using CTSolvers: Modelers
+using CTSolvers: Solvers
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/modelers/test_modelers.jl
+++ b/test/suite/modelers/test_modelers.jl
@@ -2,16 +2,14 @@ module TestModelers
 
 using Test: Test
 using CTSolvers: CTSolvers
-import CTSolvers.Modelers
-import CTBase.Strategies
+using CTSolvers: Modelers
+using CTBase: Strategies
 using ADNLPModels: ADNLPModels
 using ExaModels: ExaModels
 using SolverCore: SolverCore
-using CTSolvers.Modelers  # For testing exported symbols
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
-const CurrentModule = TestModelers
 
 """
     test_modelers_basic()
@@ -30,10 +28,11 @@ function test_modelers_basic()
 
             # Test exported types
             Test.@testset "Exported Types" begin
-                for T in (AbstractNLPModeler, ADNLP, Exa)
-                    Test.@testset "$(nameof(T))" begin
-                        Test.@test isdefined(Modelers, nameof(T))
-                        Test.@test isdefined(CurrentModule, nameof(T))
+                for name in (:AbstractNLPModeler, :ADNLP, :Exa)
+                    Test.@testset "$name" begin
+                        Test.@test isdefined(Modelers, name)
+                        Test.@test name in names(Modelers)
+                        T = getfield(Modelers, name)
                         Test.@test T isa DataType || T isa UnionAll
                     end
                 end
@@ -54,7 +53,7 @@ function test_modelers_basic()
                 )
                     Test.@testset "$f" begin
                         Test.@test isdefined(Modelers, f)
-                        Test.@test !isdefined(CurrentModule, f)
+                        Test.@test !(f in names(Modelers))
                     end
                 end
             end

--- a/test/suite/modelers/test_validation_coverage.jl
+++ b/test/suite/modelers/test_validation_coverage.jl
@@ -1,8 +1,8 @@
 module TestValidationCoverage
 
 using Test: Test
-import CTBase.Exceptions
-import CTSolvers.Modelers
+using CTBase: Exceptions
+using CTSolvers: Modelers
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/optimization/test_error_cases.jl
+++ b/test/suite/optimization/test_error_cases.jl
@@ -1,7 +1,7 @@
 module TestOptimizationErrorCases
 
 using Test: Test
-import CTBase.Exceptions
+using CTBase: Exceptions
 using NLPModels: NLPModels
 using SolverCore: SolverCore
 using ADNLPModels: ADNLPModels
@@ -10,9 +10,9 @@ const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
 
 # Import from CTSolvers
-import CTSolvers.Optimization
-import CTSolvers.Solvers
-import CTSolvers.Modelers
+using CTSolvers: Optimization
+using CTSolvers: Solvers
+using CTSolvers: Modelers
 
 # ============================================================================
 # FAKE TYPES FOR ERROR TESTING (TOP-LEVEL)

--- a/test/suite/optimization/test_optimization.jl
+++ b/test/suite/optimization/test_optimization.jl
@@ -1,20 +1,18 @@
 module TestOptimization
 
 using Test: Test
-import CTBase.Exceptions
+using CTBase: Exceptions
 using CTSolvers: CTSolvers
-import CTSolvers.Optimization
-import CTSolvers.Modelers
-import CTSolvers.Solvers
+using CTSolvers: Optimization
+using CTSolvers: Modelers
+using CTSolvers: Solvers
 using NLPModels: NLPModels
 using SolverCore: SolverCore
 using ADNLPModels: ADNLPModels
 using ExaModels: ExaModels
-using CTSolvers.Optimization  # For testing exported symbols
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
-const CurrentModule = TestOptimization
 
 # ============================================================================
 # FAKE TYPES FOR CONTRACT TESTING (TOP-LEVEL)
@@ -100,10 +98,11 @@ function test_optimization()
             end
 
             Test.@testset "Exported Abstract Types" begin
-                for T in (AbstractOptimizationProblem,)
-                    Test.@testset "$(nameof(T))" begin
-                        Test.@test isdefined(Optimization, nameof(T))
-                        Test.@test isdefined(CurrentModule, nameof(T))
+                for name in (:AbstractOptimizationProblem,)
+                    Test.@testset "$name" begin
+                        Test.@test isdefined(Optimization, name)
+                        Test.@test name in names(Optimization)
+                        T = getfield(Optimization, name)
                         Test.@test T isa DataType || T isa UnionAll
                     end
                 end
@@ -113,8 +112,8 @@ function test_optimization()
                 for f in (:build_model, :build_solution)
                     Test.@testset "$f" begin
                         Test.@test isdefined(Optimization, f)
-                        Test.@test isdefined(CurrentModule, f)
-                        Test.@test getfield(CurrentModule, f) isa Function
+                        Test.@test f in names(Optimization)
+                        Test.@test getfield(Optimization, f) isa Function
                     end
                 end
             end

--- a/test/suite/optimization/test_problem_definition.jl
+++ b/test/suite/optimization/test_problem_definition.jl
@@ -1,13 +1,13 @@
 module TestProblemDefinition
 
 using Test: Test
-import CTSolvers.Optimization
-import CTSolvers.Modelers
-import CTBase.Strategies
+using CTSolvers: Optimization
+using CTSolvers: Modelers
+using CTBase: Strategies
 using CUDA: CUDA
 
 include(joinpath(@__DIR__, "..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/optimization/test_real_problems.jl
+++ b/test/suite/optimization/test_real_problems.jl
@@ -6,14 +6,14 @@ using ADNLPModels: ADNLPModels
 using ExaModels: ExaModels
 
 include(joinpath(@__DIR__, "..", "..", "problems", "TestProblems.jl"))
-import .TestProblems
+using .TestProblems: TestProblems
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
 
 # Import from CTSolvers
-import CTSolvers.Optimization
-import CTSolvers.Modelers
+using CTSolvers: Optimization
+using CTSolvers: Modelers
 
 # ============================================================================
 # TEST FUNCTION

--- a/test/suite/solvers/__not_tested_test_knitro_parameter_validation.jl
+++ b/test/suite/solvers/__not_tested_test_knitro_parameter_validation.jl
@@ -2,9 +2,9 @@ module TestKnitroParameterValidation
 
 using Test
 using CTSolvers
-using CTSolvers.Solvers
-using CTBase.Strategies
-using CTBase.Exceptions
+using CTSolvers: Solvers
+using CTBase: Strategies
+using CTBase: Exceptions
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/solvers/test_common_solve_api.jl
+++ b/test/suite/solvers/test_common_solve_api.jl
@@ -1,8 +1,8 @@
 module TestCommonSolveAPI
 
 using Test: Test
-import CTBase.Exceptions
-import CTSolvers.Solvers
+using CTBase: Exceptions
+using CTSolvers: Solvers
 using NLPModels: NLPModels
 using SolverCore: SolverCore
 using ADNLPModels: ADNLPModels

--- a/test/suite/solvers/test_coverage_solvers.jl
+++ b/test/suite/solvers/test_coverage_solvers.jl
@@ -1,10 +1,10 @@
 module TestCoverageSolvers
 
 using Test: Test
-import CTBase.Exceptions
-import CTSolvers.Solvers
-import CTBase.Strategies
-import CTBase.Options
+using CTBase: Exceptions
+using CTSolvers: Solvers
+using CTBase: Strategies
+using CTBase: Options
 using NLPModels: NLPModels
 using SolverCore: SolverCore
 using ADNLPModels: ADNLPModels

--- a/test/suite/solvers/test_extension_stubs.jl
+++ b/test/suite/solvers/test_extension_stubs.jl
@@ -1,10 +1,10 @@
 module TestExtensionStubs
 
 using Test: Test
-import CTBase.Core
-import CTBase.Exceptions
-import CTSolvers.Solvers
-import CTBase.Strategies
+using CTBase: Core
+using CTBase: Exceptions
+using CTSolvers: Solvers
+using CTBase: Strategies
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/solvers/test_ipopt_parameter_validation.jl
+++ b/test/suite/solvers/test_ipopt_parameter_validation.jl
@@ -2,9 +2,9 @@ module TestIpoptParameterValidation
 
 using Test
 using CTSolvers
-using CTSolvers.Solvers
-using CTBase.Strategies
-using CTBase.Exceptions
+using CTSolvers: Solvers
+using CTBase: Strategies
+using CTBase: Exceptions
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
@@ -13,7 +13,7 @@ const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
 # Fake parameter type for testing (must be at module top-level)
 # ============================================================================
 
-struct FakeParam <: AbstractStrategyParameter end
+struct FakeParam <: Strategies.AbstractStrategyParameter end
 Strategies.id(::Type{FakeParam}) = :fake
 
 # ============================================================================
@@ -34,8 +34,8 @@ function test_ipopt_parameter_validation()
 
         Test.@testset "Ipopt structure" begin
             # Test that Ipopt is parameterized
-            Test.@test Solvers.Ipopt <: AbstractNLPSolver
-            Test.@test Solvers.Ipopt{Strategies.CPU} <: AbstractNLPSolver
+            Test.@test Solvers.Ipopt <: Solvers.AbstractNLPSolver
+            Test.@test Solvers.Ipopt{Strategies.CPU} <: Solvers.AbstractNLPSolver
         end
 
         Test.@testset "id() with parameters" begin

--- a/test/suite/solvers/test_solver_metadata.jl
+++ b/test/suite/solvers/test_solver_metadata.jl
@@ -1,9 +1,9 @@
 module TestSolverMetadata
 
 using Test: Test
-import CTBase.Exceptions
-import CTSolvers.Solvers
-import CTBase.Strategies
+using CTBase: Exceptions
+using CTSolvers: Solvers
+using CTBase: Strategies
 using MadNLP: MadNLP
 using MadNCL: MadNCL
 using UnoSolver: UnoSolver

--- a/test/suite/solvers/test_solver_types.jl
+++ b/test/suite/solvers/test_solver_types.jl
@@ -1,10 +1,10 @@
 module TestSolverTypes
 
 using Test: Test
-import CTBase.Core
-import CTBase.Exceptions
-import CTSolvers.Solvers
-import CTBase.Strategies
+using CTBase: Core
+using CTBase: Exceptions
+using CTSolvers: Solvers
+using CTBase: Strategies
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/solvers/test_solvers.jl
+++ b/test/suite/solvers/test_solvers.jl
@@ -1,15 +1,13 @@
 module TestSolvers
 
 using Test: Test
-import CTBase.Exceptions
+using CTBase: Exceptions
 using CTSolvers: CTSolvers
-import CTSolvers.Solvers
-import CTBase.Strategies
-using CTSolvers.Solvers  # For testing exported symbols
+using CTSolvers: Solvers
+using CTBase: Strategies
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
-const CurrentModule = TestSolvers
 
 """
     test_solvers()
@@ -37,10 +35,11 @@ function test_solvers()
 
             # Test exported abstract types
             Test.@testset "Exported Abstract Types" begin
-                for T in (AbstractNLPSolver,)
-                    Test.@testset "$(nameof(T))" begin
-                        Test.@test isdefined(Solvers, nameof(T))
-                        Test.@test isdefined(CurrentModule, nameof(T))
+                for name in (:AbstractNLPSolver,)
+                    Test.@testset "$name" begin
+                        Test.@test isdefined(Solvers, name)
+                        Test.@test name in names(Solvers)
+                        T = getfield(Solvers, name)
                         Test.@test T isa DataType || T isa UnionAll
                     end
                 end
@@ -48,10 +47,11 @@ function test_solvers()
 
             # Test exported concrete types
             Test.@testset "Exported Concrete Types" begin
-                for T in (Ipopt, MadNLP, MadNCL, Knitro, Uno)
-                    Test.@testset "$(nameof(T))" begin
-                        Test.@test isdefined(Solvers, nameof(T))
-                        Test.@test isdefined(CurrentModule, nameof(T))
+                for name in (:Ipopt, :MadNLP, :MadNCL, :Knitro, :Uno)
+                    Test.@testset "$name" begin
+                        Test.@test isdefined(Solvers, name)
+                        Test.@test name in names(Solvers)
+                        T = getfield(Solvers, name)
                         Test.@test T isa DataType || T isa UnionAll
                     end
                 end
@@ -65,7 +65,7 @@ function test_solvers()
                 )
                     Test.@testset "$f" begin
                         Test.@test isdefined(Solvers, f)
-                        Test.@test !isdefined(CurrentModule, f)
+                        Test.@test !(f in names(Solvers))
                     end
                 end
             end

--- a/test/suite/solvers/test_type_stability.jl
+++ b/test/suite/solvers/test_type_stability.jl
@@ -1,9 +1,9 @@
 module TestTypeStability
 
 using Test: Test
-import CTSolvers.Solvers
-import CTBase.Strategies
-import CTBase.Options
+using CTSolvers: Solvers
+using CTBase: Strategies
+using CTBase: Options
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/solvers/test_uno_parameter_validation.jl
+++ b/test/suite/solvers/test_uno_parameter_validation.jl
@@ -2,9 +2,9 @@ module TestUnoParameterValidation
 
 using Test
 using CTSolvers
-using CTSolvers.Solvers
-using CTBase.Strategies
-using CTBase.Exceptions
+using CTSolvers: Solvers
+using CTBase: Strategies
+using CTBase: Exceptions
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
@@ -13,7 +13,7 @@ const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
 # Fake parameter type for testing (must be at module top-level)
 # ============================================================================
 
-struct FakeParam <: AbstractStrategyParameter end
+struct FakeParam <: Strategies.AbstractStrategyParameter end
 Strategies.id(::Type{FakeParam}) = :fake
 
 # ============================================================================
@@ -36,8 +36,8 @@ function test_uno_parameter_validation()
 
         Test.@testset "Uno structure" begin
             # Test that Uno is parameterized
-            Test.@test Solvers.Uno <: AbstractNLPSolver
-            Test.@test Solvers.Uno{Strategies.CPU} <: AbstractNLPSolver
+            Test.@test Solvers.Uno <: Solvers.AbstractNLPSolver
+            Test.@test Solvers.Uno{Strategies.CPU} <: Solvers.AbstractNLPSolver
         end
 
         Test.@testset "id() with parameters" begin

--- a/test/suite/strategies/test_alias_integration.jl
+++ b/test/suite/strategies/test_alias_integration.jl
@@ -11,10 +11,10 @@ Date: 2026-03-17
 module TestAliasIntegration
 
 using Test: Test
-import CTBase.Exceptions
-import CTBase.Strategies
-import CTBase.Options
-import CTSolvers.Solvers
+using CTBase: Exceptions
+using CTBase: Strategies
+using CTBase: Options
+using CTSolvers: Solvers
 
 # Test options for verbose output
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true

--- a/test/suite/strategies/test_backward_compatibility.jl
+++ b/test/suite/strategies/test_backward_compatibility.jl
@@ -1,12 +1,12 @@
 module TestBackwardCompatibility
 
 using Test: Test
-import ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
-import ExaModels: ExaModels  # trigger CTSolversExaModels extension
-import CTBase.Exceptions
-import CTBase.Strategies
-import CTSolvers.Modelers
-import CTSolvers.Solvers
+using ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
+using ExaModels: ExaModels  # trigger CTSolversExaModels extension
+using CTBase: Exceptions
+using CTBase: Strategies
+using CTSolvers: Modelers
+using CTSolvers: Solvers
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/strategies/test_cpu_only_parameters_integration.jl
+++ b/test/suite/strategies/test_cpu_only_parameters_integration.jl
@@ -1,15 +1,13 @@
 module TestCPUOnlyParametersIntegration
-import ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
-import ExaModels: ExaModels  # trigger CTSolversExaModels extension
+using ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
+using ExaModels: ExaModels  # trigger CTSolversExaModels extension
 
 using Test
 using CTSolvers
-using CTSolvers.Modelers
-using CTSolvers.Modelers: AbstractNLPModeler
-using CTSolvers.Solvers
-using CTSolvers.Solvers: AbstractNLPSolver
-using CTBase.Strategies
-using CTBase.Exceptions
+using CTSolvers: Modelers
+using CTSolvers: Solvers
+using CTBase: Strategies
+using CTBase: Exceptions
 using CUDA
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
@@ -22,7 +20,7 @@ is_cuda_on() = CUDA.functional()
 # Fake parameter type for testing (must be at module top-level)
 # ============================================================================
 
-struct FakeParam <: AbstractStrategyParameter end
+struct FakeParam <: Strategies.AbstractStrategyParameter end
 Strategies.id(::Type{FakeParam}) = :fake
 
 # ============================================================================
@@ -44,11 +42,11 @@ function test_cpu_only_parameters_integration()
         Test.@testset "Registry with CPU-only strategies" begin
             # Create registry with parameterized CPU-only strategies
             registry = Strategies.create_registry(
-                AbstractNLPModeler => (
+                Modelers.AbstractNLPModeler => (
                     (Modelers.ADNLP, [Strategies.CPU]),
                     (Modelers.Exa, [Strategies.CPU, Strategies.GPU]),
                 ),
-                AbstractNLPSolver => (
+                Solvers.AbstractNLPSolver => (
                     (Solvers.Ipopt, [Strategies.CPU]),
                     (Solvers.MadNLP, [Strategies.CPU, Strategies.GPU]),
                     (Solvers.MadNCL, [Strategies.CPU, Strategies.GPU]),
@@ -59,11 +57,11 @@ function test_cpu_only_parameters_integration()
             Test.@test registry isa Strategies.StrategyRegistry
 
             # Verify strategy IDs
-            modeler_ids = Strategies.strategy_ids(AbstractNLPModeler, registry)
+            modeler_ids = Strategies.strategy_ids(Modelers.AbstractNLPModeler, registry)
             Test.@test :adnlp in modeler_ids
             Test.@test :exa in modeler_ids
 
-            solver_ids = Strategies.strategy_ids(AbstractNLPSolver, registry)
+            solver_ids = Strategies.strategy_ids(Solvers.AbstractNLPSolver, registry)
             Test.@test :ipopt in solver_ids
             Test.@test :madnlp in solver_ids
             Test.@test :madncl in solver_ids
@@ -75,18 +73,18 @@ function test_cpu_only_parameters_integration()
 
         Test.@testset "Build CPU-only strategies from registry" begin
             registry = Strategies.create_registry(
-                AbstractNLPModeler => ((Modelers.ADNLP, [Strategies.CPU]),),
-                AbstractNLPSolver => ((Solvers.Ipopt, [Strategies.CPU]),),
+                Modelers.AbstractNLPModeler => ((Modelers.ADNLP, [Strategies.CPU]),),
+                Solvers.AbstractNLPSolver => ((Solvers.Ipopt, [Strategies.CPU]),),
             )
 
             # Build ADNLP with CPU (should work)
             Test.@test_nowarn Strategies.build_strategy(
-                :adnlp, Strategies.CPU, AbstractNLPModeler, registry
+                :adnlp, Strategies.CPU, Modelers.AbstractNLPModeler, registry
             )
 
             # Verify type
             modeler = Strategies.build_strategy(
-                :adnlp, Strategies.CPU, AbstractNLPModeler, registry
+                :adnlp, Strategies.CPU, Modelers.AbstractNLPModeler, registry
             )
             Test.@test modeler isa Modelers.ADNLP{Strategies.CPU}
         end
@@ -97,13 +95,13 @@ function test_cpu_only_parameters_integration()
 
         Test.@testset "Reject GPU parameter for CPU-only strategies" begin
             registry = Strategies.create_registry(
-                AbstractNLPModeler => ((Modelers.ADNLP, [Strategies.CPU]),)
+                Modelers.AbstractNLPModeler => ((Modelers.ADNLP, [Strategies.CPU]),)
             )
 
             # Attempting to build ADNLP with GPU should fail
             Test.@test_throws Exceptions.IncorrectArgument begin
                 Strategies.build_strategy(
-                    :adnlp, Strategies.GPU, AbstractNLPModeler, registry
+                    :adnlp, Strategies.GPU, Modelers.AbstractNLPModeler, registry
                 )
             end
         end
@@ -114,7 +112,7 @@ function test_cpu_only_parameters_integration()
 
         Test.@testset "Mixed CPU-only and GPU-capable strategies" begin
             registry = Strategies.create_registry(
-                AbstractNLPModeler => (
+                Modelers.AbstractNLPModeler => (
                     (Modelers.ADNLP, [Strategies.CPU]),
                     (Modelers.Exa, [Strategies.CPU, Strategies.GPU]),
                 ),
@@ -122,17 +120,17 @@ function test_cpu_only_parameters_integration()
 
             # CPU parameter works for both
             Test.@test_nowarn Strategies.build_strategy(
-                :adnlp, Strategies.CPU, AbstractNLPModeler, registry
+                :adnlp, Strategies.CPU, Modelers.AbstractNLPModeler, registry
             )
             Test.@test_nowarn Strategies.build_strategy(
-                :exa, Strategies.CPU, AbstractNLPModeler, registry
+                :exa, Strategies.CPU, Modelers.AbstractNLPModeler, registry
             )
 
             # GPU tests only if CUDA is functional
             if is_cuda_on()
                 # GPU parameter works only for Exa
                 Test.@test_nowarn Strategies.build_strategy(
-                    :exa, Strategies.GPU, AbstractNLPModeler, registry
+                    :exa, Strategies.GPU, Modelers.AbstractNLPModeler, registry
                 )
             else
                 # CUDA not functional — skip GPU test silently
@@ -141,7 +139,7 @@ function test_cpu_only_parameters_integration()
             # GPU parameter fails for ADNLP (doesn't require CUDA to be functional)
             Test.@test_throws Exceptions.IncorrectArgument begin
                 Strategies.build_strategy(
-                    :adnlp, Strategies.GPU, AbstractNLPModeler, registry
+                    :adnlp, Strategies.GPU, Modelers.AbstractNLPModeler, registry
                 )
             end
         end
@@ -152,8 +150,8 @@ function test_cpu_only_parameters_integration()
 
         Test.@testset "Parameter extraction with CPU-only strategies" begin
             registry = Strategies.create_registry(
-                AbstractNLPModeler => ((Modelers.ADNLP, [Strategies.CPU]),),
-                AbstractNLPSolver => ((Solvers.Ipopt, [Strategies.CPU]),),
+                Modelers.AbstractNLPModeler => ((Modelers.ADNLP, [Strategies.CPU]),),
+                Solvers.AbstractNLPSolver => ((Solvers.Ipopt, [Strategies.CPU]),),
             )
 
             # Method with CPU parameter should work
@@ -184,12 +182,12 @@ function test_cpu_only_parameters_integration()
 
         Test.@testset "Error messages for unsupported parameters" begin
             registry = Strategies.create_registry(
-                AbstractNLPModeler => ((Modelers.ADNLP, [Strategies.CPU]),)
+                Modelers.AbstractNLPModeler => ((Modelers.ADNLP, [Strategies.CPU]),)
             )
 
             # Test error message when trying to build with GPU
             err = try
-                Strategies.build_strategy(:adnlp, Strategies.GPU, AbstractNLPModeler, registry)
+                Strategies.build_strategy(:adnlp, Strategies.GPU, Modelers.AbstractNLPModeler, registry)
             catch e
                 e
             end

--- a/test/suite/strategies/test_describe_parameters.jl
+++ b/test/suite/strategies/test_describe_parameters.jl
@@ -5,11 +5,11 @@
 module TestDescribeParameters
 
 using Test: Test
-import ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
-import ExaModels: ExaModels  # trigger CTSolversExaModels extension
-import CTBase.Exceptions
+using ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
+using ExaModels: ExaModels  # trigger CTSolversExaModels extension
+using CTBase: Exceptions
 using CTSolvers: CTSolvers
-import CTBase.Strategies
+using CTBase: Strategies
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/strategies/test_describe_registry.jl
+++ b/test/suite/strategies/test_describe_registry.jl
@@ -1,15 +1,15 @@
 module TestDescribeRegistry
 
 using Test: Test
-import ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
-import ExaModels: ExaModels  # trigger CTSolversExaModels extension
-import CTBase.Exceptions
+using ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
+using ExaModels: ExaModels  # trigger CTSolversExaModels extension
+using CTBase: Exceptions
 using CTSolvers: CTSolvers
-import CTBase.Strategies
-import CTBase.Options
-import CTSolvers.Modelers
-import CTSolvers.Solvers
-import CTSolvers.Integrators
+using CTBase: Strategies
+using CTBase: Options
+using CTSolvers: Modelers
+using CTSolvers: Solvers
+using CTSolvers: Integrators
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/strategies/test_integration_parameters.jl
+++ b/test/suite/strategies/test_integration_parameters.jl
@@ -1,13 +1,13 @@
 module TestIntegrationParameters
 
 using Test: Test
-import ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
-import ExaModels: ExaModels  # trigger CTSolversExaModels extension
-import CTBase.Exceptions
-import CTBase.Strategies
-import CTSolvers.Modelers
-import CTSolvers.Solvers
-import CTBase.Options
+using ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
+using ExaModels: ExaModels  # trigger CTSolversExaModels extension
+using CTBase: Exceptions
+using CTBase: Strategies
+using CTSolvers: Modelers
+using CTSolvers: Solvers
+using CTBase: Options
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true

--- a/test/suite/strategies/test_madnlp_gpu_linear_solver.jl
+++ b/test/suite/strategies/test_madnlp_gpu_linear_solver.jl
@@ -1,8 +1,8 @@
 module TestMadNLPGPULinearSolver
 
 using Test: Test
-import CTBase.Strategies
-import CTSolvers.Solvers
+using CTBase: Strategies
+using CTSolvers: Solvers
 
 # Import extensions to enable metadata testing
 using MadNLP: MadNLP

--- a/test/suite/strategies/test_parameter_contract.jl
+++ b/test/suite/strategies/test_parameter_contract.jl
@@ -1,12 +1,11 @@
 module TestParameterContract
-import ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
-import ExaModels: ExaModels  # trigger CTSolversExaModels extension
+using ADNLPModels: ADNLPModels  # trigger CTSolversADNLPModels extension
+using ExaModels: ExaModels  # trigger CTSolversExaModels extension
 
 using Test
 using CTSolvers
-using CTBase.Strategies
-using CTBase.Strategies: default_parameter, parameter
-using CTBase.Exceptions
+using CTBase: Strategies
+using CTBase: Exceptions
 
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
@@ -21,8 +20,8 @@ Fake strategy type that does NOT implement the parameter contract.
 This type is used to test that the fallback implementations correctly
 throw NotImplemented errors.
 """
-struct FakeStrategyWithoutContract <: AbstractStrategy
-    options::StrategyOptions
+struct FakeStrategyWithoutContract <: Strategies.AbstractStrategy
+    options::Strategies.StrategyOptions
 end
 
 # Intentionally DO NOT implement default_parameter or parameter to test the fallback behavior
@@ -51,12 +50,12 @@ function test_parameter_contract()
         Test.@testset "Fallback implementations throw NotImplemented" begin
             Test.@testset "default_parameter fallback" begin
                 err = try
-                    default_parameter(FakeStrategyWithoutContract)
+                    Strategies.default_parameter(FakeStrategyWithoutContract)
                 catch e
                     e
                 end
 
-                Test.@test err isa NotImplemented
+                Test.@test err isa Exceptions.NotImplemented
                 Test.@test occursin("must implement default_parameter", err.msg)
                 Test.@test occursin("Strategies.default_parameter", err.required_method)
                 Test.@test occursin("Strategies.default_parameter", err.suggestion)
@@ -65,12 +64,12 @@ function test_parameter_contract()
 
             Test.@testset "parameter fallback" begin
                 err = try
-                    parameter(FakeStrategyWithoutContract)
+                    Strategies.parameter(FakeStrategyWithoutContract)
                 catch e
                     e
                 end
 
-                Test.@test err isa NotImplemented
+                Test.@test err isa Exceptions.NotImplemented
                 Test.@test occursin("parameter", lowercase(err.msg))
                 Test.@test occursin("parameter", err.required_method)
                 Test.@test occursin("parameter", err.suggestion)
@@ -96,8 +95,8 @@ function test_parameter_contract()
             for (strategy_type, name) in strategies
                 Test.@testset "$name implements contract" begin
                     # Should not throw NotImplemented
-                    default = Test.@test_nowarn default_parameter(strategy_type)
-                    Test.@test default == CPU  # All current strategies default to CPU
+                    default = Test.@test_nowarn Strategies.default_parameter(strategy_type)
+                    Test.@test default == Strategies.CPU  # All current strategies default to CPU
 
                     # Type constraints enforce parameter validation at compile-time
                     # No runtime _supported_parameters() needed
@@ -113,7 +112,7 @@ function test_parameter_contract()
             Test.@testset "Cannot use FakeStrategyWithoutContract in registry" begin
                 # Attempting to query default parameter for a strategy without contract
                 # should fail with NotImplemented
-                Test.@test_throws NotImplemented default_parameter(
+                Test.@test_throws Exceptions.NotImplemented Strategies.default_parameter(
                     FakeStrategyWithoutContract
                 )
             end

--- a/test/suite/strategies/test_validation_mode.jl
+++ b/test/suite/strategies/test_validation_mode.jl
@@ -6,8 +6,8 @@ Tests the mode parameter itself: validation, default behavior, and error handlin
 module TestValidationMode
 
 using Test: Test
-import CTBase.Strategies
-import CTSolvers.Solvers
+using CTBase: Strategies
+using CTSolvers: Solvers
 using NLPModelsIpopt: NLPModelsIpopt
 
 # Test options for verbose output

--- a/test/suite/strategies/test_validation_permissive.jl
+++ b/test/suite/strategies/test_validation_permissive.jl
@@ -8,9 +8,9 @@ are still validated.
 module TestValidationPermissive
 
 using Test: Test
-import CTBase.Strategies
-import CTSolvers.Solvers
-import CTBase.Options
+using CTBase: Strategies
+using CTSolvers: Solvers
+using CTBase: Options
 using NLPModelsIpopt: NLPModelsIpopt
 
 # Test options for verbose output

--- a/test/suite/strategies/test_validation_strict.jl
+++ b/test/suite/strategies/test_validation_strict.jl
@@ -7,11 +7,11 @@ ensuring unknown options are rejected with helpful error messages.
 module TestValidationStrict
 
 using Test: Test
-import CTBase.Strategies
-import CTSolvers.Solvers
-import CTBase.Options
+using CTBase: Strategies
+using CTSolvers: Solvers
+using CTBase: Options
 using NLPModelsIpopt: NLPModelsIpopt
-import CTBase.Exceptions
+using CTBase: Exceptions
 
 # Test options for verbose output
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true


### PR DESCRIPTION
## Summary

Closes #195.

Replaces every `import` and every forbidden dotted `using Pkg.Sub` across `src/`, `ext/`, `test/`, and `docs/` with the qualified `using Pkg: Sub` form mandated by [Handbook tenet 2](https://github.com/control-toolbox/Handbook/blob/main/philosophy/modules.md#using-never-import), following the precedent set by [CTLie.jl#24](https://github.com/control-toolbox/CTLie.jl/pull/24).

- **Mechanical**: `import Pkg` / `import Pkg.Sub` / `using Pkg.Sub` → `using Pkg: Sub` (or `using Pkg: sym1, sym2` for flat, non-submodule packages).
- **Qualification**: several files relied on the dotted `using CTBase.Strategies` / `using CTSolvers.DOCP` (etc.) bare form to silently pull exported symbols (`CPU`, `GPU`, `AbstractStrategyParameter`, `DiscretizedModel`, `AbstractNLPModeler`, ...) into scope unqualified — the exact behavior tenet 2 forbids. Those call sites are now explicitly qualified (`Strategies.CPU`, `Modelers.AbstractNLPModeler`, etc.), including dispatch bounds like `P<:CPU` → `P<:Strategies.CPU`.
- `src/Integrators/Integrators.jl`: `import CTModels.Solutions: status, successful` became `using CTModels: Solutions` plus explicit `const status = Solutions.status` / `const successful = Solutions.successful` aliases, preserving the `Integrators.status`/`Integrators.successful` re-export that CTFlows.jl depends on (verified `Integrators.status === Solutions.status` still holds).
- Four test files (`test_docp.jl`, `test_modelers.jl`, `test_optimization.jl`, `test_solvers.jl`) had "Exports verification" tests that depended on the bare-`using` side effect to check whether a symbol was part of a module's public API. Rewritten to check `name in names(Module)` directly — a more correct test of "is this exported" than relying on the side effect.
- `CHANGELOG.md` is left untouched: its `import` mentions are inside dated past-release entries describing what shipped at the time (historical fact, not current guidance), matching the same principle the issue states for "Before" migration snippets.
- `BREAKING.md` is fixed for its one *current-usage* extension-pattern snippet, but the versioned Before/After migration snippets stay as historical fact.

## Regression guard

Adds `test/suite/meta/test_no_import.jl` (adapted from CTLie.jl), scanning every tracked `.jl`/`.md` file for the two forbidden patterns. It needed one adaptation beyond CTLie's version: a separate `IMPORT_EXEMPT` list (containing `CHANGELOG.md`) alongside the existing `DOTTED_USING_EXEMPT`, since CTSolvers' changelog — unlike CTLie's — has literal historical `import` lines.

## Test plan

- [x] `Pkg.test()` — full suite passes: **57982/57982**, including the new `suite/meta/test_no_import.jl` (55291 checks) and `suite/meta/test_aqua.jl`.
- [x] `rg --fixed-strings 'import ' -g '*.jl' -g '*.md' .` and the dotted-`using` regex from the issue — no residual matches outside `CHANGELOG.md` and the meta test's own docstring/comment text.
