### PR TITLE
Prepare CTSolvers 0.5.0 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTSolvers"
 uuid = "d3e8d392-8e4b-4d9b-8e92-d7d4e3650ef6"
-version = "0.4.34-beta"
+version = "0.5.0"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]
@@ -50,8 +50,8 @@ CTSolversZygote = "Zygote"
 ADNLPModels = "0.8"
 Aqua = "0.8"
 BenchmarkTools = "1"
-CTBase = "0.28"
-CTModels = "0.15"
+CTBase = "0.29"
+CTModels = "0.16"
 CUDA = "5, 6"
 CUDSS = "0.6, 0.7, 0.8"
 CommonSolve = "0.2"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,7 @@
 ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
 CTBase = "54762871-cc72-4466-b8e8-f6c8b58076cd"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
@@ -25,8 +26,9 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 ADNLPModels = "0.8"
-CTBase = "0.28"
+CTBase = "0.29"
 CUDA = "5, 6"
+CUDSS = "0.6, 0.7, 0.8"
 DiffEqBase = "6, 7"
 Documenter = "1"
 DocumenterInterLinks = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,6 +18,7 @@ using MarkdownAST: MarkdownAST
 # trigger extensions
 using ADNLPModels
 using CUDA
+using CUDSS
 using DiffEqBase
 using Enzyme
 using ExaModels
@@ -65,12 +66,12 @@ draft = false # Draft mode: if true, @example blocks in markdown are not execute
 # ═══════════════════════════════════════════════════════════════════════════════
 links = InterLinks(
     "CTBase" => (
-        "https://control-toolbox.org/CTBase.jl/dev/",
-        "https://control-toolbox.org/CTBase.jl/dev/objects.inv",
+        "https://control-toolbox.org/CTBase.jl/stable/",
+        "https://control-toolbox.org/CTBase.jl/stable/objects.inv",
     ),
     "CTModels" => (
-        "https://control-toolbox.org/CTModels.jl/dev/",
-        "https://control-toolbox.org/CTModels.jl/dev/objects.inv",
+        "https://control-toolbox.org/CTModels.jl/stable/",
+        "https://control-toolbox.org/CTModels.jl/stable/objects.inv",
     ),
 )
 


### PR DESCRIPTION
## Summary
- Bump CTSolvers to version 0.5.0.
- Update compatibility bounds for CTBase 0.29 and CTModels 0.16.
- Update the documentation environment and stable cross-references for the new compatibility baseline.
- Load CUDSS explicitly so the CTSolversMadNLPGPU extension is available during documentation generation.

#### Test plan
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — 58,100 tests passed.
- [x] `julia --project=docs docs/make.jl` — documentation build completed successfully.
- [x] Verified `CTSolversMadNLPGPU` loads with `CUDSS`.

Generated with [Devin](https://devin.ai)