### PR TITLE
Fix docstring @extref links for CTSolvers docs build

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -65,6 +65,11 @@ draft = false # Draft mode: if true, @example blocks in markdown are not execute
 # Cross-package links (InterLinks)
 # ═══════════════════════════════════════════════════════════════════════════════
 links = InterLinks(
+    "CTSolvers" => (
+        "https://control-toolbox.org/CTSolvers.jl/stable/",
+        joinpath(@__DIR__, "build", "1", "objects.inv"),
+        "https://control-toolbox.org/CTSolvers.jl/stable/objects.inv",
+    ),
     "CTBase" => (
         "https://control-toolbox.org/CTBase.jl/stable/",
         "https://control-toolbox.org/CTBase.jl/stable/objects.inv",

--- a/ext/CTSolversADNLPModels.jl
+++ b/ext/CTSolversADNLPModels.jl
@@ -28,8 +28,8 @@ Overrides the core stub in `CTSolvers.Modelers` when `ADNLPModels` is loaded.
 # Returns
 - `Bool`: `true`
 
-See also: [`CTSolvers.Modelers.__is_adbackend_type`](@ref),
-[`CTSolvers.Modelers.__is_adbackend_instance`](@ref)
+See also: [`CTSolvers.Modelers.__is_adbackend_type`](@extref),
+[`CTSolvers.Modelers.__is_adbackend_instance`](@extref)
 """
 Modelers.__is_adbackend_type(::Type{<:ADNLPModels.ADBackend}) = true
 
@@ -43,8 +43,8 @@ Overrides the core stub in `CTSolvers.Modelers` when `ADNLPModels` is loaded.
 # Returns
 - `Bool`: `true`
 
-See also: [`CTSolvers.Modelers.__is_adbackend_instance`](@ref),
-[`CTSolvers.Modelers.__is_adbackend_type`](@ref)
+See also: [`CTSolvers.Modelers.__is_adbackend_instance`](@extref),
+[`CTSolvers.Modelers.__is_adbackend_type`](@extref)
 """
 Modelers.__is_adbackend_instance(x::ADNLPModels.ADBackend) = true
 
@@ -57,14 +57,14 @@ $(TYPEDSIGNATURES)
 
 Return the list of available AD backends for `Modelers.ADNLP` using `ADNLPModels`.
 
-Overrides the core stub; called via [`CTSolvers.Modelers.get_adnlp_available_backends`](@ref).
+Overrides the core stub; called via [`CTSolvers.Modelers.get_adnlp_available_backends`](@extref).
 Includes all predefined backends from `ADNLPModels.predefined_backend` plus `:manual`.
 
 # Returns
 - `Vector{Symbol}`: available backend names (e.g. `:default`, `:optimized`, `:manual`)
 
-See also: [`CTSolvers.Modelers.get_adnlp_available_backends`](@ref),
-[`CTSolvers.Modelers.ADNLPTag`](@ref)
+See also: [`CTSolvers.Modelers.get_adnlp_available_backends`](@extref),
+[`CTSolvers.Modelers.ADNLPTag`](@extref)
 """
 function Modelers.__get_adnlp_available_backends(::Type{Modelers.ADNLPTag})
     backends = collect(keys(ADNLPModels.predefined_backend))
@@ -88,8 +88,8 @@ AD backend overrides for individual derivative operations.
 # Returns
 - `CTBase.Strategies.StrategyMetadata`: metadata object with all option definitions
 
-See also: [`CTSolvers.Modelers.ADNLP`](@ref),
-[`CTSolvers.Modelers._build_adnlp_modeler`](@ref)
+See also: [`CTSolvers.Modelers.ADNLP`](@extref),
+[`CTSolvers.Modelers._build_adnlp_modeler`](@extref)
 """
 function Strategies.metadata(::Type{Modelers.ADNLP{P}}) where {P<:Strategies.CPU}
     return Strategies.StrategyMetadata(
@@ -199,8 +199,8 @@ and `:backend` should be used instead.
 # Returns
 - `CTSolvers.Modelers.ADNLP{parameter}`: configured modeler instance
 
-See also: [`CTSolvers.Modelers.ADNLP`](@ref),
-[`CTSolvers.Modelers._build_adnlp_modeler`](@ref)
+See also: [`CTSolvers.Modelers.ADNLP`](@extref),
+[`CTSolvers.Modelers._build_adnlp_modeler`](@extref)
 """
 function Modelers._build_adnlp_modeler(
     ::Type{Modelers.ADNLPTag},

--- a/ext/CTSolversExaModels.jl
+++ b/ext/CTSolversExaModels.jl
@@ -30,8 +30,8 @@ are loaded. Covers `:base_type` (floating-point precision) and `:backend`
 # Returns
 - `CTBase.Strategies.StrategyMetadata`: metadata object with all option definitions
 
-See also: [`CTSolvers.Modelers.Exa`](@ref),
-[`CTSolvers.Modelers._build_exa_modeler`](@ref)
+See also: [`CTSolvers.Modelers.Exa`](@extref),
+[`CTSolvers.Modelers._build_exa_modeler`](@extref)
 """
 function Strategies.metadata(
     ::Type{Modelers.Exa{P}}
@@ -85,8 +85,8 @@ is issued and `:backend` should be used instead.
 # Returns
 - `CTSolvers.Modelers.Exa{parameter}`: configured modeler instance
 
-See also: [`CTSolvers.Modelers.Exa`](@ref),
-[`CTSolvers.Modelers._build_exa_modeler`](@ref)
+See also: [`CTSolvers.Modelers.Exa`](@extref),
+[`CTSolvers.Modelers._build_exa_modeler`](@extref)
 """
 function Modelers._build_exa_modeler(
     ::Type{Modelers.ExaTag},

--- a/ext/CTSolversForwardDiff.jl
+++ b/ext/CTSolversForwardDiff.jl
@@ -24,9 +24,9 @@ $(TYPEDSIGNATURES)
 Recursively extract the primal (real) value from a ForwardDiff dual number.
 
 Handles nested dual numbers for higher-order differentiation. Extends the fallback
-[`CTSolvers.Integrators.deepvalue`](@ref) to support ForwardDiff.
+[`CTSolvers.Integrators.deepvalue`](@extref) to support ForwardDiff.
 
-See also: [`CTSolvers.Integrators.deepvalue`](@ref), [`CTSolvers.Integrators.real_norm`](@ref).
+See also: [`CTSolvers.Integrators.deepvalue`](@extref), [`CTSolvers.Integrators.real_norm`](@extref).
 """
 Integrators.deepvalue(x::ForwardDiff.Dual) = Integrators.deepvalue(ForwardDiff.value(x))
 
@@ -35,10 +35,10 @@ $(TYPEDSIGNATURES)
 
 Compute the internal norm for a scalar ForwardDiff dual number using only its primal part.
 
-Extends the fallback [`CTSolvers.Integrators.real_norm`](@ref) to support ForwardDiff dual
+Extends the fallback [`CTSolvers.Integrators.real_norm`](@extref) to support ForwardDiff dual
 numbers, ensuring grid invariance (IND) when integrating ODEs with dual numbers.
 
-See also: [`CTSolvers.Integrators.real_norm`](@ref), [`CTSolvers.Integrators.deepvalue`](@ref).
+See also: [`CTSolvers.Integrators.real_norm`](@extref), [`CTSolvers.Integrators.deepvalue`](@extref).
 """
 function Integrators.real_norm(u::ForwardDiff.Dual, t)
     return Integrators.real_norm(Integrators.deepvalue(u), t)

--- a/ext/CTSolversOrdinaryDiffEqTsit5.jl
+++ b/ext/CTSolversOrdinaryDiffEqTsit5.jl
@@ -17,7 +17,7 @@ Return the default SciML ODE algorithm (Tsit5) for `Tsit5Tag`.
 
 Overrides the stub in `src/Integrators/sciml.jl` that returns `missing`.
 
-See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTSolvers.Integrators.Tsit5Tag`](@ref).
+See also: [`CTSolvers.Integrators.SciML`](@extref), [`CTSolvers.Integrators.Tsit5Tag`](@extref).
 """
 function Integrators.__default_sciml_algorithm(::Type{<:Integrators.Tsit5Tag})
     return Tsit5()

--- a/ext/CTSolversSciMLIntegrator.jl
+++ b/ext/CTSolversSciMLIntegrator.jl
@@ -41,10 +41,10 @@ parts of dual numbers.
 
 Ensures grid invariance (IND) when integrating ODEs with ForwardDiff dual numbers:
 the adaptive time grid chosen by the solver is identical whether integrating with real
-or dual numbers. Uses [`CTSolvers.Integrators.deepvalue`](@ref) to extract primal parts
+or dual numbers. Uses [`CTSolvers.Integrators.deepvalue`](@extref) to extract primal parts
 and `DiffEqBase.ODE_DEFAULT_NORM` to compute the norm.
 
-See also: [`CTSolvers.Integrators.deepvalue`](@ref), [`CTSolvers.Integrators.real_norm`](@ref).
+See also: [`CTSolvers.Integrators.deepvalue`](@extref), [`CTSolvers.Integrators.real_norm`](@extref).
 """
 function Integrators.real_norm(u::AbstractArray, t)
     return DiffEqBase.ODE_DEFAULT_NORM(Integrators.deepvalue.(u), t)
@@ -288,7 +288,7 @@ integrator construction into two cached dictionaries:
 Users can override automatic resolution by providing explicit `true`/`false` values
 when constructing the integrator.
 
-See also: [`CTSolvers.Integrators._build_sciml_integrator`](@ref).
+See also: [`CTSolvers.Integrators._build_sciml_integrator`](@extref).
 """
 const _AUTO_OPTION_KEYS = (:dense, :save_everystep, :save_start)
 
@@ -310,13 +310,13 @@ cached dictionaries `options_point` (`:auto` → `false`) and `options_trajector
 - `kwargs...`: User-provided option values. Explicit `true`/`false` override `:auto` resolution.
 
 # Returns
-- [`CTSolvers.Integrators.SciML`](@ref): integrator with cached `options_point`/`options_trajectory`.
+- [`CTSolvers.Integrators.SciML`](@extref): integrator with cached `options_point`/`options_trajectory`.
 
 # Throws
 - `CTBase.Exceptions.PreconditionError`: If no algorithm is available (e.g. `OrdinaryDiffEqTsit5`
   not loaded and no explicit `alg`).
 
-See also: [`CTSolvers.Integrators.SciML`](@ref).
+See also: [`CTSolvers.Integrators.SciML`](@extref).
 """
 function Integrators._build_sciml_integrator(
     ::Type{Integrators.SciMLTag}, ::Type{P}; mode::Symbol=:strict, kwargs...
@@ -512,7 +512,7 @@ end
 $(TYPEDSIGNATURES)
 
 Integrate an `ODEProblem` with a `SciML` integrator and resolved options.
-Returns a [`SciMLIntegrationResult`](@ref) wrapping the raw `ODESolution`.
+Returns a [`CTSolversSciMLIntegrator.SciMLIntegrationResult`](@extref) wrapping the raw `ODESolution`.
 
 # Arguments
 - `prob::SciMLBase.AbstractODEProblem`: The ODE problem to integrate (time span embedded).

--- a/ext/CTSolversUno.jl
+++ b/ext/CTSolversUno.jl
@@ -333,7 +333,7 @@ Solve an NLP problem using Uno.
 # Returns
 - `UnoSolver.UnoExecutionStats`: Solver execution statistics
 
-See also: [`solve_with_uno`](@ref), [`Solvers.extract_solver_infos`](@ref)
+See also: [`CTSolversUno.solve_with_uno`](@extref), [`CTSolvers.Solvers.extract_solver_infos`](@extref)
 """
 function CommonSolve.solve(
     nlp::NLPModels.AbstractNLPModel, solver::Solvers.Uno; display::Bool=true
@@ -361,7 +361,7 @@ Solves the NLP problem using UnoSolver backend.
 # Returns
 - `UnoSolver.UnoExecutionStats`: Solver execution statistics
 
-See also: `Solvers.Uno`, `UnoSolver.uno`, [`Solvers.extract_solver_infos`](@ref)
+See also: `Solvers.Uno`, `UnoSolver.uno`, [`CTSolvers.Solvers.extract_solver_infos`](@extref)
 """
 function solve_with_uno(
     nlp::NLPModels.AbstractNLPModel; kwargs...
@@ -391,7 +391,7 @@ A 6-element tuple `(objective, iterations, constraints_violation, message, statu
 - The successful flag is `true` when status is `:first_order` or `:acceptable`
 - This function enables integration with the CTSolvers pipeline by providing standardized solver information
 
-See also: [`solve_with_uno`](@ref)
+See also: [`CTSolversUno.solve_with_uno`](@extref)
 """
 function Solvers.extract_solver_infos(nlp_solution::UnoSolver.UnoExecutionStats)
     objective = nlp_solution.objective

--- a/src/DOCP/abstract_discretizer.jl
+++ b/src/DOCP/abstract_discretizer.jl
@@ -12,7 +12,7 @@ Abstract base type for all discretization strategies.
 Concrete subtypes implement specific transcription methods (collocation, direct
 shooting, etc.) and are defined in the package providing the method. A discretizer
 is a `Strategies.AbstractStrategy`: it carries validated options and drives
-`discretize` to turn an optimal control problem into a [`DiscretizedModel`](@ref).
+`discretize` to turn an optimal control problem into a [`CTSolvers.DOCP.DiscretizedModel`](@extref).
 
 See also: `DiscretizedModel`, `discretize`.
 """

--- a/src/DOCP/contract.jl
+++ b/src/DOCP/contract.jl
@@ -7,7 +7,7 @@
 """
 $(TYPEDSIGNATURES)
 
-Discretize an optimal control problem into a [`DiscretizedModel`](@ref).
+Discretize an optimal control problem into a [`CTSolvers.DOCP.DiscretizedModel`](@extref).
 
 # Contract
 Must be implemented in the package providing `discretizer`, dispatching on its
@@ -18,7 +18,7 @@ concrete type, e.g. `CTSolvers.discretize(ocp, ::Collocation)` in CTDirect.
 - `discretizer::AbstractDiscretizer`: The discretization strategy.
 
 # Returns
-- A [`DiscretizedModel`](@ref) with a populated cache.
+- A [`CTSolvers.DOCP.DiscretizedModel`](@extref) with a populated cache.
 
 See also: `build_model`, `build_solution`.
 """

--- a/src/DOCP/conveniences.jl
+++ b/src/DOCP/conveniences.jl
@@ -9,7 +9,7 @@ $(TYPEDSIGNATURES)
 Build an NLP model from a discretized optimal control problem.
 
 This is a convenience wrapper around `build_model` that returns only the backend
-NLP model (the `nlp` field of the [`BuiltModel`](@ref)). Use `build_model`
+NLP model (the `nlp` field of the [`CTSolvers.Optimization.BuiltModel`](@extref)). Use `build_model`
 directly when the build-time cache is needed (e.g. before `build_solution`).
 
 # Arguments
@@ -39,7 +39,7 @@ $(TYPEDSIGNATURES)
 Build an optimal control solution from NLP execution statistics.
 
 This is a convenience wrapper around `build_solution` that dispatches on the
-[`BuiltModel`](@ref) returned by `build_model` and ensures the return type is an
+[`CTSolvers.Optimization.BuiltModel`](@extref) returned by `build_model` and ensures the return type is an
 optimal control solution.
 
 # Arguments

--- a/src/Integrators/abstract_integrator.jl
+++ b/src/Integrators/abstract_integrator.jl
@@ -22,13 +22,13 @@ Methods defined on **instances** that provide the actual configuration:
 Concrete integrators implement, typically in a backend extension:
 - `CommonSolve.solve(prob, integrator::S; options, unsafe)`: integrate the (external) ODE
   problem `prob` with the resolved `options`, returning an
-  [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref).
-- [`CTSolvers.Integrators.merge`](@ref): concatenate a sequence of integration results
+  [`CTSolvers.Integrators.AbstractIntegrationResult`](@extref).
+- [`CTSolvers.Integrators.merge`](@extref): concatenate a sequence of integration results
   (multi-phase trajectories).
 
 The cached per-call option dictionaries are exposed through the
-[`CTSolvers.Integrators.options_point`](@ref) / [`CTSolvers.Integrators.options_trajectory`](@ref) accessors.
+[`CTSolvers.Integrators.options_point`](@extref) / [`CTSolvers.Integrators.options_trajectory`](@extref) accessors.
 
-See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref).
+See also: [`CTSolvers.Integrators.SciML`](@extref), [`CTSolvers.Integrators.AbstractIntegrationResult`](@extref).
 """
 abstract type AbstractIntegrator <: Strategies.AbstractStrategy end

--- a/src/Integrators/contract.jl
+++ b/src/Integrators/contract.jl
@@ -34,13 +34,13 @@ in the `CTSolversSciMLIntegrator` extension. This generic stub throws `NotImplem
 - `unsafe::Bool`: If `true`, bypass retcode checking (default: `false`).
 
 # Returns
-- An [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref).
+- An [`CTSolvers.Integrators.AbstractIntegrationResult`](@extref).
 
 # Throws
 - [`CTBase.Exceptions.NotImplemented`](@extref): until a backend extension provides the
   typed method.
 
-See also: [`CTSolvers.Integrators.AbstractIntegrator`](@ref).
+See also: [`CTSolvers.Integrators.AbstractIntegrator`](@extref).
 """
 function CommonSolve.solve(prob, integ::AbstractIntegrator; kwargs...)
     return throw(
@@ -66,13 +66,13 @@ implement this method for their specific result types, typically in a backend ex
   `T <: AbstractIntegrationResult`.
 
 # Returns
-- A single [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref) representing the merged trajectory.
+- A single [`CTSolvers.Integrators.AbstractIntegrationResult`](@extref) representing the merged trajectory.
 
 # Throws
 - [`CTBase.Exceptions.NotImplemented`](@extref): until a backend extension provides the
   typed method.
 
-See also: [`CTSolvers.Integrators.AbstractIntegrator`](@ref), [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref).
+See also: [`CTSolvers.Integrators.AbstractIntegrator`](@extref), [`CTSolvers.Integrators.AbstractIntegrationResult`](@extref).
 """
 function merge(segments::AbstractVector{T}) where {T<:AbstractIntegrationResult}
     return throw(

--- a/src/Integrators/integration_result.jl
+++ b/src/Integrators/integration_result.jl
@@ -16,7 +16,7 @@ Subtypes must implement:
 - `status(r::SubType)`: Return the termination status as a `Symbol`.
 - `successful(r::SubType)`: Return whether the integration succeeded.
 
-See also: [`CTSolvers.Integrators.final_state`](@ref), [`CTSolvers.Integrators.times`](@ref), [`CTSolvers.Integrators.evaluate_at`](@ref), [`CTModels.Solutions.status`](@extref), [`CTModels.Solutions.successful`](@extref).
+See also: [`CTSolvers.Integrators.final_state`](@extref), [`CTSolvers.Integrators.times`](@extref), [`CTSolvers.Integrators.evaluate_at`](@extref), [`CTModels.Solutions.status`](@extref), [`CTModels.Solutions.successful`](@extref).
 """
 abstract type AbstractIntegrationResult end
 
@@ -31,7 +31,7 @@ Return the final state vector from the integration result.
 # Throws
 - [`CTBase.Exceptions.NotImplemented`](@extref): If not implemented by the concrete type.
 
-See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref), [`CTSolvers.Integrators.times`](@ref), [`CTSolvers.Integrators.evaluate_at`](@ref).
+See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@extref), [`CTSolvers.Integrators.times`](@extref), [`CTSolvers.Integrators.evaluate_at`](@extref).
 """
 function final_state(r::AbstractIntegrationResult)
     return throw(
@@ -55,7 +55,7 @@ Return the vector of time points from the integration result.
 # Throws
 - [`CTBase.Exceptions.NotImplemented`](@extref): If not implemented by the concrete type.
 
-See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref), [`CTSolvers.Integrators.final_state`](@ref), [`CTSolvers.Integrators.evaluate_at`](@ref).
+See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@extref), [`CTSolvers.Integrators.final_state`](@extref), [`CTSolvers.Integrators.evaluate_at`](@extref).
 """
 function times(r::AbstractIntegrationResult)
     return throw(
@@ -80,7 +80,7 @@ Evaluate the integration result at a specific time `t`.
 # Throws
 - [`CTBase.Exceptions.NotImplemented`](@extref): If not implemented by the concrete type.
 
-See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref), [`CTSolvers.Integrators.final_state`](@ref), [`CTSolvers.Integrators.times`](@ref).
+See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@extref), [`CTSolvers.Integrators.final_state`](@extref), [`CTSolvers.Integrators.times`](@extref).
 """
 function evaluate_at(r::AbstractIntegrationResult, t::Real)
     return throw(
@@ -108,7 +108,7 @@ on OCP solutions and on integration results.
 # Throws
 - [`CTBase.Exceptions.NotImplemented`](@extref): If not implemented by the concrete type.
 
-See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref), [`CTModels.Solutions.successful`](@extref).
+See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@extref), [`CTModels.Solutions.successful`](@extref).
 """
 function Solutions.status(r::AbstractIntegrationResult)::Symbol
     return throw(
@@ -136,7 +136,7 @@ uniformly on OCP solutions and on integration results.
 # Throws
 - [`CTBase.Exceptions.NotImplemented`](@extref): If not implemented by the concrete type.
 
-See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@ref), [`CTModels.Solutions.status`](@extref).
+See also: [`CTSolvers.Integrators.AbstractIntegrationResult`](@extref), [`CTModels.Solutions.status`](@extref).
 """
 function Solutions.successful(r::AbstractIntegrationResult)::Bool
     return throw(

--- a/src/Integrators/internal_norm.jl
+++ b/src/Integrators/internal_norm.jl
@@ -22,7 +22,7 @@ recursive extraction from nested dual numbers.
   recursively extracts the primal value via `deepvalue(value(x))`.
 - This method serves as the base case for all `Number` subtypes not handled by extensions.
 
-See also: [`CTSolvers.Integrators.real_norm`](@ref).
+See also: [`CTSolvers.Integrators.real_norm`](@extref).
 """
 deepvalue(x::Number) = x
 
@@ -48,6 +48,6 @@ array overload (using `DiffEqBase.ODE_DEFAULT_NORM`) lives in the
 - For complex numbers, returns `abs(u)` (the magnitude).
 - Used by SciML integrators for step-size control in grid-invariant computations.
 
-See also: [`CTSolvers.Integrators.deepvalue`](@ref).
+See also: [`CTSolvers.Integrators.deepvalue`](@extref).
 """
 real_norm(u::Number, t) = abs(u)

--- a/src/Integrators/sciml.jl
+++ b/src/Integrators/sciml.jl
@@ -29,7 +29,7 @@ Subtypes must implement:
 - `CTBase.Strategies.description(::Type{<:SubType})`: Return description.
 - `CTBase.Strategies.metadata(::Type{<:SubType})`: Return option metadata.
 
-See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTSolvers.Integrators.SciMLTag`](@ref).
+See also: [`CTSolvers.Integrators.SciML`](@extref), [`CTSolvers.Integrators.SciMLTag`](@extref).
 """
 abstract type AbstractSciMLIntegrator <: AbstractIntegrator end
 
@@ -96,7 +96,7 @@ register `SciML` without a parameter (e.g. CTFlows' flow registry) and query
 `parameter` on the bare type. A concrete `SciML{P}` resolves to `P` via the more
 specific method below.
 
-See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTBase.Strategies.default_parameter`](@extref)
+See also: [`CTSolvers.Integrators.SciML`](@extref), [`CTBase.Strategies.default_parameter`](@extref)
 """
 Strategies.parameter(::Type{<:SciML}) = nothing
 
@@ -112,7 +112,7 @@ since `SciML` supports both execution devices. More specific than the bare
 # Returns
 - `Type{<:Union{Strategies.CPU,Strategies.GPU}}`: the execution parameter type.
 
-See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref)
+See also: [`CTSolvers.Integrators.SciML`](@extref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref)
 """
 Strategies.parameter(::Type{<:SciML{P}}) where {P<:Union{Strategies.CPU,Strategies.GPU}} = P
 
@@ -124,7 +124,7 @@ Return the default execution parameter for `SciML` when none is specified.
 Returns `Strategies.CPU`, so `SciML(...)` builds a `SciML{Strategies.CPU}` and every existing call site is
 unaffected by the device parameterization.
 
-See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTBase.Strategies.CPU`](@extref)
+See also: [`CTSolvers.Integrators.SciML`](@extref), [`CTBase.Strategies.CPU`](@extref)
 """
 Strategies.default_parameter(::Type{<:SciML}) = Strategies.CPU
 
@@ -148,7 +148,7 @@ $(TYPEDSIGNATURES)
 
 Return the pre-computed option dictionary for point (final-state) integration.
 
-See also: [`CTSolvers.Integrators.options_trajectory`](@ref).
+See also: [`CTSolvers.Integrators.options_trajectory`](@extref).
 """
 options_point(integ::SciML) = integ.options_point
 
@@ -157,7 +157,7 @@ $(TYPEDSIGNATURES)
 
 Return the pre-computed option dictionary for trajectory integration.
 
-See also: [`CTSolvers.Integrators.options_point`](@ref).
+See also: [`CTSolvers.Integrators.options_point`](@extref).
 """
 options_trajectory(integ::SciML) = integ.options_trajectory
 
@@ -178,7 +178,7 @@ Construct a `SciML{Strategies.CPU}` integrator (the default device). Equivalent 
 # Throws
 - `CTBase.Exceptions.ExtensionError`: If the `CTSolversSciMLIntegrator` extension is not loaded.
 
-See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTSolvers.Integrators._build_sciml_integrator`](@ref).
+See also: [`CTSolvers.Integrators.SciML`](@extref), [`CTSolvers.Integrators._build_sciml_integrator`](@extref).
 """
 function SciML(; mode::Symbol=:strict, kwargs...)
     P = Strategies.default_parameter(SciML)
@@ -199,7 +199,7 @@ Construct a parameterized `SciML{P}` integrator for the execution device `P`
 # Throws
 - `CTBase.Exceptions.ExtensionError`: If the `CTSolversSciMLIntegrator` extension is not loaded.
 
-See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTSolvers.Integrators._build_sciml_integrator`](@ref).
+See also: [`CTSolvers.Integrators.SciML`](@extref), [`CTSolvers.Integrators._build_sciml_integrator`](@extref).
 """
 function SciML{P}(;
     mode::Symbol=:strict, kwargs...
@@ -236,7 +236,7 @@ not loaded. The real metadata implementation is provided by the extension.
 # Throws
 - `CTBase.Exceptions.ExtensionError`: Always thrown by this stub implementation.
 
-See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTBase.Strategies.StrategyMetadata`](@extref).
+See also: [`CTSolvers.Integrators.SciML`](@extref), [`CTBase.Strategies.StrategyMetadata`](@extref).
 """
 function Strategies.metadata(::Type{<:AbstractSciMLIntegrator})
     return throw(
@@ -258,7 +258,7 @@ Preserves backward compatibility for `metadata(SciML)` once the extension define
 the parameterized `metadata(SciML{P})`. Delegates through
 [`CTBase.Strategies.default_parameter`](@extref).
 
-See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTBase.Strategies.StrategyMetadata`](@extref).
+See also: [`CTSolvers.Integrators.SciML`](@extref), [`CTBase.Strategies.StrategyMetadata`](@extref).
 """
 function Strategies.metadata(::Type{SciML})
     return Strategies.metadata(SciML{Strategies.default_parameter(SciML)})
@@ -275,7 +275,7 @@ for `Tsit5Tag` is provided by `CTSolversOrdinaryDiffEqTsit5`.
 # Returns
 - `missing`: Default stub implementation.
 
-See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTSolvers.Integrators.Tsit5Tag`](@ref).
+See also: [`CTSolvers.Integrators.SciML`](@extref), [`CTSolvers.Integrators.Tsit5Tag`](@extref).
 """
 function __default_sciml_algorithm(::Type{<:Core.AbstractTag})
     return missing
@@ -300,7 +300,7 @@ is available (problem construction / solve), since `SciML` does not receive `u0`
 # Returns
 - `Bool`: `true` if consistent, `false` otherwise.
 
-See also: [`CTSolvers.Integrators.SciML`](@ref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref).
+See also: [`CTSolvers.Integrators.SciML`](@extref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref).
 """
 function __consistent_initial_condition(::Type{<:Strategies.AbstractStrategyParameter}, u0)
     return true

--- a/src/Modelers/adnlp.jl
+++ b/src/Modelers/adnlp.jl
@@ -35,8 +35,8 @@ Overridden by the `CTSolversADNLPModels` extension for `ADNLPTag`.
 # Throws
 - `CTBase.Exceptions.ExtensionError`: always, until overridden by the extension
 
-See also: [`CTSolvers.Modelers.get_adnlp_available_backends`](@ref),
-[`CTSolvers.Modelers.ADNLPTag`](@ref)
+See also: [`CTSolvers.Modelers.get_adnlp_available_backends`](@extref),
+[`CTSolvers.Modelers.ADNLPTag`](@extref)
 """
 function __get_adnlp_available_backends(::Type{<:Core.AbstractTag})
     return throw(
@@ -62,8 +62,8 @@ Requires the `CTSolversADNLPModels` extension (`using ADNLPModels`) to be loaded
 # Throws
 - `CTBase.Exceptions.ExtensionError`: if `ADNLPModels` is not loaded
 
-See also: [`CTSolvers.Modelers.ADNLP`](@ref),
-[`CTSolvers.Modelers.get_validate_adnlp_backend`](@ref)
+See also: [`CTSolvers.Modelers.ADNLP`](@extref),
+[`CTSolvers.Modelers.get_validate_adnlp_backend`](@extref)
 """
 get_adnlp_available_backends() = __get_adnlp_available_backends(ADNLPTag)
 
@@ -258,7 +258,7 @@ ADNLP is CPU-only.
 # Returns
 - `Type{Strategies.CPU}`: the execution parameter type.
 
-See also: [`CTSolvers.Modelers.ADNLP`](@ref), [`CTBase.Strategies.CPU`](@extref)
+See also: [`CTSolvers.Modelers.ADNLP`](@extref), [`CTBase.Strategies.CPU`](@extref)
 """
 Strategies.parameter(::Type{<:Modelers.ADNLP{P}}) where {P<:Strategies.CPU} = P
 

--- a/src/Modelers/contract.jl
+++ b/src/Modelers/contract.jl
@@ -10,13 +10,13 @@
 """
 $(TYPEDSIGNATURES)
 
-Build a [`CTSolvers.Optimization.BuiltModel`](@ref) from an optimization problem using
+Build a [`CTSolvers.Optimization.BuiltModel`](@extref) from an optimization problem using
 the specified modeler.
 
 This is the modeler contract: the modeler converts the problem into a backend NLP
-model. The returned [`CTSolvers.Optimization.BuiltModel`](@ref) carries the backend NLP
+model. The returned [`CTSolvers.Optimization.BuiltModel`](@extref) carries the backend NLP
 model together with any immutable build-time auxiliary needed later by
-[`CTSolvers.Optimization.build_solution`](@ref).
+[`CTSolvers.Optimization.build_solution`](@extref).
 
 # Contract
 Must be implemented in the package providing the concrete problem, dispatching on the
@@ -30,13 +30,13 @@ generic stub throws [`CTBase.Exceptions.NotImplemented`](@extref).
 - `modeler::AbstractNLPModeler`: The modeler strategy (e.g. `ADNLP`, `Exa`).
 
 # Returns
-- A [`CTSolvers.Optimization.BuiltModel`](@ref) bundling the backend NLP model and its build-time cache.
+- A [`CTSolvers.Optimization.BuiltModel`](@extref) bundling the backend NLP model and its build-time cache.
 
 # Throws
 - [`CTBase.Exceptions.NotImplemented`](@extref): when no method exists for this
   `(problem, modeler)` pair.
 
-See also: [`CTSolvers.Optimization.build_solution`](@ref), [`CTSolvers.Optimization.BuiltModel`](@ref).
+See also: [`CTSolvers.Optimization.build_solution`](@extref), [`CTSolvers.Optimization.BuiltModel`](@extref).
 """
 function Optimization.build_model(
     prob::Optimization.AbstractOptimizationProblem,
@@ -60,8 +60,8 @@ Build a problem-level solution from NLP execution statistics using the specified
 modeler.
 
 This is the modeler contract: it reconstructs the solution from the
-[`CTSolvers.Optimization.BuiltModel`](@ref) returned by
-[`CTSolvers.Optimization.build_model`](@ref) (which carries the problem and the
+[`CTSolvers.Optimization.BuiltModel`](@extref) returned by
+[`CTSolvers.Optimization.build_model`](@extref) (which carries the problem and the
 immutable build-time cache) and the solver output.
 
 # Contract
@@ -82,7 +82,7 @@ in CTDirect. This generic stub throws [`CTBase.Exceptions.NotImplemented`](@extr
 - [`CTBase.Exceptions.NotImplemented`](@extref): when no method exists for this
   `(problem, modeler)` pair.
 
-See also: [`CTSolvers.Optimization.build_model`](@ref), [`CTSolvers.Optimization.BuiltModel`](@ref).
+See also: [`CTSolvers.Optimization.build_model`](@extref), [`CTSolvers.Optimization.BuiltModel`](@extref).
 """
 function Optimization.build_solution(
     built::Optimization.BuiltModel, model_solution, modeler::AbstractNLPModeler

--- a/src/Modelers/exa.jl
+++ b/src/Modelers/exa.jl
@@ -268,7 +268,7 @@ Extracts the type parameter `P` from `Exa{P}`, which can be either `Strategies.C
 # Returns
 - `Type{<:Union{Strategies.CPU,Strategies.GPU}}`: the execution parameter type.
 
-See also: [`CTSolvers.Modelers.Exa`](@ref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref)
+See also: [`CTSolvers.Modelers.Exa`](@extref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref)
 """
 function Strategies.parameter(
     ::Type{<:Modelers.Exa{P}}

--- a/src/Modelers/validation.jl
+++ b/src/Modelers/validation.jl
@@ -300,8 +300,8 @@ Stub — always returns `false`. Overridden by the `CTSolversADNLPModels` extens
 # Returns
 - `Bool`: `false` (stub); `true` when the extension is active and `T <: ADBackend`
 
-See also: [`CTSolvers.Modelers.__is_adbackend_instance`](@ref),
-[`CTSolvers.Modelers.validate_backend_override`](@ref)
+See also: [`CTSolvers.Modelers.__is_adbackend_instance`](@extref),
+[`CTSolvers.Modelers.validate_backend_override`](@extref)
 """
 __is_adbackend_type(::Type) = false
 
@@ -316,8 +316,8 @@ Stub — always returns `false`. Overridden by the `CTSolversADNLPModels` extens
 # Returns
 - `Bool`: `false` (stub); `true` when the extension is active and `x isa ADBackend`
 
-See also: [`CTSolvers.Modelers.__is_adbackend_type`](@ref),
-[`CTSolvers.Modelers.validate_backend_override`](@ref)
+See also: [`CTSolvers.Modelers.__is_adbackend_type`](@extref),
+[`CTSolvers.Modelers.validate_backend_override`](@extref)
 """
 __is_adbackend_instance(x) = false
 

--- a/src/Optimization/building.jl
+++ b/src/Optimization/building.jl
@@ -11,7 +11,7 @@ Build a backend NLP model from an optimization problem and an initial guess.
 
 Generic function for the model-building contract. Concrete methods must be provided
 by the package supplying the optimization problem (e.g. CTDirect for
-[`CTSolvers.DOCP.DiscretizedModel`](@ref)), dispatching on the concrete
+[`CTSolvers.DOCP.DiscretizedModel`](@extref)), dispatching on the concrete
 `(problem, modeler)` pair.
 
 # Arguments
@@ -20,14 +20,14 @@ by the package supplying the optimization problem (e.g. CTDirect for
 - `modeler::CTSolvers.Modelers.AbstractNLPModeler`: The modeler strategy (e.g. `ADNLP`, `Exa`).
 
 # Returns
-- [`CTSolvers.Optimization.BuiltModel`](@ref): immutable bundle of the problem, the
+- [`CTSolvers.Optimization.BuiltModel`](@extref): immutable bundle of the problem, the
   backend NLP model, and an optional build-time cache.
 
 # Throws
 - [`CTBase.Exceptions.NotImplemented`](@extref): when no concrete method exists for
   this `(problem, modeler)` pair.
 
-See also: [`CTSolvers.Optimization.build_solution`](@ref), [`CTSolvers.Optimization.BuiltModel`](@ref).
+See also: [`CTSolvers.Optimization.build_solution`](@extref), [`CTSolvers.Optimization.BuiltModel`](@extref).
 """
 function build_model end
 
@@ -40,7 +40,7 @@ by the package supplying the optimization problem, dispatching on the concrete
 
 # Arguments
 - `built::CTSolvers.Optimization.BuiltModel`: The bundle returned by
-  [`CTSolvers.Optimization.build_model`](@ref).
+  [`CTSolvers.Optimization.build_model`](@extref).
 - `model_solution`: NLP solver output (execution statistics from SolverCore).
 - `modeler::CTSolvers.Modelers.AbstractNLPModeler`: The modeler strategy used to build.
 
@@ -51,6 +51,6 @@ by the package supplying the optimization problem, dispatching on the concrete
 - [`CTBase.Exceptions.NotImplemented`](@extref): when no concrete method exists for
   this `(built, modeler)` pair.
 
-See also: [`CTSolvers.Optimization.build_model`](@ref), [`CTSolvers.Optimization.BuiltModel`](@ref).
+See also: [`CTSolvers.Optimization.build_model`](@extref), [`CTSolvers.Optimization.BuiltModel`](@extref).
 """
 function build_solution end

--- a/src/Optimization/built_model.jl
+++ b/src/Optimization/built_model.jl
@@ -13,7 +13,7 @@ $(TYPEDEF)
 
 Empty cache for backends whose `build_model` produces no auxiliary data.
 
-Used as the `cache` field of a [`CTSolvers.Optimization.BuiltModel`](@ref) when
+Used as the `cache` field of a [`CTSolvers.Optimization.BuiltModel`](@extref) when
 nothing besides the NLP needs to be carried to `build_solution` (e.g. the ADNLP
 backend). Reusable by any backend, including the future ODE side.
 """
@@ -22,8 +22,8 @@ struct NoCache <: Core.AbstractCache end
 """
 $(TYPEDEF)
 
-Immutable bundle produced by [`CTSolvers.Optimization.build_model`](@ref) and consumed
-by [`CTSolvers.Optimization.build_solution`](@ref).
+Immutable bundle produced by [`CTSolvers.Optimization.build_model`](@extref) and consumed
+by [`CTSolvers.Optimization.build_solution`](@extref).
 
 It pairs the optimization problem with the backend NLP model and an optional,
 immutable build-time cache. This replaces the previous pattern of mutating a
@@ -36,7 +36,7 @@ NLP (e.g. an ExaModels getter) is stored here once, never mutated.
 - `nlp::TN`: The backend NLP model. Left untyped because its package (e.g.
   `NLPModels`) is a weak dependency.
 - `cache::TC`: Immutable build-time auxiliary (`<: CTBase.Core.AbstractCache`),
-  populated by `build_model`. [`CTSolvers.Optimization.NoCache`](@ref) when the
+  populated by `build_model`. [`CTSolvers.Optimization.NoCache`](@extref) when the
   backend needs none.
 
 # Type parameters
@@ -44,7 +44,7 @@ NLP (e.g. an ExaModels getter) is stored here once, never mutated.
 - `TN`
 - `TC <: CTBase.Core.AbstractCache`
 
-See also: [`CTSolvers.Optimization.build_model`](@ref), [`CTSolvers.Optimization.build_solution`](@ref), [`CTSolvers.Optimization.NoCache`](@ref).
+See also: [`CTSolvers.Optimization.build_model`](@extref), [`CTSolvers.Optimization.build_solution`](@extref), [`CTSolvers.Optimization.NoCache`](@extref).
 """
 struct BuiltModel{TP<:AbstractOptimizationProblem,TN,TC<:Core.AbstractCache}
     problem::TP

--- a/src/Solvers/ipopt.jl
+++ b/src/Solvers/ipopt.jl
@@ -159,7 +159,7 @@ Ipopt is CPU-only.
 # Returns
 - `Type{Strategies.CPU}`: the execution parameter type.
 
-See also: [`CTSolvers.Solvers.Ipopt`](@ref), [`CTBase.Strategies.CPU`](@extref)
+See also: [`CTSolvers.Solvers.Ipopt`](@extref), [`CTBase.Strategies.CPU`](@extref)
 """
 Strategies.parameter(::Type{<:Solvers.Ipopt{P}}) where {P<:Strategies.CPU} = P
 

--- a/src/Solvers/knitro.jl
+++ b/src/Solvers/knitro.jl
@@ -162,7 +162,7 @@ Knitro is CPU-only.
 # Returns
 - `Type{Strategies.CPU}`: the execution parameter type.
 
-See also: [`CTSolvers.Solvers.Knitro`](@ref), [`CTBase.Strategies.CPU`](@extref)
+See also: [`CTSolvers.Solvers.Knitro`](@extref), [`CTBase.Strategies.CPU`](@extref)
 """
 Strategies.parameter(::Type{<:Solvers.Knitro{P}}) where {P<:Strategies.CPU} = P
 

--- a/src/Solvers/madncl.jl
+++ b/src/Solvers/madncl.jl
@@ -116,7 +116,7 @@ Extracts the type parameter `P` from `MadNCL{P}`, which can be either `Strategie
 # Returns
 - `Type{<:Union{Strategies.CPU,Strategies.GPU}}`: the execution parameter type.
 
-See also: [`CTSolvers.Solvers.MadNCL`](@ref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref)
+See also: [`CTSolvers.Solvers.MadNCL`](@extref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref)
 """
 function Strategies.parameter(
     ::Type{<:Solvers.MadNCL{P}}

--- a/src/Solvers/madnlp.jl
+++ b/src/Solvers/madnlp.jl
@@ -122,7 +122,7 @@ Extracts the type parameter `P` from `MadNLP{P}`, which can be either `Strategie
 # Returns
 - `Type{<:Union{Strategies.CPU,Strategies.GPU}}`: the execution parameter type.
 
-See also: [`CTSolvers.Solvers.MadNLP`](@ref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref)
+See also: [`CTSolvers.Solvers.MadNLP`](@extref), [`CTBase.Strategies.CPU`](@extref), [`CTBase.Strategies.GPU`](@extref)
 """
 function Strategies.parameter(
     ::Type{<:Solvers.MadNLP{P}}

--- a/src/Solvers/uno.jl
+++ b/src/Solvers/uno.jl
@@ -188,7 +188,7 @@ Uno is CPU-only.
 # Returns
 - `Type{Strategies.CPU}`: the execution parameter type.
 
-See also: [`CTSolvers.Solvers.Uno`](@ref), [`CTBase.Strategies.CPU`](@extref)
+See also: [`CTSolvers.Solvers.Uno`](@extref), [`CTBase.Strategies.CPU`](@extref)
 """
 Strategies.parameter(::Type{<:Solvers.Uno{P}}) where {P<:Strategies.CPU} = P
 


### PR DESCRIPTION
## Summary
- Convert local `@ref` docstring links to `@extref` where the target symbol is documented on a different generated API page, so DocumenterInterLinks can resolve it across pages.
- Fully qualify the `@extref` targets that were left as bare names (`DiscretizedModel`, `BuiltModel`, `solve_with_uno`, `extract_solver_infos`, `SciMLIntegrationResult`) — `@extref` matches exactly against the InterLinks inventory, unlike `@ref`, so bare names never resolved and produced `cannot resolve external link` errors.
- Register a self-referencing `"CTSolvers"` InterLinks inventory in `docs/make.jl` so intra-package `@extref` links resolve against the package's own build output.

## Test plan
- [x] `julia --project=docs docs/make.jl` builds with zero cross-reference errors, zero doctest failures, and no missing-docstring warnings (only the pre-existing benign local-build warnings remain: deploy-environment auto-detect skip, missing `logo.png`/`favicon.ico`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)