### PR TITLE
Fix GPU extension dependency diagnostics

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -5,6 +5,20 @@ and provides migration guides for users upgrading between versions.
 
 ---
 
+## v0.5.4 (2026-08-26)
+
+**No breaking changes.**
+
+This release fixes the GPU extension diagnostic for MadNLP/MadNCL. When the GPU
+extension is unavailable, the fallback now names the missing dependency among
+`MadNLPGPU`, `CUDA`, and `CUDSS` instead of always suggesting `MadNLPGPU`.
+
+### Migration - v0.5.4
+
+**No action required.** Existing code continues to work without changes.
+
+---
+
 ## v0.5.2 (2026-08-01)
 
 **No breaking changes.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.4] - 2026-08-26
+
+### Fixed
+
+- **GPU extension diagnostics** — the MadNLP/MadNCL GPU fallback now identifies the
+  missing dependency among `MadNLPGPU`, `CUDA`, and `CUDSS`, instead of always naming
+  `MadNLPGPU` ([#216](https://github.com/control-toolbox/CTSolvers.jl/issues/216)).
+
+### Compatibility
+
+- **No breaking changes**: only the fallback error diagnostic was corrected.
+
+---
+
 ## [0.5.3] - 2026-08-23
 
 ### 📦 Dependencies

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTSolvers"
 uuid = "d3e8d392-8e4b-4d9b-8e92-d7d4e3650ef6"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]

--- a/src/Solvers/madnlpsuite.jl
+++ b/src/Solvers/madnlpsuite.jl
@@ -6,6 +6,43 @@ for GPU/CPU linear solver defaults and consistency validation.
 """
 
 """
+Weak dependencies required to activate the MadNLP/MadNCL GPU solver extension.
+
+The extension is loaded only when all three packages are available and loaded:
+`MadNLPGPU`, `CUDA`, and `CUDSS`.
+"""
+const __MADNLP_GPU_DEPENDENCIES = (:MadNLPGPU, :CUDA, :CUDSS)
+
+"""
+$(TYPEDSIGNATURES)
+
+Build the diagnostic error for an unavailable MadNLP/MadNCL GPU extension.
+
+# Arguments
+- `is_loaded::Function`: Predicate that reports whether a dependency is loaded. It
+  defaults to checking the names in `Base.loaded_modules`.
+
+# Returns
+- `Exceptions.ExtensionError`: Error naming the missing dependencies, or all three
+  extension triggers when none is reported missing.
+
+See also: [`CTSolvers.Solvers.__madnlp_suite_default_linear_solver`](@ref)
+"""
+function __madnlp_gpu_extension_error(
+    is_loaded::Function = dependency ->
+        any(pkgid -> pkgid.name === dependency, keys(Base.loaded_modules)),
+)
+    missing = filter(dependency -> !is_loaded(dependency), __MADNLP_GPU_DEPENDENCIES)
+    weakdeps = isempty(missing) ? __MADNLP_GPU_DEPENDENCIES : missing
+    return Exceptions.ExtensionError(
+        weakdeps...;
+        message="to use GPU linear solver with MadNLP/MadNCL",
+        feature="GPU computation with MadNLP/MadNCL",
+        context="the CTSolversMadNLPGPU extension needs all three of MadNLPGPU, CUDA, and CUDSS",
+    )
+end
+
+"""
 $(TYPEDSIGNATURES)
 
 Return the default linear solver for the given parameter type.
@@ -25,14 +62,7 @@ Return the default linear solver for the given parameter type.
 - GPU implementation provided by CTSolversMadNLPGPU extension
 """
 function __madnlp_suite_default_linear_solver(::Type{<:Strategies.GPU})
-    return throw(
-        Exceptions.ExtensionError(
-            :MadNLPGPU;
-            message="to use GPU linear solver with MadNLP/MadNCL",
-            feature="GPU computation with MadNLP/MadNCL",
-            context="Load MadNLPGPU extension first: using MadNLPGPU",
-        ),
-    )
+    return throw(__madnlp_gpu_extension_error())
 end
 
 """

--- a/test/suite/solvers/test_extension_stubs.jl
+++ b/test/suite/solvers/test_extension_stubs.jl
@@ -25,6 +25,30 @@ function test_extension_stubs()
     Test.@testset "Extension Stubs" verbose=VERBOSE showtiming=SHOWTIMING begin
 
         # ====================================================================
+        # UNIT TESTS - MadNLP/MadNCL GPU Stub
+        # ====================================================================
+
+        Test.@testset "Solvers MadNLP GPU dependency diagnostics" begin
+            all_loaded = _ -> true
+            none_loaded = _ -> false
+            cudss_missing = dependency -> dependency !== :CUDSS
+
+            Test.@test Solvers.__madnlp_gpu_extension_error(cudss_missing).weakdeps ===
+                (:CUDSS,)
+            Test.@test Solvers.__madnlp_gpu_extension_error(none_loaded).weakdeps ===
+                (:MadNLPGPU, :CUDA, :CUDSS)
+            Test.@test Solvers.__madnlp_gpu_extension_error(all_loaded).weakdeps ===
+                (:MadNLPGPU, :CUDA, :CUDSS)
+
+            err = Solvers.__madnlp_gpu_extension_error(cudss_missing)
+            Test.@test err isa Exceptions.ExtensionError
+            Test.@test occursin("CUDSS", string(err))
+            Test.@test !occursin("MadNLPGPU, CUDA, CUDSS", string(err))
+            Test.@test err.feature == "GPU computation with MadNLP/MadNCL"
+            Test.@test occursin("all three", err.context)
+        end
+
+        # ====================================================================
         # UNIT TESTS - Solvers.Ipopt Stub
         # ====================================================================
 


### PR DESCRIPTION
## Summary
- Fix the MadNLP/MadNCL GPU fallback to identify the missing dependency among MadNLPGPU, CUDA, and CUDSS.
- Add deterministic tests for missing and fully loaded dependency scenarios.
- Bump CTSolvers from 0.5.3 to 0.5.4 and update release documentation.

Closes #216.

#### Test plan
- [x] Targeted `suite/solvers` tests: 201 passed.
- [x] Full test suite: 58,371 passed.
- [x] JET correctness gate passed.
- [x] `git diff --check` passed.

Generated with [Devin](https://devin.ai)