### PR TITLE
Recognise both kkt and occidata GPU runners in test capabilities

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ on:
     types: [labeled, synchronize, reopened]
     
 jobs:
-  # Job pour les runners GitHub hosted (ubuntu, windows, macos)
+  # Job for the GitHub-hosted runners (ubuntu, windows, macos)
   test-cpu-github:
     # A 'labeled' event fires once per label added, and re-evaluates against the PR's
     # *current* full label set — so adding several labels in a row would otherwise
@@ -28,23 +28,7 @@ jobs:
     secrets:
       SSH_KEY: ${{ secrets.SSH_KEY }}
 
-  # Job pour le runner self-hosted kkt (GPU/CUDA)
-  test-gpu-kkt:
-    # See the comment on test-cpu-github above.
-    if: >
-      github.event_name != 'pull_request' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'run ci kkt-runner') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run ci kkt-runner'))
-    uses: control-toolbox/CTActions/.github/workflows/ci.yml@main
-    with:
-      versions: '["1"]'
-      runs_on: '[["kkt"]]'
-      runner_type: 'self-hosted'
-      use_ct_registry: true
-    secrets:
-      SSH_KEY: ${{ secrets.SSH_KEY }}
-
-  # Job pour le runner self-hosted occidata (GPU/CUDA)
+  # Job for the self-hosted occidata runner (GPU/CUDA)
   test-gpu-occidata:
     # See the comment on test-cpu-github above.
     if: >

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -5,6 +5,22 @@ and provides migration guides for users upgrading between versions.
 
 ---
 
+## Unreleased
+
+**No breaking changes.**
+
+Test-runner detection now recognises both the `kkt` and `occidata` self-hosted GPU
+runners ([#217](https://github.com/control-toolbox/CTSolvers.jl/issues/217)),
+GPU-dependent testsets skip visibly with `Test.@test_skip` on CPU runners, and
+`.github/workflows/CI.yml` runs its self-hosted GPU job on `occidata` only. No
+source or public API changes.
+
+### Migration - Unreleased
+
+**No action required.**
+
+---
+
 ## v0.5.4 (2026-08-26)
 
 **No breaking changes.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **GPU test-runner detection recognises both `kkt` and `occidata`**
+  ([#217](https://github.com/control-toolbox/CTSolvers.jl/issues/217)). The
+  environment contract keyed on `RUNNER_NAME == "kkt"`; it now uses
+  `Main.TestCapabilities.ON_GPU_RUNNER`
+  (`get(ENV, "RUNNER_NAME", "") in ("kkt", "occidata")`), so a broken/absent CUDA
+  device fails loudly on either self-hosted GPU runner instead of being silently
+  skipped.
+- **GPU-dependent testsets now skip visibly.** Several `@testset "GPU …"` blocks
+  guarded their only assertions behind a bare `if is_cuda_on()` /
+  `if CUDA.functional()`, producing a green testset with zero assertions on every
+  CPU/developer runner. They now branch to `Test.@test_skip` on the `else`, so the
+  skip shows as `Broken` in the summary. The per-file `is_cuda_on()` copies are
+  removed in favour of the single `Main.TestCapabilities.CUDA_FUNCTIONAL`.
+- **`.github/workflows/CI.yml`** now runs the self-hosted GPU job on `occidata`
+  only (the `kkt` job was removed); comments translated to English.
+
+### Added
+
+- **Meta-test against the silent-CUDA-guard anti-pattern** —
+  `test/suite/environment/test_environment_contract.jl` gains
+  `_silent_cuda_guard_offenders()` and a testset that fails if any
+  `if is_cuda_on()` / `if CUDA.functional()` guard reappears in `test/suite/`,
+  mirroring the existing `isdefined(Main, ...)` audit.
+
+---
+
 ## [0.5.4] - 2026-08-26
 
 ### Fixed

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,25 +23,33 @@ using .TestData: VERBOSE, SHOWTIMING
 
 # CUDA availability check
 using CUDA
-is_cuda_on() = CUDA.functional()
-if is_cuda_on()
-    println("✓ CUDA functional, GPU tests enabled")
-else
-    println("⚠️  CUDA not functional, GPU tests will be skipped")
-end
 
 # Capability constants computed once, here, where a top-level `using` is guaranteed to bind
 # into Main. Test files must read Main.TestCapabilities.* instead of `isdefined(Main, :X)`
 # checks: `using X` inside a suite/*/test_*.jl file's own module binds X into that submodule,
 # not into Main, so such checks are always false regardless of what is actually loaded.
+#
+# `CUDA_FUNCTIONAL` is the suite's single CUDA-device predicate — never define a local
+# `is_cuda_on()` in a test file (duplicated copies drift; see Handbook philosophy/testing.md).
+# `ON_GPU_RUNNER` turns the device tier from *skipped* into *required* on the self-hosted GPU
+# runners: `RUNNER_NAME` is set by the GitHub Actions runner agent itself (no CI.yml/CTActions
+# change needed) and equals the runner label — `kkt` or `occidata` (see CI.yml). Enforcement
+# lives centrally in test/suite/environment/test_environment_contract.jl.
 module TestCapabilities
 using CUDA: CUDA
 using CUDSS: CUDSS          # with CUDA, arms MadNLPGPUCUDAExt
 using MadNLPGPU: MadNLPGPU
 
 const CUDA_FUNCTIONAL = CUDA.functional()
+const ON_GPU_RUNNER = get(ENV, "RUNNER_NAME", "") in ("kkt", "occidata")
 const GPU_SOLVER_ARMED = MadNLPGPU.CUDSSSolver isa Type
 const GPU_SOLVER = GPU_SOLVER_ARMED ? MadNLPGPU.CUDSSSolver : nothing
+end
+
+if TestCapabilities.CUDA_FUNCTIONAL
+    println("✓ CUDA functional, GPU tests enabled")
+else
+    println("⚠️  CUDA not functional, GPU device tests will be skipped (Test.@test_skip)")
 end
 
 # Run tests using the TestRunner extension

--- a/test/suite/environment/test_environment_contract.jl
+++ b/test/suite/environment/test_environment_contract.jl
@@ -42,6 +42,42 @@ function _isdefined_main_offenders()
     return offenders
 end
 
+"""
+    _silent_cuda_guard_offenders()
+
+Recursively find, under `test/suite/` (located via `@__DIR__`, not `pwd()`), lines that open
+an `if` block directly on a CUDA-device predicate — a local `is_cuda_on()` call or a bare
+`CUDA.functional()` call — the anti-pattern that makes a correctly-skipped run (no device, as
+expected on a CPU/developer machine) and a silently-broken run (device *should* be present
+but isn't) produce the same output: a green testset with zero assertions (see Handbook
+`philosophy/testing.md` §"Capability-gated tests", and control-toolbox/CTSolvers.jl#189).
+
+The fix is `if Main.TestCapabilities.CUDA_FUNCTIONAL ... else Test.@test_skip ... end`, with
+the device tier made *required* on the GPU runners centrally, in the testset below.
+
+This file is excluded from the walk: it necessarily spells out the very patterns it searches
+for (regex source, comments, warning text).
+"""
+function _silent_cuda_guard_offenders()
+    suite_dir = joinpath(@__DIR__, "..")
+    offenders = Tuple{String,Int,String}[]
+    # Assembled from two literals so this line does not match itself.
+    pattern = Regex("if\\s+(is_cuda_on\\(\\)|CUDA" * "\\.functional\\(\\))")
+    this_file = basename(@__FILE__)
+    for (root, _, files) in walkdir(suite_dir)
+        for f in files
+            (endswith(f, ".jl") && f != this_file) || continue
+            path = joinpath(root, f)
+            for (lineno, line) in enumerate(eachline(path))
+                if match(pattern, line) !== nothing
+                    push!(offenders, (relpath(path, suite_dir), lineno, strip(line)))
+                end
+            end
+        end
+    end
+    return offenders
+end
+
 function test_environment_contract()
     Test.@testset "Test-environment contract" verbose=VERBOSE showtiming=SHOWTIMING begin
         Test.@testset "GPU solver extension is armed" begin
@@ -53,12 +89,17 @@ function test_environment_contract()
         end
 
         Test.@testset "GPU driver required on the GPU runner" begin
+            # Central enforcement of the Handbook's capability-gated-test contract: on a
+            # machine that is supposed to have a GPU, a missing/broken device fails loudly
+            # here rather than being silently skipped everywhere else.
+            #
             # Heuristic: RUNNER_NAME is set automatically by the GitHub Actions runner agent
-            # itself (no .github/workflows/CI.yml or CTActions change needed) and equals
-            # "kkt" for the self-hosted GPU runner (see CI.yml's `runs_on: '[["kkt"]]'`). If
-            # the runner is ever renamed, update the literal below — this check then just
-            # silently stops firing rather than failing loudly.
-            if get(ENV, "RUNNER_NAME", "") == "kkt"
+            # itself (no .github/workflows/CI.yml or CTActions change needed) and equals the
+            # runner label — "kkt" or "occidata", the self-hosted GPU runners (see CI.yml's
+            # `runs_on: '[["occidata"]]'`). `ON_GPU_RUNNER` matches both. If a runner is ever
+            # renamed, update the tuple in test/runtests.jl — the check then just stops
+            # firing silently rather than failing loudly.
+            if Main.TestCapabilities.ON_GPU_RUNNER
                 Test.@test Main.TestCapabilities.CUDA_FUNCTIONAL
             end
         end
@@ -68,6 +109,14 @@ function test_environment_contract()
             Test.@test isempty(offenders)
             for (file, lineno, sym) in offenders
                 @warn "isdefined(Main, :$sym) anti-pattern at $file:$lineno — use Main.TestCapabilities instead"
+            end
+        end
+
+        Test.@testset "silent CUDA-guard anti-pattern has not returned" begin
+            offenders = _silent_cuda_guard_offenders()
+            Test.@test isempty(offenders)
+            for (file, lineno, text) in offenders
+                @warn "silent CUDA guard at $file:$lineno — use Main.TestCapabilities.CUDA_FUNCTIONAL with a Test.@test_skip else branch" text
             end
         end
     end

--- a/test/suite/extensions/test_madncl_extension.jl
+++ b/test/suite/extensions/test_madncl_extension.jl
@@ -28,8 +28,8 @@ const CTSolversMadNCL = Base.get_extension(CTSolvers, :CTSolversMadNCL)
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
 
-# CUDA availability check
-is_cuda_on() = CUDA.functional()
+# CUDA-device tests read Main.TestCapabilities.CUDA_FUNCTIONAL (the suite's single device
+# predicate) and Test.@test_skip when it is false — never a silent `if`.
 
 """
     test_madncl_extension()
@@ -311,8 +311,7 @@ function test_madncl_extension()
         # ====================================================================
 
         Test.@testset "GPU Tests" begin
-            # Check if CUDA is available and functional
-            if CUDA.functional()
+            if Main.TestCapabilities.CUDA_FUNCTIONAL
                 Test.@testset "Rosenbrock Problem - GPU" begin
                     ros = TestProblems.Rosenbrock()
 
@@ -324,6 +323,8 @@ function test_madncl_extension()
 
                     Test.@test solver isa Solvers.MadNCL
                 end
+            else
+                Test.@test_skip "GPU solver construction needs a functional CUDA device"
             end
         end
 
@@ -483,7 +484,7 @@ function test_madncl_extension()
         # ====================================================================
 
         Test.@testset "GPU Tests" begin
-            if is_cuda_on() && MadNLPGPU.CUDSSSolver isa Type
+            if Main.TestCapabilities.CUDA_FUNCTIONAL && MadNLPGPU.CUDSSSolver isa Type
                 gpu_modeler = Modelers.Exa{Strategies.GPU}()
                 gpu_solver = Solvers.MadNCL{Strategies.GPU}(
                     max_iter=1000,
@@ -511,6 +512,8 @@ function test_madncl_extension()
                     Test.@test length(sol.solution) == 1
                     Test.@test Array(sol.solution)[1] ≈ max_prob.sol[1] atol=1e-6
                 end
+            else
+                Test.@test_skip "GPU solve needs a functional CUDA device and an armed CUDSS"
             end
         end
 
@@ -519,7 +522,7 @@ function test_madncl_extension()
         # ====================================================================
 
         Test.@testset "GPU - solve_with_madncl" begin
-            if is_cuda_on() && MadNLPGPU.CUDSSSolver isa Type
+            if Main.TestCapabilities.CUDA_FUNCTIONAL && MadNLPGPU.CUDSSSolver isa Type
                 gpu_modeler = Modelers.Exa{Strategies.GPU}()
                 madncl_options = Dict(
                     :max_iter => 1000,
@@ -546,6 +549,8 @@ function test_madncl_extension()
                     Test.@test length(sol.solution) == 1
                     Test.@test Array(sol.solution)[1] ≈ max_prob.sol[1] atol=1e-6
                 end
+            else
+                Test.@test_skip "GPU solve needs a functional CUDA device and an armed CUDSS"
             end
         end
 
@@ -554,7 +559,7 @@ function test_madncl_extension()
         # ====================================================================
 
         Test.@testset "GPU - Initial Guess (max_iter=0)" begin
-            if is_cuda_on() && MadNLPGPU.CUDSSSolver isa Type
+            if Main.TestCapabilities.CUDA_FUNCTIONAL && MadNLPGPU.CUDSSSolver isa Type
                 gpu_modeler = Modelers.Exa{Strategies.GPU}()
                 ncl_opts_0 = MadNCL.NCLOptions{Float64}(verbose=false, max_auglag_iter=0)
                 gpu_solver_0 = Solvers.MadNCL{Strategies.GPU}(
@@ -573,6 +578,8 @@ function test_madncl_extension()
                     expected = vcat(elec.init.x, elec.init.y, elec.init.z)
                     Test.@test Array(sol.solution) ≈ expected atol=1e-6
                 end
+            else
+                Test.@test_skip "GPU solve needs a functional CUDA device and an armed CUDSS"
             end
         end
     end

--- a/test/suite/extensions/test_madnlp_extension.jl
+++ b/test/suite/extensions/test_madnlp_extension.jl
@@ -27,8 +27,8 @@ const CTSolversMadNLP = Base.get_extension(CTSolvers, :CTSolversMadNLP)
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
 
-# CUDA availability check
-is_cuda_on() = CUDA.functional()
+# CUDA-device tests read Main.TestCapabilities.CUDA_FUNCTIONAL (the suite's single device
+# predicate) and Test.@test_skip when it is false — never a silent `if`.
 
 """
     test_madnlp_extension()
@@ -286,7 +286,7 @@ function test_madnlp_extension()
         # ====================================================================
 
         Test.@testset "GPU Tests" begin
-            if is_cuda_on() && MadNLPGPU.CUDSSSolver isa Type
+            if Main.TestCapabilities.CUDA_FUNCTIONAL && MadNLPGPU.CUDSSSolver isa Type
                 gpu_modeler = Modelers.Exa{Strategies.GPU}()
                 gpu_solver = Solvers.MadNLP{Strategies.GPU}(
                     max_iter=1000,
@@ -324,6 +324,8 @@ function test_madnlp_extension()
                     Test.@test length(sol.solution) == 1
                     Test.@test Array(sol.solution)[1] ≈ max_prob.sol[1] atol=1e-6
                 end
+            else
+                Test.@test_skip "GPU solve needs a functional CUDA device and an armed CUDSS"
             end
         end
 
@@ -662,7 +664,7 @@ function test_madnlp_extension()
         # ====================================================================
 
         Test.@testset "GPU - solve_with_madnlp" begin
-            if is_cuda_on() && MadNLPGPU.CUDSSSolver isa Type
+            if Main.TestCapabilities.CUDA_FUNCTIONAL && MadNLPGPU.CUDSSSolver isa Type
                 gpu_modeler = Modelers.Exa{Strategies.GPU}()
                 madnlp_options = Dict(
                     :max_iter => 1000,
@@ -697,6 +699,8 @@ function test_madnlp_extension()
                     Test.@test length(sol.solution) == 1
                     Test.@test Array(sol.solution)[1] ≈ max_prob.sol[1] atol=1e-6
                 end
+            else
+                Test.@test_skip "GPU solve needs a functional CUDA device and an armed CUDSS"
             end
         end
 
@@ -705,7 +709,7 @@ function test_madnlp_extension()
         # ====================================================================
 
         Test.@testset "GPU - Initial Guess (max_iter=0)" begin
-            if is_cuda_on() && MadNLPGPU.CUDSSSolver isa Type
+            if Main.TestCapabilities.CUDA_FUNCTIONAL && MadNLPGPU.CUDSSSolver isa Type
                 gpu_modeler = Modelers.Exa{Strategies.GPU}()
                 gpu_solver_0 = Solvers.MadNLP{Strategies.GPU}(
                     max_iter=0,
@@ -731,6 +735,8 @@ function test_madnlp_extension()
                     expected = vcat(elec.init.x, elec.init.y, elec.init.z)
                     Test.@test Array(sol.solution) ≈ expected atol=1e-6
                 end
+            else
+                Test.@test_skip "GPU solve needs a functional CUDA device and an armed CUDSS"
             end
         end
     end

--- a/test/suite/integrators/test_sciml_parameter.jl
+++ b/test/suite/integrators/test_sciml_parameter.jl
@@ -16,7 +16,8 @@ using CUDA: CUDA
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
 
-is_cuda_on() = CUDA.functional()
+# CUDA-device cases read Main.TestCapabilities.CUDA_FUNCTIONAL (the suite's single device
+# predicate) and Test.@test_skip when it is false — never a silent `if`.
 
 """
     test_sciml_parameter()
@@ -27,7 +28,8 @@ Covers the `SciML{P<:Union{CPU,GPU}}` parameterization (GPU roadmap phase 1 / D1
 contract (`parameter`/`default_parameter`/`id`), per-parameter `metadata` and back-compat bare
 delegation, per-parameter construction, registry `[CPU, GPU]` registration + global-parameter
 extraction, and the `__consistent_initial_condition` device consistency validators. All assertions
-run on CPU; only the `CuArray` cases are gated behind `is_cuda_on()`.
+run on CPU; only the `CuArray` cases are gated behind `Main.TestCapabilities.CUDA_FUNCTIONAL`
+(with a visible `Test.@test_skip` when no device is present).
 """
 function test_sciml_parameter()
     Test.@testset "SciML{P} parameterization" verbose=VERBOSE showtiming=SHOWTIMING begin
@@ -129,7 +131,7 @@ function test_sciml_parameter()
             Test.@test Integrators.__consistent_initial_condition(Strategies.GPU, host) ==
                 false
 
-            if is_cuda_on()
+            if Main.TestCapabilities.CUDA_FUNCTIONAL
                 dev = CUDA.cu(host)
                 Test.@test Integrators.__consistent_initial_condition(
                     Strategies.GPU, dev
@@ -137,6 +139,8 @@ function test_sciml_parameter()
                 Test.@test Integrators.__consistent_initial_condition(
                     Strategies.CPU, dev
                 ) == false
+            else
+                Test.@test_skip "device/host consistency on a CuArray needs a functional CUDA device"
             end
         end
     end

--- a/test/suite/modelers/test_exa_gpu.jl
+++ b/test/suite/modelers/test_exa_gpu.jl
@@ -13,7 +13,8 @@ using CUDA: CUDA
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
 
-is_cuda_on() = CUDA.functional()
+# CUDA-device cases read Main.TestCapabilities.CUDA_FUNCTIONAL (the suite's single device
+# predicate) and Test.@test_skip when it is false — never a silent `if`.
 
 """
     test_exa_gpu()
@@ -107,14 +108,16 @@ function test_exa_gpu()
             # Test GPU parameter with nothing backend (should warn)
             Test.@test_logs (:warn, r"Inconsistent backend") gpu_validator(nothing)
 
-            # If CUDA is available, test with CUDA backend
-            if is_cuda_on()
+            # Backend validation against a real CUDABackend needs a functional CUDA device
+            if Main.TestCapabilities.CUDA_FUNCTIONAL
                 cuda_backend = CUDA.CUDABackend()
                 Test.@test cpu_validator(cuda_backend) === cuda_backend  # This will warn but still return cuda_backend
                 Test.@test gpu_validator(cuda_backend) === cuda_backend
 
                 # Test CPU parameter with CUDA backend (should warn)
                 Test.@test_logs (:warn, r"Inconsistent backend") cpu_validator(cuda_backend)
+            else
+                Test.@test_skip "CUDABackend validator checks need a functional CUDA device"
             end
         end
     end

--- a/test/suite/strategies/test_cpu_only_parameters_integration.jl
+++ b/test/suite/strategies/test_cpu_only_parameters_integration.jl
@@ -13,8 +13,8 @@ using CUDA
 const VERBOSE = isdefined(Main, :TestData) ? Main.TestData.VERBOSE : true
 const SHOWTIMING = isdefined(Main, :TestData) ? Main.TestData.SHOWTIMING : true
 
-# CUDA availability check
-is_cuda_on() = CUDA.functional()
+# CUDA-device cases read Main.TestCapabilities.CUDA_FUNCTIONAL (the suite's single device
+# predicate) and Test.@test_skip when it is false — never a silent `if`.
 
 # ============================================================================
 # Fake parameter type for testing (must be at module top-level)
@@ -126,14 +126,14 @@ function test_cpu_only_parameters_integration()
                 :exa, Strategies.CPU, Modelers.AbstractNLPModeler, registry
             )
 
-            # GPU tests only if CUDA is functional
-            if is_cuda_on()
+            # GPU parameter build needs a functional CUDA device
+            if Main.TestCapabilities.CUDA_FUNCTIONAL
                 # GPU parameter works only for Exa
                 Test.@test_nowarn Strategies.build_strategy(
                     :exa, Strategies.GPU, Modelers.AbstractNLPModeler, registry
                 )
             else
-                # CUDA not functional — skip GPU test silently
+                Test.@test_skip "building an :exa GPU strategy needs a functional CUDA device"
             end
 
             # GPU parameter fails for ADNLP (doesn't require CUDA to be functional)


### PR DESCRIPTION
Closes #217.

## Context

The GPU test environment keyed its device contract on `RUNNER_NAME == "kkt"`
(in `test/suite/environment/test_environment_contract.jl`). A second self-hosted
GPU runner, `occidata`, was added to `.github/workflows/CI.yml` on 2026-08-24 but
the test side was never taught about it, so on `occidata` a broken/absent CUDA
device was **silently skipped** instead of failing loudly — the failure class of
#189.

Separately, several `@testset "GPU …"` blocks guarded their only assertions behind
a bare `if is_cuda_on()` / `if CUDA.functional()`, producing a green testset with
zero assertions on every CPU/developer runner, indistinguishable from a silently
broken device run.

Mirrors the `on_gpu_runner()` helper already merged in
`OptimalControl.jl/test/helpers/capabilities.jl` and the Handbook contract in
`philosophy/testing.md`.

## Changes

- **`test/runtests.jl`** — `Main.TestCapabilities` gains
  `ON_GPU_RUNNER = get(ENV, "RUNNER_NAME", "") in ("kkt", "occidata")`.
  `CUDA_FUNCTIONAL` stays the single device predicate; the top-level
  `is_cuda_on()` (used only for the startup `println`) is removed.
- **`test/suite/environment/test_environment_contract.jl`**
  - "GPU driver required on the GPU runner" now checks `ON_GPU_RUNNER`, so a
    missing/broken device fails loudly on **either** GPU runner.
  - New `_silent_cuda_guard_offenders()` + testset "silent CUDA-guard
    anti-pattern has not returned" fails if a bare `if is_cuda_on()` /
    `if CUDA.functional()` guard reappears anywhere in `test/suite/`, mirroring
    the existing `isdefined(Main, ...)` audit.
- **GPU-dependent testsets** (`test_madnlp_extension`, `test_madncl_extension`,
  `test_sciml_parameter`, `test_cpu_only_parameters_integration`,
  `test_exa_gpu`) — bare `if is_cuda_on()` guards now branch to
  `Test.@test_skip` on the `else`, and read
  `Main.TestCapabilities.CUDA_FUNCTIONAL` instead of a per-file `is_cuda_on()`
  copy.
- **`.github/workflows/CI.yml`** — the self-hosted GPU job now runs on `occidata`
  only (the `kkt` job was removed); comments translated to English. The test-side
  `on_gpu_runner()` check still accepts `kkt` for transition compatibility.
- **`CHANGELOG.md`** / **`BREAKING.md`** — `[Unreleased]` entries (no breaking
  change).

## Verification

`julia --project -e 'using Pkg; Pkg.test(; test_args=[...])'` over the six touched
files:

```
CTSolvers tests | 337 pass, 10 broken, 0 fail
```

The GPU testsets that were previously silent `Pass 0` now show as `Broken` in the
summary. With `RUNNER_NAME=occidata` set, `test_environment_contract` runs
`Test.@test Main.TestCapabilities.CUDA_FUNCTIONAL` and fails loudly on a machine
without a device (the intended contract), rather than skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)