### PR TITLE
Match RUNNER_NAME substring for GPU-runner detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **GPU test-runner detection recognises both `kkt` and `occidata`**
   ([#217](https://github.com/control-toolbox/CTSolvers.jl/issues/217)). The
   environment contract keyed on `RUNNER_NAME == "kkt"`; it now uses
-  `Main.TestCapabilities.ON_GPU_RUNNER`
-  (`get(ENV, "RUNNER_NAME", "") in ("kkt", "occidata")`), so a broken/absent CUDA
-  device fails loudly on either self-hosted GPU runner instead of being silently
-  skipped.
+  `Main.TestCapabilities.ON_GPU_RUNNER`, which matches the `kkt` / `occidata`
+  substring of `RUNNER_NAME` (the self-hosted runners are registered as
+  `kkt-runner` / `occidata-runner`), so a broken/absent CUDA device fails loudly
+  on either self-hosted GPU runner instead of being silently skipped.
 - **GPU-dependent testsets now skip visibly.** Several `@testset "GPU …"` blocks
   guarded their only assertions behind a bare `if is_cuda_on()` /
   `if CUDA.functional()`, producing a green testset with zero assertions on every

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,15 +33,20 @@ using CUDA
 # `is_cuda_on()` in a test file (duplicated copies drift; see Handbook philosophy/testing.md).
 # `ON_GPU_RUNNER` turns the device tier from *skipped* into *required* on the self-hosted GPU
 # runners: `RUNNER_NAME` is set by the GitHub Actions runner agent itself (no CI.yml/CTActions
-# change needed) and equals the runner label — `kkt` or `occidata` (see CI.yml). Enforcement
-# lives centrally in test/suite/environment/test_environment_contract.jl.
+# change needed) to the runner's *registered name*. Our self-hosted GPU runners are registered
+# as `kkt-runner` / `occidata-runner` (the CI.yml `runs_on` label is the bare `kkt`/`occidata`,
+# which is a different string), so match on the `kkt` / `occidata` substring to stay robust to
+# the `-runner` suffix. Enforcement lives centrally in
+# test/suite/environment/test_environment_contract.jl.
 module TestCapabilities
 using CUDA: CUDA
 using CUDSS: CUDSS          # with CUDA, arms MadNLPGPUCUDAExt
 using MadNLPGPU: MadNLPGPU
 
 const CUDA_FUNCTIONAL = CUDA.functional()
-const ON_GPU_RUNNER = get(ENV, "RUNNER_NAME", "") in ("kkt", "occidata")
+const ON_GPU_RUNNER = any(
+    gpu -> occursin(gpu, get(ENV, "RUNNER_NAME", "")), ("kkt", "occidata")
+)
 const GPU_SOLVER_ARMED = MadNLPGPU.CUDSSSolver isa Type
 const GPU_SOLVER = GPU_SOLVER_ARMED ? MadNLPGPU.CUDSSSolver : nothing
 end

--- a/test/suite/environment/test_environment_contract.jl
+++ b/test/suite/environment/test_environment_contract.jl
@@ -94,11 +94,12 @@ function test_environment_contract()
             # here rather than being silently skipped everywhere else.
             #
             # Heuristic: RUNNER_NAME is set automatically by the GitHub Actions runner agent
-            # itself (no .github/workflows/CI.yml or CTActions change needed) and equals the
-            # runner label — "kkt" or "occidata", the self-hosted GPU runners (see CI.yml's
-            # `runs_on: '[["occidata"]]'`). `ON_GPU_RUNNER` matches both. If a runner is ever
-            # renamed, update the tuple in test/runtests.jl — the check then just stops
-            # firing silently rather than failing loudly.
+            # itself (no .github/workflows/CI.yml or CTActions change needed) to the runner's
+            # registered name — `kkt-runner` / `occidata-runner` for our self-hosted GPU
+            # runners (the CI.yml `runs_on` label is the bare `kkt`/`occidata`). `ON_GPU_RUNNER`
+            # (test/runtests.jl) matches the `kkt`/`occidata` substring, so it survives the
+            # `-runner` suffix; if a runner is renamed past that, the check stops firing
+            # silently rather than failing loudly.
             if Main.TestCapabilities.ON_GPU_RUNNER
                 Test.@test Main.TestCapabilities.CUDA_FUNCTIONAL
             end


### PR DESCRIPTION
Follow-up to #220 (refs #217).

## What the occidata CI run revealed

The first `test-gpu-occidata` run after #220
([run 33074921887](https://github.com/control-toolbox/CTSolvers.jl/actions/runs/33074921887/job/98526505870))
showed `test_environment_contract.jl` passing **3** tests, not 4 — the
"GPU driver required on the GPU runner" testset ran **zero assertions** even
though `✓ CUDA functional` printed.

Cause: the runner logs `Runner name: 'occidata-runner'`, so `RUNNER_NAME` is
`occidata-runner`, and `ON_GPU_RUNNER = RUNNER_NAME in ("kkt", "occidata")` was
`false`. (The pre-existing `== "kkt"` check was almost certainly dead for the
same reason — `kkt-runner`.)

## Fix

`ON_GPU_RUNNER` now matches the `kkt` / `occidata` **substring** of `RUNNER_NAME`,
so it survives the `-runner` suffix on both runners:

```julia
const ON_GPU_RUNNER = any(
    gpu -> occursin(gpu, get(ENV, "RUNNER_NAME", "")), ("kkt", "occidata")
)
```

Verified locally:

| `RUNNER_NAME` | `ON_GPU_RUNNER` |
| --- | --- |
| `occidata-runner`, `kkt-runner`, `occidata` | `true` |
| `""`, `GitHub Actions 5`, `my-laptop` | `false` |

With `RUNNER_NAME=occidata-runner`, `test_environment_contract` now runs
`Test.@test CUDA_FUNCTIONAL` (4 tests) instead of skipping it.

## Not addressed here

The occidata job also hit a `Package Test not found in current path` cascade from
test file 32/62 onward — a mid-run collapse of Julia's package resolution under
the GPU workload. This is **pre-existing** (the occidata "Run tests" step already
failed on 2026-08-24, run 32723660671, and passed on the commit right before
#220, run 33071700602 — i.e. it is intermittent) and unrelated to the
runner-detection change. Worth its own issue about occidata runner
stability / TestRunner robustness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)