### PR TITLE
Fix default is_loaded predicate in __madnlp_gpu_extension_error (#222)

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -9,13 +9,27 @@ and provides migration guides for users upgrading between versions.
 
 **No breaking changes.**
 
-Test-runner detection now recognises both the `kkt` and `occidata` self-hosted GPU
-runners ([#217](https://github.com/control-toolbox/CTSolvers.jl/issues/217)),
-GPU-dependent testsets skip visibly with `Test.@test_skip` on CPU runners, and
-`.github/workflows/CI.yml` runs its self-hosted GPU job on `occidata` only. No
-source or public API changes.
+---
 
-### Migration - Unreleased
+## v0.5.5-beta (2026-08-27)
+
+**No breaking changes.**
+
+This release fixes the default dependency check in the MadNLP/MadNCL GPU fallback
+diagnostic ([#222](https://github.com/control-toolbox/CTSolvers.jl/issues/222)): it
+now correctly identifies which of `MadNLPGPU`, `CUDA`, and `CUDSS` is missing instead
+of always naming all three. It also folds in the earlier unreleased test-runner
+changes: detection recognises both the `kkt` and `occidata` self-hosted GPU runners
+([#217](https://github.com/control-toolbox/CTSolvers.jl/issues/217)), GPU-dependent
+testsets skip visibly with `Test.@test_skip` on CPU runners, and
+`.github/workflows/CI.yml` runs its self-hosted GPU job on `occidata` only.
+
+The internal helper `Solvers.__madnlp_gpu_extension_error` changed its optional
+argument from a predicate `is_loaded::Function` to a collection `loaded_modules`.
+This symbol is unexported and internal (`__`-prefixed), so it is not part of the
+public API.
+
+### Migration - v0.5.5-beta
 
 **No action required.**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.5.5-beta] - 2026-08-27
+
+### Fixed
+
+- **GPU extension diagnostic default predicate** — `__madnlp_gpu_extension_error`
+  compared `Base.PkgId.name` (a `String`) to each expected dependency (a `Symbol`)
+  with `===`, so the check always failed and the error listed all three of
+  `MadNLPGPU`, `CUDA`, and `CUDSS` as missing even when only one was absent
+  ([#222](https://github.com/control-toolbox/CTSolvers.jl/issues/222)). The helper
+  now takes the loaded package identifiers as data (`loaded_modules`, defaulting to
+  `keys(Base.loaded_modules)`) and matches names as `String`s, and the test suite
+  drives that default path with fake `Base.PkgId`s instead of an injected predicate.
+
 ### Changed
 
 - **GPU test-runner detection recognises both `kkt` and `occidata`**

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTSolvers"
 uuid = "d3e8d392-8e4b-4d9b-8e92-d7d4e3650ef6"
-version = "0.5.4"
+version = "0.5.5-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]

--- a/src/Solvers/madnlpsuite.jl
+++ b/src/Solvers/madnlpsuite.jl
@@ -19,8 +19,9 @@ $(TYPEDSIGNATURES)
 Build the diagnostic error for an unavailable MadNLP/MadNCL GPU extension.
 
 # Arguments
-- `is_loaded::Function`: Predicate that reports whether a dependency is loaded. It
-  defaults to checking the names in `Base.loaded_modules`.
+- `loaded_modules`: Iterable of loaded package identifiers, each exposing a `String`
+  `name` field (as `Base.PkgId` does). Defaults to `keys(Base.loaded_modules)`. A
+  dependency counts as present when its name appears among these.
 
 # Returns
 - `Exceptions.ExtensionError`: Error naming the missing dependencies, or all three
@@ -28,12 +29,12 @@ Build the diagnostic error for an unavailable MadNLP/MadNCL GPU extension.
 
 See also: [`CTSolvers.Solvers.__madnlp_suite_default_linear_solver`](@ref)
 """
-function __madnlp_gpu_extension_error(
-    is_loaded::Function = dependency ->
-        any(pkgid -> pkgid.name === dependency, keys(Base.loaded_modules)),
-)
-    missing = filter(dependency -> !is_loaded(dependency), __MADNLP_GPU_DEPENDENCIES)
-    weakdeps = isempty(missing) ? __MADNLP_GPU_DEPENDENCIES : missing
+function __madnlp_gpu_extension_error(loaded_modules=keys(Base.loaded_modules))
+    loaded_names = Set(pkgid.name for pkgid in loaded_modules)
+    absent = filter(
+        dependency -> String(dependency) ∉ loaded_names, __MADNLP_GPU_DEPENDENCIES
+    )
+    weakdeps = isempty(absent) ? __MADNLP_GPU_DEPENDENCIES : absent
     return Exceptions.ExtensionError(
         weakdeps...;
         message="to use GPU linear solver with MadNLP/MadNCL",

--- a/test/suite/solvers/test_extension_stubs.jl
+++ b/test/suite/solvers/test_extension_stubs.jl
@@ -29,9 +29,14 @@ function test_extension_stubs()
         # ====================================================================
 
         Test.@testset "Solvers MadNLP GPU dependency diagnostics" begin
-            all_loaded = _ -> true
-            none_loaded = _ -> false
-            cudss_missing = dependency -> dependency !== :CUDSS
+            # Fake package identifiers: stand-ins for modules that are never loaded,
+            # exercising the real name-matching in the default code path (issue #222,
+            # where `PkgId.name::String` was compared to a `Symbol` with `===`).
+            loaded(names...) = [Base.PkgId(String(name)) for name in names]
+
+            all_loaded = loaded(:MadNLPGPU, :CUDA, :CUDSS)
+            none_loaded = loaded(:SomethingUnrelated)
+            cudss_missing = loaded(:MadNLPGPU, :CUDA)
 
             Test.@test Solvers.__madnlp_gpu_extension_error(cudss_missing).weakdeps ===
                 (:CUDSS,)
@@ -39,6 +44,9 @@ function test_extension_stubs()
                 (:MadNLPGPU, :CUDA, :CUDSS)
             Test.@test Solvers.__madnlp_gpu_extension_error(all_loaded).weakdeps ===
                 (:MadNLPGPU, :CUDA, :CUDSS)
+
+            # Default (no-arg) path stays reachable and well-formed.
+            Test.@test Solvers.__madnlp_gpu_extension_error() isa Exceptions.ExtensionError
 
             err = Solvers.__madnlp_gpu_extension_error(cudss_missing)
             Test.@test err isa Exceptions.ExtensionError


### PR DESCRIPTION
## Problem

Closes #222.

The default dependency check in `Solvers.__madnlp_gpu_extension_error` compared
`Base.PkgId.name` (a `String`, e.g. `"CUDA"`) against each expected dependency
(a `Symbol`, e.g. `:CUDA`) with `===`. The comparison always yields `false`, so
every dependency read as missing and the GPU fallback error always listed all
three of `MadNLPGPU`, `CUDA` and `CUDSS` — even when only one was absent,
defeating the purpose of the diagnostic.

The tests never caught this because they only exercised an injected predicate
and never reached the default implementation.

## Fix

Stop injecting a predicate closure. The optional argument becomes plain data —
the collection of loaded package identifiers, defaulting to
`keys(Base.loaded_modules)`. The name matching now lives in the function body
(comparing `String`s), so the default path is covered by the suite.

```julia
function __madnlp_gpu_extension_error(loaded_modules=keys(Base.loaded_modules))
    loaded_names = Set(pkgid.name for pkgid in loaded_modules)
    absent = filter(
        dependency -> String(dependency) ∉ loaded_names, __MADNLP_GPU_DEPENDENCIES
    )
    weakdeps = isempty(absent) ? __MADNLP_GPU_DEPENDENCIES : absent
    ...
```

The local `missing` (which shadowed `Base.missing`) is renamed to `absent`.

## Tests

`test/suite/solvers/test_extension_stubs.jl` now builds fake `Base.PkgId`s —
stand-ins for packages that are never actually loaded — and feeds them through
the real default code path, plus a smoke test of the no-argument call. This is a
regression test for the String/Symbol mismatch.

## Compatibility

No breaking changes. `Solvers.__madnlp_gpu_extension_error` is an unexported,
internal (`__`-prefixed) helper; its optional argument changed from a predicate
`is_loaded::Function` to a collection `loaded_modules`.

Version bumped to `0.5.5-beta`; `CHANGELOG.md` and `BREAKING.md` updated.

## Verification

- `Pkg.test(; test_args=["test/suite/solvers", "test/suite/extensions"])` — green
- Full suite — green (`882 passed`, 7 pre-existing `@test_skip` GPU broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)