### PR TITLE
chore: widen CTBase/CTModels compat to 0.30/0.19 (CTSolvers 0.5.6-beta)

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -11,6 +11,18 @@ and provides migration guides for users upgrading between versions.
 
 ---
 
+## v0.5.6-beta (2026-08-28)
+
+**No breaking changes.**
+
+`[compat]` widened to accept CTBase 0.30 (`"0.29, 0.30"`) and CTModels 0.19
+(`"0.18, 0.19"`). CTBase 0.30 adds the Makie plotting backend and CTModels 0.19
+moves its plotting case layer into `CTModels.PlotCase`; both are purely additive
+(see the respective `BREAKING.md` non-breaking notes). CTSolvers touches neither,
+no source change, full suite green. No migration required.
+
+---
+
 ## v0.5.5-beta (2026-08-27)
 
 **No breaking changes.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.6-beta] - 2026-08-28
+
+### Changed
+
+- **`[compat]` widened: `CTBase = "0.29, 0.30"`, `CTModels = "0.18, 0.19"`**
+  (`Project.toml`; `docs/Project.toml` gains `CTBase = "0.29, 0.30"`). CTBase 0.30
+  adds the `Plotting.MakieBackend` / `CTBaseMakie` extension and CTModels 0.19
+  relocates its plotting case layer to `CTModels.PlotCase`; both are documented as
+  fully additive — no public API, type, or signature changed. CTSolvers uses
+  neither plotting path, so no source change was needed and the full suite passes
+  unchanged against CTBase 0.30.1-beta / CTModels 0.19.1-beta.
+
+### Compatibility
+
+- **No breaking changes**: compat-only update. See [BREAKING.md](BREAKING.md).
+
+---
+
 ## [0.5.5-beta] - 2026-08-27
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CTSolvers"
 uuid = "d3e8d392-8e4b-4d9b-8e92-d7d4e3650ef6"
-version = "0.5.5-beta"
+version = "0.5.6-beta"
 authors = ["Olivier Cots <olivier.cots@toulouse-inp.fr>"]
 
 [deps]
@@ -50,8 +50,8 @@ CTSolversZygote = "Zygote"
 ADNLPModels = "0.8"
 Aqua = "0.8"
 BenchmarkTools = "1"
-CTBase = "0.29"
-CTModels = "0.18"
+CTBase = "0.29, 0.30"
+CTModels = "0.18, 0.19"
 CUDA = "5, 6"
 CUDSS = "0.6, 0.7, 0.8"
 CommonSolve = "0.2"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -28,7 +28,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 ADNLPModels = "0.8"
-CTBase = "0.29"
+CTBase = "0.29, 0.30"
 CUDA = "5, 6"
 CUDSS = "0.6, 0.7, 0.8"
 CommonSolve = "0.2"


### PR DESCRIPTION
## What

Widen `[compat]` `CTBase = "0.29"` → `"0.29, 0.30"` and `CTModels = "0.18"` →
`"0.18, 0.19"` in `Project.toml` (+ `CTBase` in `docs/Project.toml`), bump
`version` to `0.5.6-beta`, add the CHANGELOG / BREAKING entries.

## Why

- **CTBase `0.29 → 0.30`** — `0.30.0-beta` / `0.30.1-beta` are both
  `## Non-breaking note` in CTBase `BREAKING.md` (the Makie plotting backend,
  purely additive).
- **CTModels `0.18 → 0.19`** — `0.19.0-beta` / `0.19.1-beta` relocate the
  plotting case layer into `CTModels.PlotCase`; the public API (types, signatures,
  `Plots.plot`) is unchanged.

CTSolvers uses neither plotting path — compat-only, **no source change**.

Needed so CTFlows can move to CTBase 0.30 / CTModels 0.19 for its Makie
trajectory-plotting backend (control-toolbox/CTFlows.jl#414).

## Verification

Full CTSolvers suite green against locally dev-ed CTBase `0.30.1-beta` /
CTModels `0.19.1-beta`: `58662 passed, 10 broken` (pre-existing GPU/CPU-gated
skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)